### PR TITLE
fix(db): prevent lower-priority alert from overriding higher one

### DIFF
--- a/internal/db/alerts.go
+++ b/internal/db/alerts.go
@@ -42,6 +42,8 @@ func (d *DB) AlertSet(target, reason, level string) error {
             reason     = excluded.reason,
             level      = excluded.level,
             created_at = excluded.created_at
+        WHERE (CASE excluded.level WHEN 'error' THEN 3 WHEN 'warn' THEN 2 WHEN 'info' THEN 1 ELSE 0 END)
+            >= (CASE alerts.level WHEN 'error' THEN 3 WHEN 'warn' THEN 2 WHEN 'info' THEN 1 ELSE 0 END)
     `, target, reason, level)
     return err
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -59,6 +59,24 @@ func TestAlertSetReplacesExisting(t *testing.T) {
     }
 }
 
+func TestAlertSetDoesNotDowngrade(t *testing.T) {
+    d := openTestDB(t)
+
+    d.AlertSet("s:1", "reason 1", "error")
+    d.AlertSet("s:1", "reason 2", "defer")
+
+    alerts, _ := d.AlertList()
+    if len(alerts) != 1 {
+        t.Fatalf("expected 1, got %d", len(alerts))
+    }
+    if alerts[0].Level != "error" {
+        t.Errorf("expected level=error to be preserved, got %s", alerts[0].Level)
+    }
+    if alerts[0].Reason != "reason 1" {
+        t.Errorf("expected reason to be preserved, got %s", alerts[0].Reason)
+    }
+}
+
 func TestAlertRemove(t *testing.T) {
     d := openTestDB(t)
 


### PR DESCRIPTION
## Summary

- `AlertSet` used `ON CONFLICT DO UPDATE SET` unconditionally, allowing a lower-priority level (e.g. `defer`) to silently overwrite a higher one (e.g. `error`)
- Added a `WHERE` guard to the `ON CONFLICT DO UPDATE` using inline priority scores: `error=3`, `warn=2`, `info=1`, `defer=0`
- Added `TestAlertSetDoesNotDowngrade` to cover the regression

## Test plan

- [ ] `go test ./internal/db/...` passes (includes new downgrade test)
- [ ] `go test ./...` passes — no regressions
- [ ] Set an `error` (or `warn`) alert on a session via `demux alert set --target <session> --level error --reason "test"`, then press `d` in the TUI — the existing alert must remain unchanged
- [ ] Set a `defer` alert on a session with no existing alert, press `d` — defer is applied normally
- [ ] Set a `defer` alert then press `d` again — defer is removed (toggle off still works)