### PR TITLE
fix(tui): use highest-severity timestamp as priority sort tiebreaker

### DIFF
--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -125,6 +125,20 @@ func (s *SidebarModel) newestSessionAlert(sess string) time.Time {
     return newest
 }
 
+// newestAlertAtSeverity returns the most recent CreatedAt among alerts for a
+// session whose alertSeverity equals sv, or zero time if none match.
+func (s *SidebarModel) newestAlertAtSeverity(sess string, sv int) time.Time {
+    var newest time.Time
+    for target, a := range s.alerts {
+        if strings.HasPrefix(target, sess+":") || target == sess {
+            if alertSeverity(a.Level) == sv && a.CreatedAt.After(newest) {
+                newest = a.CreatedAt
+            }
+        }
+    }
+    return newest
+}
+
 // highestSessionAlertSeverity returns the maximum alertSeverity value across
 // all alerts belonging to the session, or -1 if the session has no alerts.
 func (s *SidebarModel) highestSessionAlertSeverity(sess string) int {
@@ -311,8 +325,8 @@ func (s *SidebarModel) rebuildNodes() {
                     if svi != svj {
                         return svi > svj
                     }
-                    ti := s.newestSessionAlert(si.DisplayName)
-                    tj := s.newestSessionAlert(sj.DisplayName)
+                    ti := s.newestAlertAtSeverity(si.DisplayName, svi)
+                    tj := s.newestAlertAtSeverity(sj.DisplayName, svj)
                     if !ti.Equal(tj) {
                         return ti.After(tj)
                     }

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -528,6 +528,32 @@ func TestRebuildNodes_PrioritySort_SeverityBeatsRecency(t *testing.T) {
     }
 }
 
+// TestRebuildNodes_PrioritySort_TiebreakerIgnoresLowerLevelAlert is the
+// regression test for the bug where a session with [warn (old), defer (new)]
+// sorted before a session with [warn (recent)] because the defer timestamp was
+// used as the tiebreaker instead of restricting to the matching severity.
+func TestRebuildNodes_PrioritySort_TiebreakerIgnoresLowerLevelAlert(t *testing.T) {
+    // hf has a warn (9m) and a newer defer (11s). dm has a warn (7m).
+    // Both highest severities are equal (warn). Tiebreaker must compare only
+    // the warn timestamps: dm's warn (7m) is more recent, so dm sorts first.
+    now := time.Now()
+    s := SidebarModel{
+        sessions: makeSessions("hf-add-to-home-screen", "dm-main"),
+        alerts: map[string]db.Alert{
+            "hf-add-to-home-screen:0.1": {Target: "hf-add-to-home-screen:0.1", Level: "warn", CreatedAt: now.Add(-9 * time.Minute)},
+            "hf-add-to-home-screen":     {Target: "hf-add-to-home-screen", Level: "defer", CreatedAt: now.Add(-11 * time.Second)},
+            "dm-main:0.1":               {Target: "dm-main:0.1", Level: "warn", CreatedAt: now.Add(-7 * time.Minute)},
+        },
+    }
+    s.rebuildNodes()
+    if len(s.nodes) < 2 {
+        t.Fatalf("expected 2 nodes, got %d", len(s.nodes))
+    }
+    if s.nodes[0].Session != "dm-main" {
+        t.Errorf("expected dm-main (newer warn) first, got %q", s.nodes[0].Session)
+    }
+}
+
 // --- Alert filter ---
 
 func TestRebuildNodes_LastSeenSort(t *testing.T) {


### PR DESCRIPTION
## Summary

- When two sessions share the same highest alert severity, the tiebreaker previously called `newestSessionAlert()` which scanned alerts at **all** levels
- A lower-priority `defer` alert (e.g. 11s old) could beat an older `warn` alert (7m old), causing the wrong session to rank first
- Add `newestAlertAtSeverity()` and use it in the tiebreaker so only alerts matching the winning severity level are compared

## Test Plan

- [ ] `go test ./internal/tui/...` passes (239 tests)
- [ ] New regression test `TestRebuildNodes_PrioritySort_TiebreakerIgnoresLowerLevelAlert` covers the exact scenario: session with `[warn (9m), defer (11s)]` must sort after session with `[warn (7m)]`
- [ ] Manual: open two sessions both with `warn` alerts; add a `defer` alert to the older one and verify it does not jump to the top of the sidebar