### PR TITLE
chore: apply gofmt -s formatting across all Go files

### DIFF
--- a/cmd/alert.go
+++ b/cmd/alert.go
@@ -1,133 +1,133 @@
 package cmd
 
 import (
-    "fmt"
+	"fmt"
 
-    "github.com/rtalexk/demux/internal/format"
-    "github.com/spf13/cobra"
+	"github.com/rtalexk/demux/internal/format"
+	"github.com/spf13/cobra"
 )
 
 var (
-    alertSetTarget    string
-    alertRemoveTarget string
-    alertReason       string
-    alertLevel        string
+	alertSetTarget    string
+	alertRemoveTarget string
+	alertReason       string
+	alertLevel        string
 )
 
 type alertRow struct {
-    target  string
-    level   string
-    reason  string
-    created string
+	target  string
+	level   string
+	reason  string
+	created string
 }
 
 func (r alertRow) Fields() []string {
-    return []string{r.target, r.level, r.reason, r.created}
+	return []string{r.target, r.level, r.reason, r.created}
 }
 
 var alertCmd = &cobra.Command{
-    Use:   "alert",
-    Short: "Manage alerts",
-    RunE:  runAlertList,
+	Use:   "alert",
+	Short: "Manage alerts",
+	RunE:  runAlertList,
 }
 
 var alertListCmd = &cobra.Command{
-    Use:     "list",
-    Aliases: []string{"ls"},
-    Short:   "List alerts",
-    RunE:    runAlertList,
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List alerts",
+	RunE:    runAlertList,
 }
 
 var alertSetCmd = &cobra.Command{
-    Use:   "set",
-    Short: "Set (create or replace) an alert",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        d, err := openDB()
-        if err != nil {
-            return fmt.Errorf("open db: %w", err)
-        }
-        defer d.Close()
+	Use:   "set",
+	Short: "Set (create or replace) an alert",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("open db: %w", err)
+		}
+		defer d.Close()
 
-        if alertReason == "" {
-            if alertLevel == "defer" {
-                alertReason = loadConfig().Alerts.DeferDefaultReason
-                if alertReason == "" {
-                    return fmt.Errorf("--reason is required (alerts.defer_default_reason is not set)")
-                }
-            } else {
-                return fmt.Errorf("--reason is required")
-            }
-        }
+		if alertReason == "" {
+			if alertLevel == "defer" {
+				alertReason = loadConfig().Alerts.DeferDefaultReason
+				if alertReason == "" {
+					return fmt.Errorf("--reason is required (alerts.defer_default_reason is not set)")
+				}
+			} else {
+				return fmt.Errorf("--reason is required")
+			}
+		}
 
-        if err := d.AlertSet(alertSetTarget, alertReason, alertLevel); err != nil {
-            return fmt.Errorf("alert set: %w", err)
-        }
-        fmt.Printf("Alert set for %s\n", alertSetTarget)
-        return nil
-    },
+		if err := d.AlertSet(alertSetTarget, alertReason, alertLevel); err != nil {
+			return fmt.Errorf("alert set: %w", err)
+		}
+		fmt.Printf("Alert set for %s\n", alertSetTarget)
+		return nil
+	},
 }
 
 var alertRemoveCmd = &cobra.Command{
-    Use:     "remove",
-    Aliases: []string{"rm"},
-    Short:   "Remove an alert",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        d, err := openDB()
-        if err != nil {
-            return fmt.Errorf("open db: %w", err)
-        }
-        defer d.Close()
+	Use:     "remove",
+	Aliases: []string{"rm"},
+	Short:   "Remove an alert",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		d, err := openDB()
+		if err != nil {
+			return fmt.Errorf("open db: %w", err)
+		}
+		defer d.Close()
 
-        if err := d.AlertRemove(alertRemoveTarget); err != nil {
-            return fmt.Errorf("alert remove: %w", err)
-        }
-        fmt.Printf("Alert removed for %s\n", alertRemoveTarget)
-        return nil
-    },
+		if err := d.AlertRemove(alertRemoveTarget); err != nil {
+			return fmt.Errorf("alert remove: %w", err)
+		}
+		fmt.Printf("Alert removed for %s\n", alertRemoveTarget)
+		return nil
+	},
 }
 
 func runAlertList(cmd *cobra.Command, args []string) error {
-    d, err := openDB()
-    if err != nil {
-        return fmt.Errorf("open db: %w", err)
-    }
-    defer d.Close()
+	d, err := openDB()
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer d.Close()
 
-    alerts, err := d.AlertList()
-    if err != nil {
-        return fmt.Errorf("alert list: %w", err)
-    }
+	alerts, err := d.AlertList()
+	if err != nil {
+		return fmt.Errorf("alert list: %w", err)
+	}
 
-    headers := []string{"TARGET", "LEVEL", "REASON", "CREATED"}
-    rows := make([]format.Row, len(alerts))
-    for i, a := range alerts {
-        rows[i] = alertRow{
-            target:  a.Target,
-            level:   a.Level,
-            reason:  a.Reason,
-            created: format.Age(a.CreatedAt),
-        }
-    }
+	headers := []string{"TARGET", "LEVEL", "REASON", "CREATED"}
+	rows := make([]format.Row, len(alerts))
+	for i, a := range alerts {
+		rows[i] = alertRow{
+			target:  a.Target,
+			level:   a.Level,
+			reason:  a.Reason,
+			created: format.Age(a.CreatedAt),
+		}
+	}
 
-    output := format.Render(resolveFormat(cmd), headers, rows, isTTY())
-    fmt.Println(output)
-    return nil
+	output := format.Render(resolveFormat(cmd), headers, rows, isTTY())
+	fmt.Println(output)
+	return nil
 }
 
 func init() {
-    // alert set flags
-    alertSetCmd.Flags().StringVar(&alertSetTarget, "target", "", "Target: session:window or session:window.pane (required)")
-    alertSetCmd.Flags().StringVar(&alertReason, "reason", "", "Alert reason text")
-    alertSetCmd.Flags().StringVar(&alertLevel, "level", "info", "Alert level: info|warn|error|defer")
-    alertSetCmd.MarkFlagRequired("target")
+	// alert set flags
+	alertSetCmd.Flags().StringVar(&alertSetTarget, "target", "", "Target: session:window or session:window.pane (required)")
+	alertSetCmd.Flags().StringVar(&alertReason, "reason", "", "Alert reason text")
+	alertSetCmd.Flags().StringVar(&alertLevel, "level", "info", "Alert level: info|warn|error|defer")
+	alertSetCmd.MarkFlagRequired("target")
 
-    // alert remove flags
-    alertRemoveCmd.Flags().StringVar(&alertRemoveTarget, "target", "", "Target: session:window or session:window.pane (required)")
-    alertRemoveCmd.MarkFlagRequired("target")
+	// alert remove flags
+	alertRemoveCmd.Flags().StringVar(&alertRemoveTarget, "target", "", "Target: session:window or session:window.pane (required)")
+	alertRemoveCmd.MarkFlagRequired("target")
 
-    // wire subcommands
-    alertCmd.AddCommand(alertSetCmd, alertRemoveCmd, alertListCmd)
+	// wire subcommands
+	alertCmd.AddCommand(alertSetCmd, alertRemoveCmd, alertListCmd)
 
-    // register with root
-    rootCmd.AddCommand(alertCmd)
+	// register with root
+	rootCmd.AddCommand(alertCmd)
 }

--- a/cmd/alert_test.go
+++ b/cmd/alert_test.go
@@ -1,43 +1,43 @@
 package cmd_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/db"
 )
 
 func TestAlertCRUD(t *testing.T) {
-    d, err := db.Open(":memory:")
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer d.Close()
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
 
-    // set
-    if err := d.AlertSet("s:1", "waiting", "info"); err != nil {
-        t.Fatal(err)
-    }
+	// set
+	if err := d.AlertSet("s:1", "waiting", "info"); err != nil {
+		t.Fatal(err)
+	}
 
-    // list
-    alerts, err := d.AlertList()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(alerts) != 1 || alerts[0].Target != "s:1" {
-        t.Fatalf("unexpected alerts: %v", alerts)
-    }
+	// list
+	alerts, err := d.AlertList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(alerts) != 1 || alerts[0].Target != "s:1" {
+		t.Fatalf("unexpected alerts: %v", alerts)
+	}
 
-    // replace
-    d.AlertSet("s:1", "new reason", "warn")
-    alerts, _ = d.AlertList()
-    if len(alerts) != 1 || alerts[0].Reason != "new reason" {
-        t.Errorf("expected replaced alert")
-    }
+	// replace
+	d.AlertSet("s:1", "new reason", "warn")
+	alerts, _ = d.AlertList()
+	if len(alerts) != 1 || alerts[0].Reason != "new reason" {
+		t.Errorf("expected replaced alert")
+	}
 
-    // remove
-    d.AlertRemove("s:1")
-    alerts, _ = d.AlertList()
-    if len(alerts) != 0 {
-        t.Errorf("expected 0 after remove")
-    }
+	// remove
+	d.AlertRemove("s:1")
+	alerts, _ = d.AlertList()
+	if len(alerts) != 0 {
+		t.Errorf("expected 0 after remove")
+	}
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,23 +1,23 @@
 package cmd
 
 import (
-    "fmt"
+	"fmt"
 
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 var configCmd = &cobra.Command{
-    Use:   "config",
-    Short: "Config-related subcommands",
+	Use:   "config",
+	Short: "Config-related subcommands",
 }
 
 var configInitCmd = &cobra.Command{
-    Use:   "init",
-    Short: "Print an example config file with defaults",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        fmt.Print(defaultConfigTOML)
-        return nil
-    },
+	Use:   "init",
+	Short: "Print an example config file with defaults",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Print(defaultConfigTOML)
+		return nil
+	},
 }
 
 const defaultConfigTOML = `# demux configuration
@@ -188,6 +188,6 @@ shells = ["zsh", "bash", "sh", "fish", "dash", "nu", "pwsh"]
 `
 
 func init() {
-    configCmd.AddCommand(configInitCmd)
-    rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configInitCmd)
+	rootCmd.AddCommand(configCmd)
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -1,68 +1,68 @@
 package cmd
 
 import (
-    "strings"
+	"strings"
 
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/spf13/cobra"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/spf13/cobra"
 )
 
 var eventPaneFocusTarget string
 
 var eventCmd = &cobra.Command{
-    Use:   "event",
-    Short: "Send an external event to demux",
+	Use:   "event",
+	Short: "Send an external event to demux",
 }
 
 var eventPaneFocusCmd = &cobra.Command{
-    Use:   "pane_focus",
-    Short: "Clear alerts for the focused pane, its window, and its session",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        target := eventPaneFocusTarget
-        if target == "" {
-            var err error
-            target, err = tmuxPaneTarget()
-            if err != nil {
-                return err
-            }
-        }
+	Use:   "pane_focus",
+	Short: "Clear alerts for the focused pane, its window, and its session",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		target := eventPaneFocusTarget
+		if target == "" {
+			var err error
+			target, err = tmuxPaneTarget()
+			if err != nil {
+				return err
+			}
+		}
 
-        d, err := openDB()
-        if err != nil {
-            return err
-        }
-        defer d.Close()
+		d, err := openDB()
+		if err != nil {
+			return err
+		}
+		defer d.Close()
 
-        return applyPaneFocus(d, target)
-    },
+		return applyPaneFocus(d, target)
+	},
 }
 
 func applyPaneFocus(d *db.DB, paneTarget string) error {
-    if err := d.AlertRemove(paneTarget); err != nil {
-        return err
-    }
-    if err := d.AlertRemove(windowTargetFromPane(paneTarget)); err != nil {
-        return err
-    }
-    return d.AlertRemove(sessionTargetFromPane(paneTarget))
+	if err := d.AlertRemove(paneTarget); err != nil {
+		return err
+	}
+	if err := d.AlertRemove(windowTargetFromPane(paneTarget)); err != nil {
+		return err
+	}
+	return d.AlertRemove(sessionTargetFromPane(paneTarget))
 }
 
 func windowTargetFromPane(paneTarget string) string {
-    if i := strings.LastIndex(paneTarget, "."); i != -1 {
-        return paneTarget[:i]
-    }
-    return paneTarget
+	if i := strings.LastIndex(paneTarget, "."); i != -1 {
+		return paneTarget[:i]
+	}
+	return paneTarget
 }
 
 func sessionTargetFromPane(paneTarget string) string {
-    if i := strings.Index(paneTarget, ":"); i != -1 {
-        return paneTarget[:i]
-    }
-    return paneTarget
+	if i := strings.Index(paneTarget, ":"); i != -1 {
+		return paneTarget[:i]
+	}
+	return paneTarget
 }
 
 func init() {
-    eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusTarget, "target", "", "Pane target: session:window.pane (auto-detected if omitted)")
-    eventCmd.AddCommand(eventPaneFocusCmd)
-    rootCmd.AddCommand(eventCmd)
+	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusTarget, "target", "", "Pane target: session:window.pane (auto-detected if omitted)")
+	eventCmd.AddCommand(eventPaneFocusCmd)
+	rootCmd.AddCommand(eventCmd)
 }

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -1,118 +1,118 @@
 package cmd
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/db"
 )
 
 func TestWindowTargetFromPane_WithPane(t *testing.T) {
-    got := windowTargetFromPane("main:1.2")
-    want := "main:1"
-    if got != want {
-        t.Errorf("windowTargetFromPane(%q) = %q, want %q", "main:1.2", got, want)
-    }
+	got := windowTargetFromPane("main:1.2")
+	want := "main:1"
+	if got != want {
+		t.Errorf("windowTargetFromPane(%q) = %q, want %q", "main:1.2", got, want)
+	}
 }
 
 func TestWindowTargetFromPane_NoDot(t *testing.T) {
-    got := windowTargetFromPane("main:1")
-    want := "main:1"
-    if got != want {
-        t.Errorf("windowTargetFromPane(%q) = %q, want %q", "main:1", got, want)
-    }
+	got := windowTargetFromPane("main:1")
+	want := "main:1"
+	if got != want {
+		t.Errorf("windowTargetFromPane(%q) = %q, want %q", "main:1", got, want)
+	}
 }
 
 func TestWindowTargetFromPane_NamedWindowWithDots(t *testing.T) {
-    // session name contains a dot; LastIndex correctly strips only the pane suffix
-    got := windowTargetFromPane("a.b:c.0")
-    want := "a.b:c"
-    if got != want {
-        t.Errorf("windowTargetFromPane(%q) = %q, want %q", "a.b:c.0", got, want)
-    }
+	// session name contains a dot; LastIndex correctly strips only the pane suffix
+	got := windowTargetFromPane("a.b:c.0")
+	want := "a.b:c"
+	if got != want {
+		t.Errorf("windowTargetFromPane(%q) = %q, want %q", "a.b:c.0", got, want)
+	}
 }
 
 func TestPaneFocusClearsAlertsIncludingSticky(t *testing.T) {
-    d, err := db.Open(":memory:")
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer d.Close()
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
 
-    if err := d.AlertSet("work:2.3", "Claude finished", "info"); err != nil {
-        t.Fatal(err)
-    }
-    if err := d.AlertSet("work:2", "needs attention", "warn"); err != nil {
-        t.Fatal(err)
-    }
+	if err := d.AlertSet("work:2.3", "Claude finished", "info"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.AlertSet("work:2", "needs attention", "warn"); err != nil {
+		t.Fatal(err)
+	}
 
-    // confirm both alerts exist before clearing
-    seeded, err := d.AlertList()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(seeded) != 2 {
-        t.Fatalf("expected 2 seeded alerts, got %d", len(seeded))
-    }
+	// confirm both alerts exist before clearing
+	seeded, err := d.AlertList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seeded) != 2 {
+		t.Fatalf("expected 2 seeded alerts, got %d", len(seeded))
+	}
 
-    if err := applyPaneFocus(d, "work:2.3"); err != nil {
-        t.Fatal(err)
-    }
+	if err := applyPaneFocus(d, "work:2.3"); err != nil {
+		t.Fatal(err)
+	}
 
-    alerts, err := d.AlertList()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(alerts) != 0 {
-        t.Errorf("expected 0 alerts after pane_focus, got %d: %+v", len(alerts), alerts)
-    }
+	alerts, err := d.AlertList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(alerts) != 0 {
+		t.Errorf("expected 0 alerts after pane_focus, got %d: %+v", len(alerts), alerts)
+	}
 }
 
 func TestPaneFocusNoAlertsIsNoop(t *testing.T) {
-    d, err := db.Open(":memory:")
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer d.Close()
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
 
-    if err := applyPaneFocus(d, "work:2.3"); err != nil {
-        t.Fatalf("unexpected error on empty db: %v", err)
-    }
+	if err := applyPaneFocus(d, "work:2.3"); err != nil {
+		t.Fatalf("unexpected error on empty db: %v", err)
+	}
 }
 
 func TestApplyPaneFocusClearsSessionLevel(t *testing.T) {
-    d, err := db.Open(":memory:")
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer d.Close()
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
 
-    if err := d.AlertSet("main", "come back", "defer"); err != nil {
-        t.Fatalf("seed: %v", err)
-    }
-    if err := d.AlertSet("main:0", "window alert", "info"); err != nil {
-        t.Fatalf("seed: %v", err)
-    }
-    if err := d.AlertSet("main:0.0", "pane alert", "warn"); err != nil {
-        t.Fatalf("seed: %v", err)
-    }
+	if err := d.AlertSet("main", "come back", "defer"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := d.AlertSet("main:0", "window alert", "info"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := d.AlertSet("main:0.0", "pane alert", "warn"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
 
-    seeded, err := d.AlertList()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(seeded) != 3 {
-        t.Fatalf("expected 3 seeded alerts, got %d", len(seeded))
-    }
+	seeded, err := d.AlertList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seeded) != 3 {
+		t.Fatalf("expected 3 seeded alerts, got %d", len(seeded))
+	}
 
-    if err := applyPaneFocus(d, "main:0.0"); err != nil {
-        t.Fatal(err)
-    }
+	if err := applyPaneFocus(d, "main:0.0"); err != nil {
+		t.Fatal(err)
+	}
 
-    alerts, err := d.AlertList()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(alerts) != 0 {
-        t.Errorf("expected 0 alerts after pane_focus, got %d: %+v", len(alerts), alerts)
-    }
+	alerts, err := d.AlertList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(alerts) != 0 {
+		t.Errorf("expected 0 alerts after pane_focus, got %d: %+v", len(alerts), alerts)
+	}
 }

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -1,73 +1,73 @@
 package cmd
 
 import (
-    "fmt"
-    "os"
-    "os/exec"
-    "sort"
-    "strings"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
 
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 var hooksInitTool string
 
 var hooksCmd = &cobra.Command{
-    Use:   "hooks",
-    Short: "AI agent hook utilities",
+	Use:   "hooks",
+	Short: "AI agent hook utilities",
 }
 
 var hooksInitCmd = &cobra.Command{
-    Use:   "init",
-    Short: "Print hook configuration for an AI agent",
-    Long: `Prints a configuration snippet for the specified tool.
+	Use:   "init",
+	Short: "Print hook configuration for an AI agent",
+	Long: `Prints a configuration snippet for the specified tool.
 
 Supported tools: tmux
 
 For --tool tmux, prints hook lines to add to ~/.tmux.conf.`,
-    RunE: func(cmd *cobra.Command, args []string) error {
-        def, err := resolveAgent(hooksInitTool)
-        if err != nil {
-            return err
-        }
-        fmt.Print(def.snippet)
-        return nil
-    },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		def, err := resolveAgent(hooksInitTool)
+		if err != nil {
+			return err
+		}
+		fmt.Print(def.snippet)
+		return nil
+	},
 }
 
 type agentDef struct {
-    snippet string
+	snippet string
 }
 
 var agentDefs = map[string]agentDef{
-    "tmux": {snippet: tmuxHooksSnippet},
+	"tmux": {snippet: tmuxHooksSnippet},
 }
 
 func resolveAgent(name string) (agentDef, error) {
-    if def, ok := agentDefs[name]; ok {
-        return def, nil
-    }
-    supported := make([]string, 0, len(agentDefs))
-    for k := range agentDefs {
-        supported = append(supported, k)
-    }
-    sort.Strings(supported)
-    return agentDef{}, fmt.Errorf("unknown tool %q: supported tools: %s", name, strings.Join(supported, ", "))
+	if def, ok := agentDefs[name]; ok {
+		return def, nil
+	}
+	supported := make([]string, 0, len(agentDefs))
+	for k := range agentDefs {
+		supported = append(supported, k)
+	}
+	sort.Strings(supported)
+	return agentDef{}, fmt.Errorf("unknown tool %q: supported tools: %s", name, strings.Join(supported, ", "))
 }
 
 // tmuxPaneTarget returns the current tmux target as "session:windowIndex.paneIndex".
 // It uses $TMUX_PANE (set by tmux at process start) so the result always refers
 // to the pane where the agent was launched, not the currently focused pane.
 func tmuxPaneTarget() (string, error) {
-    args := []string{"display-message", "-p", "#S:#I.#P"}
-    if pane := os.Getenv("TMUX_PANE"); pane != "" {
-        args = []string{"display-message", "-t", pane, "-p", "#S:#I.#P"}
-    }
-    out, err := exec.Command("tmux", args...).Output()
-    if err != nil {
-        return "", fmt.Errorf("get tmux pane target: %w", err)
-    }
-    return strings.TrimSpace(string(out)), nil
+	args := []string{"display-message", "-p", "#S:#I.#P"}
+	if pane := os.Getenv("TMUX_PANE"); pane != "" {
+		args = []string{"display-message", "-t", pane, "-p", "#S:#I.#P"}
+	}
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("get tmux pane target: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 const tmuxHooksSnippet = `# demux tmux hooks
@@ -100,8 +100,8 @@ set-hook -g client-focus-in "run-shell 'demux event pane_focus --target #{sessio
 `
 
 func init() {
-    hooksInitCmd.Flags().StringVar(&hooksInitTool, "tool", "", "Tool to configure (required): tmux")
-    hooksInitCmd.MarkFlagRequired("tool")
-    hooksCmd.AddCommand(hooksInitCmd)
-    rootCmd.AddCommand(hooksCmd)
+	hooksInitCmd.Flags().StringVar(&hooksInitTool, "tool", "", "Tool to configure (required): tmux")
+	hooksInitCmd.MarkFlagRequired("tool")
+	hooksCmd.AddCommand(hooksInitCmd)
+	rootCmd.AddCommand(hooksCmd)
 }

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -1,39 +1,39 @@
 package cmd
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 )
 
 func TestResolveAgent_Unknown(t *testing.T) {
-    _, err := resolveAgent("aider")
-    if err == nil {
-        t.Fatal("expected error for unknown agent")
-    }
-    msg := err.Error()
-    if !strings.Contains(msg, "aider") {
-        t.Errorf("error should mention the bad value, got: %s", msg)
-    }
-    if !strings.Contains(msg, "tmux") {
-        t.Errorf("error should list tmux as supported agent, got: %s", msg)
-    }
+	_, err := resolveAgent("aider")
+	if err == nil {
+		t.Fatal("expected error for unknown agent")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "aider") {
+		t.Errorf("error should mention the bad value, got: %s", msg)
+	}
+	if !strings.Contains(msg, "tmux") {
+		t.Errorf("error should list tmux as supported agent, got: %s", msg)
+	}
 }
 
 func TestResolveAgent_Tmux(t *testing.T) {
-    def, err := resolveAgent("tmux")
-    if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    if def.snippet != tmuxHooksSnippet {
-        t.Errorf("snippet mismatch")
-    }
+	def, err := resolveAgent("tmux")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if def.snippet != tmuxHooksSnippet {
+		t.Errorf("snippet mismatch")
+	}
 }
 
 func TestTmuxHooksSnippet_ContainsAfterSelectPane(t *testing.T) {
-    if !strings.Contains(tmuxHooksSnippet, "after-select-pane") {
-        t.Error("tmuxHooksSnippet should reference after-select-pane hook")
-    }
-    if !strings.Contains(tmuxHooksSnippet, "demux event pane_focus") {
-        t.Error("tmuxHooksSnippet should call demux event pane_focus")
-    }
+	if !strings.Contains(tmuxHooksSnippet, "after-select-pane") {
+		t.Error("tmuxHooksSnippet should reference after-select-pane hook")
+	}
+	if !strings.Contains(tmuxHooksSnippet, "demux event pane_focus") {
+		t.Error("tmuxHooksSnippet should call demux event pane_focus")
+	}
 }

--- a/cmd/ports.go
+++ b/cmd/ports.go
@@ -1,94 +1,94 @@
 package cmd
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 
-    "github.com/mattn/go-isatty"
-    "github.com/rtalexk/demux/internal/format"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/tmux"
-    "github.com/spf13/cobra"
+	"github.com/mattn/go-isatty"
+	"github.com/rtalexk/demux/internal/format"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+	"github.com/spf13/cobra"
 )
 
 var portsCmd = &cobra.Command{
-    Use:   "ports",
-    Short: "List all TCP listening ports",
-    RunE:  runPorts,
+	Use:   "ports",
+	Short: "List all TCP listening ports",
+	RunE:  runPorts,
 }
 
 func init() {
-    rootCmd.AddCommand(portsCmd)
+	rootCmd.AddCommand(portsCmd)
 }
 
 type portRow struct {
-    port, pid, process, session, window, pane, up string
+	port, pid, process, session, window, pane, up string
 }
 
 func (r portRow) Fields() []string {
-    return []string{r.port, r.pid, r.process, r.session, r.window, r.pane, r.up}
+	return []string{r.port, r.pid, r.process, r.session, r.window, r.pane, r.up}
 }
 
 func runPorts(cmd *cobra.Command, _ []string) error {
-    ports, err := proc.ListeningPorts()
-    if err != nil {
-        return fmt.Errorf("list ports: %w", err)
-    }
+	ports, err := proc.ListeningPorts()
+	if err != nil {
+		return fmt.Errorf("list ports: %w", err)
+	}
 
-    procs, err := proc.Snapshot()
-    if err != nil {
-        demuxlog.Warn("proc snapshot failed", "err", err)
-    }
-    pidToProc := map[int32]proc.Process{}
-    for _, p := range procs {
-        pidToProc[p.PID] = p
-    }
+	procs, err := proc.Snapshot()
+	if err != nil {
+		demuxlog.Warn("proc snapshot failed", "err", err)
+	}
+	pidToProc := map[int32]proc.Process{}
+	for _, p := range procs {
+		pidToProc[p.PID] = p
+	}
 
-    allPanes, err := tmux.ListPanes()
-    if err != nil {
-        demuxlog.Warn("tmux panes unavailable", "err", err)
-    }
-    type paneRef struct{ session, window, pane string }
-    cwdToPane := map[string]paneRef{}
-    for _, p := range allPanes {
-        if _, exists := cwdToPane[p.CWD]; !exists {
-            cwdToPane[p.CWD] = paneRef{
-                session: p.Session,
-                window:  fmt.Sprint(p.WindowIndex),
-                pane:    fmt.Sprint(p.PaneIndex),
-            }
-        }
-    }
+	allPanes, err := tmux.ListPanes()
+	if err != nil {
+		demuxlog.Warn("tmux panes unavailable", "err", err)
+	}
+	type paneRef struct{ session, window, pane string }
+	cwdToPane := map[string]paneRef{}
+	for _, p := range allPanes {
+		if _, exists := cwdToPane[p.CWD]; !exists {
+			cwdToPane[p.CWD] = paneRef{
+				session: p.Session,
+				window:  fmt.Sprint(p.WindowIndex),
+				pane:    fmt.Sprint(p.PaneIndex),
+			}
+		}
+	}
 
-    headers := []string{"PORT", "PID", "PROCESS", "SESSION", "WINDOW", "PANE", "UP"}
-    var rows []format.Row
+	headers := []string{"PORT", "PID", "PROCESS", "SESSION", "WINDOW", "PANE", "UP"}
+	var rows []format.Row
 
-    for _, pi := range ports {
-        p := pidToProc[pi.PID]
-        session, window, pane := "—", "—", "—"
+	for _, pi := range ports {
+		p := pidToProc[pi.PID]
+		session, window, pane := "—", "—", "—"
 
-        cwd, err := proc.CWD(pi.PID)
-        if err == nil && cwd != "" {
-            if ref, ok := cwdToPane[cwd]; ok {
-                session = ref.session
-                window = ref.window
-                pane = ref.pane
-            }
-        }
+		cwd, err := proc.CWD(pi.PID)
+		if err == nil && cwd != "" {
+			if ref, ok := cwdToPane[cwd]; ok {
+				session = ref.session
+				window = ref.window
+				pane = ref.pane
+			}
+		}
 
-        rows = append(rows, portRow{
-            port:    fmt.Sprintf(":%d", pi.Port),
-            pid:     fmt.Sprint(pi.PID),
-            process: p.Name,
-            session: session,
-            window:  window,
-            pane:    pane,
-            up:      format.Duration(p.Uptime),
-        })
-    }
+		rows = append(rows, portRow{
+			port:    fmt.Sprintf(":%d", pi.Port),
+			pid:     fmt.Sprint(pi.PID),
+			process: p.Name,
+			session: session,
+			window:  window,
+			pane:    pane,
+			up:      format.Duration(p.Uptime),
+		})
+	}
 
-    isTTYVal := isatty.IsTerminal(os.Stdout.Fd())
-    fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
-    return nil
+	isTTYVal := isatty.IsTerminal(os.Stdout.Fd())
+	fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
+	return nil
 }

--- a/cmd/procs.go
+++ b/cmd/procs.go
@@ -1,189 +1,187 @@
 package cmd
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 
-    "github.com/mattn/go-isatty"
-    "github.com/rtalexk/demux/internal/format"
-    "github.com/rtalexk/demux/internal/git"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/tmux"
-    "github.com/spf13/cobra"
+	"github.com/mattn/go-isatty"
+	"github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/git"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+	"github.com/spf13/cobra"
 )
 
 var (
-    procsSession string
-    procsWindow  string
-    procsGit     bool
+	procsSession string
+	procsWindow  string
+	procsGit     bool
 )
 
 var procsCmd = &cobra.Command{
-    Use:   "procs",
-    Short: "List processes across sessions",
-    RunE:  runProcs,
+	Use:   "procs",
+	Short: "List processes across sessions",
+	RunE:  runProcs,
 }
 
 func init() {
-    rootCmd.AddCommand(procsCmd)
-    procsCmd.Flags().StringVar(&procsSession, "session", "", "Filter to session")
-    procsCmd.Flags().StringVar(&procsWindow, "window", "", "Filter to window (session:index)")
-    procsCmd.Flags().BoolVar(&procsGit, "git", false, "Include git column on pane headers")
+	rootCmd.AddCommand(procsCmd)
+	procsCmd.Flags().StringVar(&procsSession, "session", "", "Filter to session")
+	procsCmd.Flags().StringVar(&procsWindow, "window", "", "Filter to window (session:index)")
+	procsCmd.Flags().BoolVar(&procsGit, "git", false, "Include git column on pane headers")
 }
 
 type procRow struct {
-    session, window, pane, process, pid, cpu, mem, port, up, cwd string
-    gitCol                                                         string
-    includeGit                                                     bool
+	session, window, pane, process, pid, cpu, mem, port, up, cwd string
+	gitCol                                                       string
+	includeGit                                                   bool
 }
 
 func (r procRow) Fields() []string {
-    base := []string{r.session, r.window, r.pane, r.process, r.pid, r.cpu, r.mem, r.port, r.up, r.cwd}
-    if r.includeGit {
-        return append(base, r.gitCol)
-    }
-    return base
+	base := []string{r.session, r.window, r.pane, r.process, r.pid, r.cpu, r.mem, r.port, r.up, r.cwd}
+	if r.includeGit {
+		return append(base, r.gitCol)
+	}
+	return base
 }
-
 
 func runProcs(cmd *cobra.Command, _ []string) error {
-    cfg := loadConfig()
+	cfg := loadConfig()
 
-    allPanes, err := tmux.ListPanes()
-    if err != nil {
-        return fmt.Errorf("tmux not available: %w", err)
-    }
+	allPanes, err := tmux.ListPanes()
+	if err != nil {
+		return fmt.Errorf("tmux not available: %w", err)
+	}
 
-    allProcs, err := proc.Snapshot()
-    if err != nil {
-        return fmt.Errorf("snapshot procs: %w", err)
-    }
+	allProcs, err := proc.Snapshot()
+	if err != nil {
+		return fmt.Errorf("snapshot procs: %w", err)
+	}
 
-    cwdByPID, err := proc.CWDAll()
-    if err != nil {
-        demuxlog.Warn("cwd fetch failed", "err", err)
-    }
+	cwdByPID, err := proc.CWDAll()
+	if err != nil {
+		demuxlog.Warn("cwd fetch failed", "err", err)
+	}
 
-    ports, err := proc.ListeningPorts()
-    if err != nil {
-        demuxlog.Warn("port list failed", "err", err)
-    }
-    portByPID := map[int32]int{}
-    for _, p := range ports {
-        portByPID[p.PID] = p.Port
-    }
+	ports, err := proc.ListeningPorts()
+	if err != nil {
+		demuxlog.Warn("port list failed", "err", err)
+	}
+	portByPID := map[int32]int{}
+	for _, p := range ports {
+		portByPID[p.PID] = p.Port
+	}
 
-    grouped := tmux.GroupBySessions(allPanes)
+	grouped := tmux.GroupBySessions(allPanes)
 
-    headers := []string{"SESSION", "WINDOW", "PANE", "PROCESS", "PID", "CPU", "MEM", "PORT", "UP", "CWD"}
-    if procsGit {
-        headers = append(headers, "GIT")
-    }
+	headers := []string{"SESSION", "WINDOW", "PANE", "PROCESS", "PID", "CPU", "MEM", "PORT", "UP", "CWD"}
+	if procsGit {
+		headers = append(headers, "GIT")
+	}
 
-    // Pre-fetch git info in parallel for all deviant panes.
-    var gitWork []git.ConcurrentWork
-    if procsGit {
-        for sessionName, windows := range grouped {
-            if procsSession != "" && sessionName != procsSession {
-                continue
-            }
-            if isIgnored(cfg, sessionName) {
-                continue
-            }
-            primaryCWD := tmux.PrimaryPaneCWD(windows[0])
-            for wi, wPanes := range windows {
-                if procsWindow != "" && fmt.Sprintf("%s:%d", sessionName, wi) != procsWindow {
-                    continue
-                }
-                for _, pane := range wPanes {
-                    paneCWD := pane.CWD
-                    if !git.IsDescendant(paneCWD, primaryCWD) && paneCWD != primaryCWD {
-                        key := fmt.Sprintf("%s:%d:%d", sessionName, wi, pane.PaneIndex)
-                        gitWork = append(gitWork, git.ConcurrentWork{Key: key, Dir: paneCWD})
-                    }
-                }
-            }
-        }
-    }
-    gitResults := git.FetchConcurrent(gitWork, cfg.Git.TimeoutMs)
+	// Pre-fetch git info in parallel for all deviant panes.
+	var gitWork []git.ConcurrentWork
+	if procsGit {
+		for sessionName, windows := range grouped {
+			if procsSession != "" && sessionName != procsSession {
+				continue
+			}
+			if isIgnored(cfg, sessionName) {
+				continue
+			}
+			primaryCWD := tmux.PrimaryPaneCWD(windows[0])
+			for wi, wPanes := range windows {
+				if procsWindow != "" && fmt.Sprintf("%s:%d", sessionName, wi) != procsWindow {
+					continue
+				}
+				for _, pane := range wPanes {
+					paneCWD := pane.CWD
+					if !git.IsDescendant(paneCWD, primaryCWD) && paneCWD != primaryCWD {
+						key := fmt.Sprintf("%s:%d:%d", sessionName, wi, pane.PaneIndex)
+						gitWork = append(gitWork, git.ConcurrentWork{Key: key, Dir: paneCWD})
+					}
+				}
+			}
+		}
+	}
+	gitResults := git.FetchConcurrent(gitWork, cfg.Git.TimeoutMs)
 
-    var rows []format.Row
+	var rows []format.Row
 
-    for sessionName, windows := range grouped {
-        if procsSession != "" && sessionName != procsSession {
-            continue
-        }
-        if isIgnored(cfg, sessionName) {
-            continue
-        }
+	for sessionName, windows := range grouped {
+		if procsSession != "" && sessionName != procsSession {
+			continue
+		}
+		if isIgnored(cfg, sessionName) {
+			continue
+		}
 
-        primaryCWD := tmux.PrimaryPaneCWD(windows[0])
+		primaryCWD := tmux.PrimaryPaneCWD(windows[0])
 
-        for wi, wPanes := range windows {
-            if procsWindow != "" && fmt.Sprintf("%s:%d", sessionName, wi) != procsWindow {
-                continue
-            }
+		for wi, wPanes := range windows {
+			if procsWindow != "" && fmt.Sprintf("%s:%d", sessionName, wi) != procsWindow {
+				continue
+			}
 
-            for _, pane := range wPanes {
-                paneCWD := pane.CWD
-                gitCol := "—"
-                if procsGit {
-                    key := fmt.Sprintf("%s:%d:%d", sessionName, wi, pane.PaneIndex)
-                    if !git.IsDescendant(paneCWD, primaryCWD) && paneCWD != primaryCWD {
-                        if info, ok := gitResults[key]; ok {
-                            gitCol = "↪ " + info.Branch + " " + git.Indicators(info)
-                        } else {
-                            gitCol = cfg.Git.ErrorDisplay
-                        }
-                    }
-                }
+			for _, pane := range wPanes {
+				paneCWD := pane.CWD
+				gitCol := "—"
+				if procsGit {
+					key := fmt.Sprintf("%s:%d:%d", sessionName, wi, pane.PaneIndex)
+					if !git.IsDescendant(paneCWD, primaryCWD) && paneCWD != primaryCWD {
+						if info, ok := gitResults[key]; ok {
+							gitCol = "↪ " + info.Branch + " " + git.Indicators(info)
+						} else {
+							gitCol = cfg.Git.ErrorDisplay
+						}
+					}
+				}
 
-                rows = append(rows, procRow{
-                    session:    sessionName,
-                    window:     fmt.Sprint(wi),
-                    pane:       fmt.Sprint(pane.PaneIndex),
-                    process:    "(pane)",
-                    pid:        "—",
-                    cpu:        "—",
-                    mem:        "—",
-                    port:       "—",
-                    up:         "—",
-                    cwd:        paneCWD,
-                    gitCol:     gitCol,
-                    includeGit: procsGit,
-                })
+				rows = append(rows, procRow{
+					session:    sessionName,
+					window:     fmt.Sprint(wi),
+					pane:       fmt.Sprint(pane.PaneIndex),
+					process:    "(pane)",
+					pid:        "—",
+					cpu:        "—",
+					mem:        "—",
+					port:       "—",
+					up:         "—",
+					cwd:        paneCWD,
+					gitCol:     gitCol,
+					includeGit: procsGit,
+				})
 
-                for _, p := range allProcs {
-                    cwd, ok := cwdByPID[p.PID]
-                    if !ok || cwd != paneCWD {
-                        continue
-                    }
-                    portStr := "—"
-                    if port, ok := portByPID[p.PID]; ok {
-                        portStr = fmt.Sprintf(":%d", port)
-                    }
-                    rows = append(rows, procRow{
-                        session:    sessionName,
-                        window:     fmt.Sprint(wi),
-                        pane:       fmt.Sprint(pane.PaneIndex),
-                        process:    p.Name,
-                        pid:        fmt.Sprint(p.PID),
-                        cpu:        fmt.Sprintf("%.1f%%", p.CPU),
-                        mem:        format.Mem(p.MemRSS),
-                        port:       portStr,
-                        up:         format.Duration(p.Uptime),
-                        cwd:        paneCWD,
-                        gitCol:     "—",
-                        includeGit: procsGit,
-                    })
-                }
-            }
-        }
-    }
+				for _, p := range allProcs {
+					cwd, ok := cwdByPID[p.PID]
+					if !ok || cwd != paneCWD {
+						continue
+					}
+					portStr := "—"
+					if port, ok := portByPID[p.PID]; ok {
+						portStr = fmt.Sprintf(":%d", port)
+					}
+					rows = append(rows, procRow{
+						session:    sessionName,
+						window:     fmt.Sprint(wi),
+						pane:       fmt.Sprint(pane.PaneIndex),
+						process:    p.Name,
+						pid:        fmt.Sprint(p.PID),
+						cpu:        fmt.Sprintf("%.1f%%", p.CPU),
+						mem:        format.Mem(p.MemRSS),
+						port:       portStr,
+						up:         format.Duration(p.Uptime),
+						cwd:        paneCWD,
+						gitCol:     "—",
+						includeGit: procsGit,
+					})
+				}
+			}
+		}
+	}
 
-    isTTYVal := isatty.IsTerminal(os.Stdout.Fd())
-    fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
-    return nil
+	isTTYVal := isatty.IsTerminal(os.Stdout.Fd())
+	fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
+	return nil
 }
-

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -1,111 +1,111 @@
 package cmd
 
 import (
-    "fmt"
-    "sort"
+	"fmt"
+	"sort"
 
-    "github.com/rtalexk/demux/internal/format"
-    "github.com/rtalexk/demux/internal/query"
-    "github.com/spf13/cobra"
+	"github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/query"
+	"github.com/spf13/cobra"
 )
 
 var sessionNameOnly bool
 
 var queryCmd = &cobra.Command{
-    Use:   "query <term>",
-    Short: "Fuzzy search sessions, windows, and processes",
-    Args:  cobra.ExactArgs(1),
-    RunE:  runQuery,
+	Use:   "query <term>",
+	Short: "Fuzzy search sessions, windows, and processes",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runQuery,
 }
 
 func init() {
-    queryCmd.Flags().BoolVar(&sessionNameOnly, "session-name-only", false,
-        "Output unique session names only (for piping to fzf)")
-    rootCmd.AddCommand(queryCmd)
+	queryCmd.Flags().BoolVar(&sessionNameOnly, "session-name-only", false,
+		"Output unique session names only (for piping to fzf)")
+	rootCmd.AddCommand(queryCmd)
 }
 
 type queryRow struct {
-    typ, session, window, score, matchedIn string
+	typ, session, window, score, matchedIn string
 }
 
 func (r queryRow) Fields() []string {
-    return []string{r.typ, r.session, r.window, r.score, r.matchedIn}
+	return []string{r.typ, r.session, r.window, r.score, r.matchedIn}
 }
 
 func runQuery(cmd *cobra.Command, args []string) error {
-    pq := query.Parse(args[0])
-    result, err := query.Run(pq)
-    if err != nil {
-        return err
-    }
+	pq := query.Parse(args[0])
+	result, err := query.Run(pq)
+	if err != nil {
+		return err
+	}
 
-    type flatRow struct {
-        score     int
-        typ       string
-        session   string
-        window    string
-        matchedIn string
-    }
-    var flat []flatRow
+	type flatRow struct {
+		score     int
+		typ       string
+		session   string
+		window    string
+		matchedIn string
+	}
+	var flat []flatRow
 
-    for _, sm := range result.Sessions {
-        if len(sm.MatchPos) > 0 {
-            flat = append(flat, flatRow{
-                score:     sm.Score,
-                typ:       "session",
-                session:   sm.Name,
-                window:    "-",
-                matchedIn: "s:" + sm.Name,
-            })
-        }
-        for _, wm := range sm.Windows {
-            flat = append(flat, flatRow{
-                score:     wm.Score,
-                typ:       "window",
-                session:   sm.Name,
-                window:    fmt.Sprintf("%d", wm.Index),
-                matchedIn: "w:" + wm.Name,
-            })
-        }
-        for _, pm := range sm.Procs {
-            flat = append(flat, flatRow{
-                score:     pm.Score,
-                typ:       "process",
-                session:   sm.Name,
-                window:    "-",
-                matchedIn: "p:" + pm.Name,
-            })
-        }
-    }
+	for _, sm := range result.Sessions {
+		if len(sm.MatchPos) > 0 {
+			flat = append(flat, flatRow{
+				score:     sm.Score,
+				typ:       "session",
+				session:   sm.Name,
+				window:    "-",
+				matchedIn: "s:" + sm.Name,
+			})
+		}
+		for _, wm := range sm.Windows {
+			flat = append(flat, flatRow{
+				score:     wm.Score,
+				typ:       "window",
+				session:   sm.Name,
+				window:    fmt.Sprintf("%d", wm.Index),
+				matchedIn: "w:" + wm.Name,
+			})
+		}
+		for _, pm := range sm.Procs {
+			flat = append(flat, flatRow{
+				score:     pm.Score,
+				typ:       "process",
+				session:   sm.Name,
+				window:    "-",
+				matchedIn: "p:" + pm.Name,
+			})
+		}
+	}
 
-    sort.Slice(flat, func(i, j int) bool {
-        return flat[i].score > flat[j].score
-    })
+	sort.Slice(flat, func(i, j int) bool {
+		return flat[i].score > flat[j].score
+	})
 
-    if sessionNameOnly {
-        seen := make(map[string]bool)
-        for _, r := range flat {
-            if !seen[r.session] {
-                seen[r.session] = true
-                fmt.Println(r.session)
-            }
-        }
-        return nil
-    }
+	if sessionNameOnly {
+		seen := make(map[string]bool)
+		for _, r := range flat {
+			if !seen[r.session] {
+				seen[r.session] = true
+				fmt.Println(r.session)
+			}
+		}
+		return nil
+	}
 
-    headers := []string{"TYPE", "SESSION", "WINDOW", "SCORE", "MATCHED IN"}
-    rows := make([]format.Row, len(flat))
-    for i, r := range flat {
-        rows[i] = queryRow{
-            typ:       r.typ,
-            session:   r.session,
-            window:    r.window,
-            score:     fmt.Sprintf("%d", r.score),
-            matchedIn: r.matchedIn,
-        }
-    }
+	headers := []string{"TYPE", "SESSION", "WINDOW", "SCORE", "MATCHED IN"}
+	rows := make([]format.Row, len(flat))
+	for i, r := range flat {
+		rows[i] = queryRow{
+			typ:       r.typ,
+			session:   r.session,
+			window:    r.window,
+			score:     fmt.Sprintf("%d", r.score),
+			matchedIn: r.matchedIn,
+		}
+	}
 
-    isTTYVal := isTTY()
-    fmt.Print(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
-    return nil
+	isTTYVal := isTTY()
+	fmt.Print(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
+	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,15 +1,15 @@
 package cmd
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 
-    "github.com/mattn/go-isatty"
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/tui"
-    "github.com/spf13/cobra"
+	"github.com/mattn/go-isatty"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/tui"
+	"github.com/spf13/cobra"
 )
 
 var formatFlag string
@@ -18,103 +18,102 @@ var searchFlag bool
 var logLevelFlag string
 
 var rootCmd = &cobra.Command{
-    Use:          "demux",
-    Short:        "Monitor tmux sessions, processes, and alerts",
-    SilenceUsage: true,
-    PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-        cfg := loadConfig()
-        levelStr := cfg.Log.Level
-        if logLevelFlag != "" {
-            levelStr = logLevelFlag
-        }
-        level, err := demuxlog.ParseLevel(levelStr)
-        if err != nil {
-            // Invalid level from config or flag — warn but continue with default.
-            fmt.Fprintf(os.Stderr, "demux: %v\n", err)
-            level = demuxlog.LevelWarn
-        }
-        logPath, err := demuxlog.DefaultPath()
-        if err != nil {
-            // Cannot determine home dir — disable logging silently.
-            return nil
-        }
-        closer, err := demuxlog.Open(logPath, level)
-        if err != nil {
-            fmt.Fprintf(os.Stderr, "demux: failed to open log file: %v\n", err)
-            return nil
-        }
-        // Register closer so the file is flushed/closed on exit.
-        // Cobra doesn't expose a post-run hook on root that fires for all children,
-        // so we use a finalizer via the cobra RunE pattern.
-        cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
-            return closer.Close()
-        }
-        return nil
-    },
-    RunE: func(cmd *cobra.Command, args []string) error {
-        cfg := loadConfig()
-        if compactFlag {
-            cfg.Mode = "compact"
-        }
-        if searchFlag {
-            cfg.Sidebar.FocusSearchOnOpen = true
-        }
-        dbPath, err := db.DefaultPath()
-        if err != nil {
-            return err
-        }
-        database, err := db.Open(dbPath)
-        if err != nil {
-            return fmt.Errorf("open db: %w", err)
-        }
-        defer database.Close()
-        return tui.Run(cfg, database)
-    },
+	Use:          "demux",
+	Short:        "Monitor tmux sessions, processes, and alerts",
+	SilenceUsage: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		cfg := loadConfig()
+		levelStr := cfg.Log.Level
+		if logLevelFlag != "" {
+			levelStr = logLevelFlag
+		}
+		level, err := demuxlog.ParseLevel(levelStr)
+		if err != nil {
+			// Invalid level from config or flag — warn but continue with default.
+			fmt.Fprintf(os.Stderr, "demux: %v\n", err)
+			level = demuxlog.LevelWarn
+		}
+		logPath, err := demuxlog.DefaultPath()
+		if err != nil {
+			// Cannot determine home dir — disable logging silently.
+			return nil
+		}
+		closer, err := demuxlog.Open(logPath, level)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "demux: failed to open log file: %v\n", err)
+			return nil
+		}
+		// Register closer so the file is flushed/closed on exit.
+		// Cobra doesn't expose a post-run hook on root that fires for all children,
+		// so we use a finalizer via the cobra RunE pattern.
+		cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+			return closer.Close()
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := loadConfig()
+		if compactFlag {
+			cfg.Mode = "compact"
+		}
+		if searchFlag {
+			cfg.Sidebar.FocusSearchOnOpen = true
+		}
+		dbPath, err := db.DefaultPath()
+		if err != nil {
+			return err
+		}
+		database, err := db.Open(dbPath)
+		if err != nil {
+			return fmt.Errorf("open db: %w", err)
+		}
+		defer database.Close()
+		return tui.Run(cfg, database)
+	},
 }
 
 func Execute() {
-    if err := rootCmd.Execute(); err != nil {
-        os.Exit(1)
-    }
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 func init() {
-    rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "", "Output format: text|table|json")
-    rootCmd.PersistentFlags().StringVar(&logLevelFlag, "log-level", "", "Log level: off|error|warn|info|debug (overrides config)")
-    rootCmd.PersistentFlags().BoolVar(&compactFlag, "compact", false, "Launch in compact mode (sidebar + search only)")
-    rootCmd.PersistentFlags().BoolVar(&searchFlag, "search", false, "Start with focus in the search input")
+	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "", "Output format: text|table|json")
+	rootCmd.PersistentFlags().StringVar(&logLevelFlag, "log-level", "", "Log level: off|error|warn|info|debug (overrides config)")
+	rootCmd.PersistentFlags().BoolVar(&compactFlag, "compact", false, "Launch in compact mode (sidebar + search only)")
+	rootCmd.PersistentFlags().BoolVar(&searchFlag, "search", false, "Start with focus in the search input")
 }
 
 func loadConfig() config.Config {
-    path, err := config.DefaultPath()
-    if err != nil {
-        demuxlog.Warn("cannot determine config path", "err", err)
-        return config.Default()
-    }
-    cfg, err := config.Load(path)
-    if err != nil {
-        demuxlog.Warn("failed to load config, using defaults", "path", path, "err", err)
-        return config.Default()
-    }
-    return cfg
+	path, err := config.DefaultPath()
+	if err != nil {
+		demuxlog.Warn("cannot determine config path", "err", err)
+		return config.Default()
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		demuxlog.Warn("failed to load config, using defaults", "path", path, "err", err)
+		return config.Default()
+	}
+	return cfg
 }
 
 func openDB() (*db.DB, error) {
-    path, err := db.DefaultPath()
-    if err != nil {
-        return nil, err
-    }
-    return db.Open(path)
+	path, err := db.DefaultPath()
+	if err != nil {
+		return nil, err
+	}
+	return db.Open(path)
 }
 
 func resolveFormat(cmd *cobra.Command) string {
-    if formatFlag != "" {
-        return formatFlag
-    }
-    return "table"
+	if formatFlag != "" {
+		return formatFlag
+	}
+	return "table"
 }
 
 func isTTY() bool {
-    return isatty.IsTerminal(os.Stdout.Fd())
+	return isatty.IsTerminal(os.Stdout.Fd())
 }
-

--- a/cmd/session_config.go
+++ b/cmd/session_config.go
@@ -1,248 +1,248 @@
 package cmd
 
 import (
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/session"
-    "github.com/rtalexk/demux/internal/tmux"
-    "github.com/spf13/cobra"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/session"
+	"github.com/rtalexk/demux/internal/tmux"
+	"github.com/spf13/cobra"
 )
 
 var sessionCmd = &cobra.Command{
-    Use:   "session",
-    Short: "Manage session config entries",
+	Use:   "session",
+	Short: "Manage session config entries",
 }
 
 // --- add ---
 
 var (
-    sessionAddName     string
-    sessionAddGroup    string
-    sessionAddPath     string
-    sessionAddWorktree bool
-    sessionAddLabels   string
-    sessionAddIcon     string
-    sessionAddWindows  string
-    sessionAddPrivate  bool
+	sessionAddName     string
+	sessionAddGroup    string
+	sessionAddPath     string
+	sessionAddWorktree bool
+	sessionAddLabels   string
+	sessionAddIcon     string
+	sessionAddWindows  string
+	sessionAddPrivate  bool
 )
 
 var sessionAddCmd = &cobra.Command{
-    Use:   "config-add",
-    Short: "Add a session entry to sessions.toml (or private.toml with --private)",
-    RunE:  runSessionAdd,
+	Use:   "config-add",
+	Short: "Add a session entry to sessions.toml (or private.toml with --private)",
+	RunE:  runSessionAdd,
 }
 
 func init() {
-    sessionAddCmd.Flags().StringVar(&sessionAddName, "name", "", "Session name (required)")
-    sessionAddCmd.Flags().StringVar(&sessionAddGroup, "group", "", "Session group")
-    sessionAddCmd.Flags().StringVar(&sessionAddPath, "path", "", "Path to session directory (required)")
-    sessionAddCmd.Flags().BoolVar(&sessionAddWorktree, "worktree", false, "Mark as a worktree session")
-    sessionAddCmd.Flags().StringVar(&sessionAddLabels, "labels", "", "Comma-separated labels (e.g. work,rust)")
-    sessionAddCmd.Flags().StringVar(&sessionAddIcon, "icon", "", "Icon glyph")
-    sessionAddCmd.Flags().StringVar(&sessionAddWindows, "windows", "", "Comma-separated window template ids (e.g. editor,terminal)")
-    sessionAddCmd.Flags().BoolVar(&sessionAddPrivate, "private", false, "Write to private.toml instead of sessions.toml")
+	sessionAddCmd.Flags().StringVar(&sessionAddName, "name", "", "Session name (required)")
+	sessionAddCmd.Flags().StringVar(&sessionAddGroup, "group", "", "Session group")
+	sessionAddCmd.Flags().StringVar(&sessionAddPath, "path", "", "Path to session directory (required)")
+	sessionAddCmd.Flags().BoolVar(&sessionAddWorktree, "worktree", false, "Mark as a worktree session")
+	sessionAddCmd.Flags().StringVar(&sessionAddLabels, "labels", "", "Comma-separated labels (e.g. work,rust)")
+	sessionAddCmd.Flags().StringVar(&sessionAddIcon, "icon", "", "Icon glyph")
+	sessionAddCmd.Flags().StringVar(&sessionAddWindows, "windows", "", "Comma-separated window template ids (e.g. editor,terminal)")
+	sessionAddCmd.Flags().BoolVar(&sessionAddPrivate, "private", false, "Write to private.toml instead of sessions.toml")
 
-    _ = sessionAddCmd.MarkFlagRequired("name")
-    _ = sessionAddCmd.MarkFlagRequired("path")
+	_ = sessionAddCmd.MarkFlagRequired("name")
+	_ = sessionAddCmd.MarkFlagRequired("path")
 
-    sessionCmd.AddCommand(sessionAddCmd)
+	sessionCmd.AddCommand(sessionAddCmd)
 }
 
 func runSessionAdd(_ *cobra.Command, _ []string) error {
-    path, err := sessionFilePath(sessionAddPrivate)
-    if err != nil {
-        return err
-    }
+	path, err := sessionFilePath(sessionAddPrivate)
+	if err != nil {
+		return err
+	}
 
-    var labels []string
-    if sessionAddLabels != "" {
-        for _, l := range strings.Split(sessionAddLabels, ",") {
-            if t := strings.TrimSpace(l); t != "" {
-                labels = append(labels, t)
-            }
-        }
-    }
+	var labels []string
+	if sessionAddLabels != "" {
+		for _, l := range strings.Split(sessionAddLabels, ",") {
+			if t := strings.TrimSpace(l); t != "" {
+				labels = append(labels, t)
+			}
+		}
+	}
 
-    var windows []string
-    if sessionAddWindows != "" {
-        for _, w := range strings.Split(sessionAddWindows, ",") {
-            if t := strings.TrimSpace(w); t != "" {
-                windows = append(windows, t)
-            }
-        }
-    }
+	var windows []string
+	if sessionAddWindows != "" {
+		for _, w := range strings.Split(sessionAddWindows, ",") {
+			if t := strings.TrimSpace(w); t != "" {
+				windows = append(windows, t)
+			}
+		}
+	}
 
-    e := session.ConfigEntry{
-        Name:     sessionAddName,
-        Group:    sessionAddGroup,
-        Path:     sessionAddPath,
-        Worktree: sessionAddWorktree,
-        Labels:   labels,
-        Icon:     sessionAddIcon,
-        Windows:  windows,
-    }
+	e := session.ConfigEntry{
+		Name:     sessionAddName,
+		Group:    sessionAddGroup,
+		Path:     sessionAddPath,
+		Worktree: sessionAddWorktree,
+		Labels:   labels,
+		Icon:     sessionAddIcon,
+		Windows:  windows,
+	}
 
-    if err := session.AppendEntry(path, e); err != nil {
-        return err
-    }
+	if err := session.AppendEntry(path, e); err != nil {
+		return err
+	}
 
-    fmt.Printf("Added session %q to %s\n", e.DisplayName(), filepath.Base(path))
-    return nil
+	fmt.Printf("Added session %q to %s\n", e.DisplayName(), filepath.Base(path))
+	return nil
 }
 
 // --- get-config ---
 
 var (
-    sessionGetConfigName string
+	sessionGetConfigName string
 )
 
 var sessionGetConfigCmd = &cobra.Command{
-    Use:   "config-get",
-    Short: "Print the config block for a session",
-    RunE:  runSessionGetConfig,
+	Use:   "config-get",
+	Short: "Print the config block for a session",
+	RunE:  runSessionGetConfig,
 }
 
 func init() {
-    sessionGetConfigCmd.Flags().StringVar(&sessionGetConfigName, "name", "", "Session name (required)")
+	sessionGetConfigCmd.Flags().StringVar(&sessionGetConfigName, "name", "", "Session name (required)")
 
-    _ = sessionGetConfigCmd.MarkFlagRequired("name")
+	_ = sessionGetConfigCmd.MarkFlagRequired("name")
 
-    sessionCmd.AddCommand(sessionGetConfigCmd)
+	sessionCmd.AddCommand(sessionGetConfigCmd)
 }
 
 func runSessionGetConfig(_ *cobra.Command, _ []string) error {
-    cfgPath, err := config.DefaultPath()
-    if err != nil {
-        return fmt.Errorf("config dir: %w", err)
-    }
-    cfg, err := session.LoadConfigSessions(filepath.Dir(cfgPath))
-    if err != nil {
-        return err
-    }
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		return fmt.Errorf("config dir: %w", err)
+	}
+	cfg, err := session.LoadConfigSessions(filepath.Dir(cfgPath))
+	if err != nil {
+		return err
+	}
 
-    for _, e := range cfg.Entries {
-        if e.DisplayName() == sessionGetConfigName {
-            fmt.Print(session.FormatBlock(e))
-            return nil
-        }
-    }
-    return fmt.Errorf("session %q not found", sessionGetConfigName)
+	for _, e := range cfg.Entries {
+		if e.DisplayName() == sessionGetConfigName {
+			fmt.Print(session.FormatBlock(e))
+			return nil
+		}
+	}
+	return fmt.Errorf("session %q not found", sessionGetConfigName)
 }
 
 // --- remove ---
 
 var (
-    sessionRemoveName    string
-    sessionRemovePrivate bool
+	sessionRemoveName    string
+	sessionRemovePrivate bool
 )
 
 var sessionRemoveCmd = &cobra.Command{
-    Use:     "config-remove",
-    Aliases: []string{"config-rm"},
-    Short:   "Remove a session entry from sessions.toml (or private.toml with --private)",
-    RunE:    runSessionRemove,
+	Use:     "config-remove",
+	Aliases: []string{"config-rm"},
+	Short:   "Remove a session entry from sessions.toml (or private.toml with --private)",
+	RunE:    runSessionRemove,
 }
 
 func init() {
-    sessionRemoveCmd.Flags().StringVar(&sessionRemoveName, "name", "", "Session name (required)")
-    sessionRemoveCmd.Flags().BoolVar(&sessionRemovePrivate, "private", false, "Target private.toml instead of sessions.toml")
+	sessionRemoveCmd.Flags().StringVar(&sessionRemoveName, "name", "", "Session name (required)")
+	sessionRemoveCmd.Flags().BoolVar(&sessionRemovePrivate, "private", false, "Target private.toml instead of sessions.toml")
 
-    _ = sessionRemoveCmd.MarkFlagRequired("name")
+	_ = sessionRemoveCmd.MarkFlagRequired("name")
 
-    sessionCmd.AddCommand(sessionRemoveCmd)
+	sessionCmd.AddCommand(sessionRemoveCmd)
 }
 
 func runSessionRemove(_ *cobra.Command, _ []string) error {
-    path, err := sessionFilePath(sessionRemovePrivate)
-    if err != nil {
-        return err
-    }
+	path, err := sessionFilePath(sessionRemovePrivate)
+	if err != nil {
+		return err
+	}
 
-    if err := session.RemoveEntry(path, sessionRemoveName); err != nil {
-        return err
-    }
+	if err := session.RemoveEntry(path, sessionRemoveName); err != nil {
+		return err
+	}
 
-    fmt.Printf("Removed session %q from %s\n", sessionRemoveName, filepath.Base(path))
-    return nil
+	fmt.Printf("Removed session %q from %s\n", sessionRemoveName, filepath.Base(path))
+	return nil
 }
 
 // --- create-windows ---
 
 var (
-    sessionCreateWindowsSession string
-    sessionCreateWindowsIDs     string
+	sessionCreateWindowsSession string
+	sessionCreateWindowsIDs     string
 )
 
 var sessionCreateWindowsCmd = &cobra.Command{
-    Use:   "create-windows",
-    Short: "Create tmux windows for a session using window template ids",
-    RunE:  runSessionCreateWindows,
+	Use:   "create-windows",
+	Short: "Create tmux windows for a session using window template ids",
+	RunE:  runSessionCreateWindows,
 }
 
 func init() {
-    sessionCreateWindowsCmd.Flags().StringVar(&sessionCreateWindowsSession, "session", "", "Tmux session name (required)")
-    sessionCreateWindowsCmd.Flags().StringVar(&sessionCreateWindowsIDs, "windows", "", "Comma-separated window template ids (required)")
+	sessionCreateWindowsCmd.Flags().StringVar(&sessionCreateWindowsSession, "session", "", "Tmux session name (required)")
+	sessionCreateWindowsCmd.Flags().StringVar(&sessionCreateWindowsIDs, "windows", "", "Comma-separated window template ids (required)")
 
-    _ = sessionCreateWindowsCmd.MarkFlagRequired("session")
-    _ = sessionCreateWindowsCmd.MarkFlagRequired("windows")
+	_ = sessionCreateWindowsCmd.MarkFlagRequired("session")
+	_ = sessionCreateWindowsCmd.MarkFlagRequired("windows")
 
-    sessionCmd.AddCommand(sessionCreateWindowsCmd)
+	sessionCmd.AddCommand(sessionCreateWindowsCmd)
 }
 
 func runSessionCreateWindows(_ *cobra.Command, _ []string) error {
-    cfgPath, err := config.DefaultPath()
-    if err != nil {
-        return fmt.Errorf("config dir: %w", err)
-    }
-    cfg, err := session.LoadConfigSessions(filepath.Dir(cfgPath))
-    if err != nil {
-        return err
-    }
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		return fmt.Errorf("config dir: %w", err)
+	}
+	cfg, err := session.LoadConfigSessions(filepath.Dir(cfgPath))
+	if err != nil {
+		return err
+	}
 
-    var sessionPath string
-    for _, e := range cfg.Entries {
-        if e.DisplayName() == sessionCreateWindowsSession {
-            sessionPath = e.Path
-            break
-        }
-    }
+	var sessionPath string
+	for _, e := range cfg.Entries {
+		if e.DisplayName() == sessionCreateWindowsSession {
+			sessionPath = e.Path
+			break
+		}
+	}
 
-    var ids []string
-    for _, id := range strings.Split(sessionCreateWindowsIDs, ",") {
-        if t := strings.TrimSpace(id); t != "" {
-            ids = append(ids, t)
-        }
-    }
+	var ids []string
+	for _, id := range strings.Split(sessionCreateWindowsIDs, ",") {
+		if t := strings.TrimSpace(id); t != "" {
+			ids = append(ids, t)
+		}
+	}
 
-    specs, unknown := session.ResolveWindowSpecs(ids, cfg.WindowTemplates)
-    for _, id := range unknown {
-        fmt.Fprintf(os.Stderr, "demux: unknown window_template id %q (skipped)\n", id)
-    }
-    if len(specs) == 0 {
-        return fmt.Errorf("no valid window templates resolved from %q", sessionCreateWindowsIDs)
-    }
+	specs, unknown := session.ResolveWindowSpecs(ids, cfg.WindowTemplates)
+	for _, id := range unknown {
+		fmt.Fprintf(os.Stderr, "demux: unknown window_template id %q (skipped)\n", id)
+	}
+	if len(specs) == 0 {
+		return fmt.Errorf("no valid window templates resolved from %q", sessionCreateWindowsIDs)
+	}
 
-    return tmux.CreateSessionWindows(sessionCreateWindowsSession, sessionPath, specs)
+	return tmux.CreateSessionWindows(sessionCreateWindowsSession, sessionPath, specs)
 }
 
 // --- helpers ---
 
 func sessionFilePath(private bool) (string, error) {
-    cfgPath, err := config.DefaultPath()
-    if err != nil {
-        return "", fmt.Errorf("config dir: %w", err)
-    }
-    name := "sessions.toml"
-    if private {
-        name = "private.toml"
-    }
-    return filepath.Join(filepath.Dir(cfgPath), name), nil
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		return "", fmt.Errorf("config dir: %w", err)
+	}
+	name := "sessions.toml"
+	if private {
+		name = "private.toml"
+	}
+	return filepath.Join(filepath.Dir(cfgPath), name), nil
 }
 
 func init() {
-    rootCmd.AddCommand(sessionCmd)
+	rootCmd.AddCommand(sessionCmd)
 }

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -1,197 +1,195 @@
 package cmd
 
 import (
-    "fmt"
-    "os"
-    "strings"
+	"fmt"
+	"os"
+	"strings"
 
-    "github.com/mattn/go-isatty"
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/format"
-    "github.com/rtalexk/demux/internal/git"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/tmux"
-    "github.com/spf13/cobra"
+	"github.com/mattn/go-isatty"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/git"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+	"github.com/spf13/cobra"
 )
 
 var (
-    sessionListGit     bool
-    sessionListGitOnly bool
+	sessionListGit     bool
+	sessionListGitOnly bool
 )
 
 var sessionListCmd = &cobra.Command{
-    Use:   "list",
-    Short: "List all tmux sessions",
-    RunE:  runSessions,
+	Use:   "list",
+	Short: "List all tmux sessions",
+	RunE:  runSessions,
 }
 
 func init() {
-    sessionCmd.AddCommand(sessionListCmd)
-    sessionListCmd.Flags().BoolVar(&sessionListGit, "git", false, "Include git columns")
-    sessionListCmd.Flags().BoolVar(&sessionListGitOnly, "git-only", false, "Show only session + git columns")
+	sessionCmd.AddCommand(sessionListCmd)
+	sessionListCmd.Flags().BoolVar(&sessionListGit, "git", false, "Include git columns")
+	sessionListCmd.Flags().BoolVar(&sessionListGitOnly, "git-only", false, "Show only session + git columns")
 }
 
 type sessionRow struct {
-    session, windows, procs, alerts, status string
-    branch, dirty, ahead, behind            string
-    includeGit, gitOnly                     bool
+	session, windows, procs, alerts, status string
+	branch, dirty, ahead, behind            string
+	includeGit, gitOnly                     bool
 }
 
 func (r sessionRow) Fields() []string {
-    base := []string{r.session, r.windows, r.procs, r.alerts, r.status}
-    gitCols := []string{r.branch, r.dirty, r.ahead, r.behind}
-    if r.gitOnly {
-        return append([]string{r.session}, gitCols...)
-    }
-    if r.includeGit {
-        return append(base, gitCols...)
-    }
-    return base
+	base := []string{r.session, r.windows, r.procs, r.alerts, r.status}
+	gitCols := []string{r.branch, r.dirty, r.ahead, r.behind}
+	if r.gitOnly {
+		return append([]string{r.session}, gitCols...)
+	}
+	if r.includeGit {
+		return append(base, gitCols...)
+	}
+	return base
 }
 
-
 func runSessions(cmd *cobra.Command, _ []string) error {
-    cfg := loadConfig()
+	cfg := loadConfig()
 
-    panes, err := tmux.ListPanes()
-    if err != nil {
-        return fmt.Errorf("tmux not available: %w", err)
-    }
-    grouped := tmux.GroupBySessions(panes)
+	panes, err := tmux.ListPanes()
+	if err != nil {
+		return fmt.Errorf("tmux not available: %w", err)
+	}
+	grouped := tmux.GroupBySessions(panes)
 
-    database, err := openDB()
-    if err != nil {
-        return err
-    }
-    defer database.Close()
-    alerts, err := database.AlertList()
-    if err != nil {
-        demuxlog.Warn("failed to list alerts", "err", err)
-    }
+	database, err := openDB()
+	if err != nil {
+		return err
+	}
+	defer database.Close()
+	alerts, err := database.AlertList()
+	if err != nil {
+		demuxlog.Warn("failed to list alerts", "err", err)
+	}
 
-    alertsBySession := map[string][]db.Alert{}
-    for _, a := range alerts {
-        parts := strings.SplitN(a.Target, ":", 2)
-        if len(parts) > 0 {
-            alertsBySession[parts[0]] = append(alertsBySession[parts[0]], a)
-        }
-    }
+	alertsBySession := map[string][]db.Alert{}
+	for _, a := range alerts {
+		parts := strings.SplitN(a.Target, ":", 2)
+		if len(parts) > 0 {
+			alertsBySession[parts[0]] = append(alertsBySession[parts[0]], a)
+		}
+	}
 
-    headers := []string{"SESSION", "WINDOWS", "PROCS", "ALERTS", "STATUS"}
-    if sessionListGitOnly {
-        headers = []string{"SESSION", "BRANCH", "DIRTY", "AHEAD", "BEHIND"}
-    } else if sessionListGit {
-        headers = append(headers, "BRANCH", "DIRTY", "AHEAD", "BEHIND")
-    }
+	headers := []string{"SESSION", "WINDOWS", "PROCS", "ALERTS", "STATUS"}
+	if sessionListGitOnly {
+		headers = []string{"SESSION", "BRANCH", "DIRTY", "AHEAD", "BEHIND"}
+	} else if sessionListGit {
+		headers = append(headers, "BRANCH", "DIRTY", "AHEAD", "BEHIND")
+	}
 
-    allProcs, err := proc.Snapshot()
-    if err != nil {
-        demuxlog.Warn("proc snapshot failed", "err", err)
-    }
-    cwdByPID, err := proc.CWDAll()
-    if err != nil {
-        demuxlog.Warn("cwd fetch failed", "err", err)
-    }
+	allProcs, err := proc.Snapshot()
+	if err != nil {
+		demuxlog.Warn("proc snapshot failed", "err", err)
+	}
+	cwdByPID, err := proc.CWDAll()
+	if err != nil {
+		demuxlog.Warn("cwd fetch failed", "err", err)
+	}
 
-    sessionProcCount := map[string]int{}
-    for sessionName, windows := range grouped {
-        primaryCWD := tmux.PrimaryPaneCWD(windows[0])
-        if primaryCWD == "" {
-            continue
-        }
-        for _, p := range allProcs {
-            cwd, ok := cwdByPID[p.PID]
-            if !ok {
-                continue
-            }
-            if cwd == primaryCWD || git.IsDescendant(cwd, primaryCWD) {
-                sessionProcCount[sessionName]++
-            }
-        }
-    }
+	sessionProcCount := map[string]int{}
+	for sessionName, windows := range grouped {
+		primaryCWD := tmux.PrimaryPaneCWD(windows[0])
+		if primaryCWD == "" {
+			continue
+		}
+		for _, p := range allProcs {
+			cwd, ok := cwdByPID[p.PID]
+			if !ok {
+				continue
+			}
+			if cwd == primaryCWD || git.IsDescendant(cwd, primaryCWD) {
+				sessionProcCount[sessionName]++
+			}
+		}
+	}
 
-    // Pre-fetch git info in parallel for all non-ignored sessions.
-    var gitWork []git.ConcurrentWork
-    if sessionListGit || sessionListGitOnly {
-        for sessionName, windows := range grouped {
-            if isIgnored(cfg, sessionName) {
-                continue
-            }
-            if cwd := tmux.PrimaryPaneCWD(windows[0]); cwd != "" {
-                gitWork = append(gitWork, git.ConcurrentWork{Key: sessionName, Dir: cwd})
-            }
-        }
-    }
-    gitResults := git.FetchConcurrent(gitWork, cfg.Git.TimeoutMs)
+	// Pre-fetch git info in parallel for all non-ignored sessions.
+	var gitWork []git.ConcurrentWork
+	if sessionListGit || sessionListGitOnly {
+		for sessionName, windows := range grouped {
+			if isIgnored(cfg, sessionName) {
+				continue
+			}
+			if cwd := tmux.PrimaryPaneCWD(windows[0]); cwd != "" {
+				gitWork = append(gitWork, git.ConcurrentWork{Key: sessionName, Dir: cwd})
+			}
+		}
+	}
+	gitResults := git.FetchConcurrent(gitWork, cfg.Git.TimeoutMs)
 
-    var rows []format.Row
-    for sessionName, windows := range grouped {
-        if isIgnored(cfg, sessionName) {
-            continue
-        }
-        sessionAlerts := alertsBySession[sessionName]
-        status := "ok"
-        for _, a := range sessionAlerts {
-            switch a.Level {
-            case "error":
-                status = "error"
-            case "warn":
-                if status != "error" {
-                    status = "warn"
-                }
-            }
-        }
+	var rows []format.Row
+	for sessionName, windows := range grouped {
+		if isIgnored(cfg, sessionName) {
+			continue
+		}
+		sessionAlerts := alertsBySession[sessionName]
+		status := "ok"
+		for _, a := range sessionAlerts {
+			switch a.Level {
+			case "error":
+				status = "error"
+			case "warn":
+				if status != "error" {
+					status = "warn"
+				}
+			}
+		}
 
-        row := sessionRow{
-            session:    sessionName,
-            windows:    fmt.Sprint(len(windows)),
-            procs:      fmt.Sprint(sessionProcCount[sessionName]),
-            alerts:     fmt.Sprint(len(sessionAlerts)),
-            status:     status,
-            includeGit: sessionListGit,
-            gitOnly:    sessionListGitOnly,
-        }
+		row := sessionRow{
+			session:    sessionName,
+			windows:    fmt.Sprint(len(windows)),
+			procs:      fmt.Sprint(sessionProcCount[sessionName]),
+			alerts:     fmt.Sprint(len(sessionAlerts)),
+			status:     status,
+			includeGit: sessionListGit,
+			gitOnly:    sessionListGitOnly,
+		}
 
-        if sessionListGit || sessionListGitOnly {
-            primaryCWD := tmux.PrimaryPaneCWD(windows[0])
-            if primaryCWD == "" {
-                row.branch = cfg.Git.FallbackDisplay
-                row.dirty = "—"
-                row.ahead = "—"
-                row.behind = "—"
-            } else if info, ok := gitResults[sessionName]; ok {
-                row.branch = info.Branch
-                if info.Dirty {
-                    row.dirty = "yes"
-                } else {
-                    row.dirty = "no"
-                }
-                row.ahead = fmt.Sprint(info.Ahead)
-                row.behind = fmt.Sprint(info.Behind)
-            } else {
-                row.branch = cfg.Git.ErrorDisplay
-                row.dirty = "—"
-                row.ahead = "—"
-                row.behind = "—"
-            }
-        }
+		if sessionListGit || sessionListGitOnly {
+			primaryCWD := tmux.PrimaryPaneCWD(windows[0])
+			if primaryCWD == "" {
+				row.branch = cfg.Git.FallbackDisplay
+				row.dirty = "—"
+				row.ahead = "—"
+				row.behind = "—"
+			} else if info, ok := gitResults[sessionName]; ok {
+				row.branch = info.Branch
+				if info.Dirty {
+					row.dirty = "yes"
+				} else {
+					row.dirty = "no"
+				}
+				row.ahead = fmt.Sprint(info.Ahead)
+				row.behind = fmt.Sprint(info.Behind)
+			} else {
+				row.branch = cfg.Git.ErrorDisplay
+				row.dirty = "—"
+				row.ahead = "—"
+				row.behind = "—"
+			}
+		}
 
-        rows = append(rows, row)
-    }
+		rows = append(rows, row)
+	}
 
-    isTTYVal := isatty.IsTerminal(os.Stdout.Fd())
-    fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
-    return nil
+	isTTYVal := isatty.IsTerminal(os.Stdout.Fd())
+	fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
+	return nil
 }
 
 func isIgnored(cfg config.Config, name string) bool {
-    for _, s := range cfg.IgnoredSessions {
-        if s == name {
-            return true
-        }
-    }
-    return false
+	for _, s := range cfg.IgnoredSessions {
+		if s == name {
+			return true
+		}
+	}
+	return false
 }
-

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,84 +1,84 @@
 package cmd
 
 import (
-    "fmt"
+	"fmt"
 
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 var statusCmd = &cobra.Command{
-    Use:   "status",
-    Short: "Output compact summary for tmux status bar",
-    RunE:  runStatus,
+	Use:   "status",
+	Short: "Output compact summary for tmux status bar",
+	RunE:  runStatus,
 }
 
 func init() {
-    rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(statusCmd)
 }
 
 func tmuxCounter(style, icon string, count int) string {
-    return fmt.Sprintf("%s%s %d", style, icon, count)
+	return fmt.Sprintf("%s%s %d", style, icon, count)
 }
 
 func runStatus(cmd *cobra.Command, _ []string) error {
-    database, err := openDB()
-    if err != nil {
-        return err
-    }
-    defer database.Close()
+	database, err := openDB()
+	if err != nil {
+		return err
+	}
+	defer database.Close()
 
-    alerts, err := database.AlertList()
-    if err != nil {
-        return err
-    }
+	alerts, err := database.AlertList()
+	if err != nil {
+		return err
+	}
 
-    var infos, warns, errors int
-    for _, a := range alerts {
-        switch a.Level {
-        case "info":
-            infos++
-        case "warn":
-            warns++
-        case "error":
-            errors++
-        }
-    }
+	var infos, warns, errors int
+	for _, a := range alerts {
+		switch a.Level {
+		case "info":
+			infos++
+		case "warn":
+			warns++
+		case "error":
+			errors++
+		}
+	}
 
-    cfg := loadConfig()
+	cfg := loadConfig()
 
-    fmtName := resolveFormat(cmd)
-    if fmtName == "table" {
-        // status command defaults to tmux format
-        fmtName = "tmux"
-    }
+	fmtName := resolveFormat(cmd)
+	if fmtName == "table" {
+		// status command defaults to tmux format
+		fmtName = "tmux"
+	}
 
-    switch fmtName {
-    case "tmux":
-        if infos == 0 && warns == 0 && errors == 0 {
-            fmt.Print("#[fg=green]#[default]")
-        } else {
-            sep := ""
-            if infos > 0 {
-                fmt.Print(tmuxCounter("#[fg=cyan]", cfg.Theme.IconAlertInfo, infos))
-                sep = " "
-            }
-            if warns > 0 {
-                fmt.Printf("%s%s", sep, tmuxCounter("#[fg=yellow]", cfg.Theme.IconAlertWarn, warns))
-                sep = " "
-            }
-            if errors > 0 {
-                fmt.Printf("%s%s", sep, tmuxCounter("#[fg=red,bold]", cfg.Theme.IconAlertError, errors))
-            }
-            fmt.Print("#[default]")
-        }
-    case "json":
-        fmt.Printf(`{"infos":%d,"warns":%d,"errors":%d}`+"\n", infos, warns, errors)
-    default:
-        if infos == 0 && warns == 0 && errors == 0 {
-            fmt.Println("ok")
-        } else {
-            fmt.Printf("infos=%d warns=%d errors=%d\n", infos, warns, errors)
-        }
-    }
-    return nil
+	switch fmtName {
+	case "tmux":
+		if infos == 0 && warns == 0 && errors == 0 {
+			fmt.Print("#[fg=green]#[default]")
+		} else {
+			sep := ""
+			if infos > 0 {
+				fmt.Print(tmuxCounter("#[fg=cyan]", cfg.Theme.IconAlertInfo, infos))
+				sep = " "
+			}
+			if warns > 0 {
+				fmt.Printf("%s%s", sep, tmuxCounter("#[fg=yellow]", cfg.Theme.IconAlertWarn, warns))
+				sep = " "
+			}
+			if errors > 0 {
+				fmt.Printf("%s%s", sep, tmuxCounter("#[fg=red,bold]", cfg.Theme.IconAlertError, errors))
+			}
+			fmt.Print("#[default]")
+		}
+	case "json":
+		fmt.Printf(`{"infos":%d,"warns":%d,"errors":%d}`+"\n", infos, warns, errors)
+	default:
+		if infos == 0 && warns == 0 && errors == 0 {
+			fmt.Println("ok")
+		} else {
+			fmt.Printf("infos=%d warns=%d errors=%d\n", infos, warns, errors)
+		}
+	}
+	return nil
 }

--- a/cmd/windows.go
+++ b/cmd/windows.go
@@ -1,115 +1,114 @@
 package cmd
 
 import (
-    "fmt"
-    "os"
-    "strings"
+	"fmt"
+	"os"
+	"strings"
 
-    "github.com/mattn/go-isatty"
-    "github.com/rtalexk/demux/internal/format"
-    "github.com/rtalexk/demux/internal/git"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/tmux"
-    "github.com/spf13/cobra"
+	"github.com/mattn/go-isatty"
+	"github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/git"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/tmux"
+	"github.com/spf13/cobra"
 )
 
 var (
-    windowsSession string
-    windowsGit     bool
+	windowsSession string
+	windowsGit     bool
 )
 
 var windowsCmd = &cobra.Command{
-    Use:   "windows",
-    Short: "List windows in a session",
-    RunE:  runWindows,
+	Use:   "windows",
+	Short: "List windows in a session",
+	RunE:  runWindows,
 }
 
 func init() {
-    rootCmd.AddCommand(windowsCmd)
-    windowsCmd.Flags().StringVar(&windowsSession, "session", "", "Session name (required)")
-    windowsCmd.MarkFlagRequired("session")
-    windowsCmd.Flags().BoolVar(&windowsGit, "git", false, "Include git column")
+	rootCmd.AddCommand(windowsCmd)
+	windowsCmd.Flags().StringVar(&windowsSession, "session", "", "Session name (required)")
+	windowsCmd.MarkFlagRequired("session")
+	windowsCmd.Flags().BoolVar(&windowsGit, "git", false, "Include git column")
 }
 
 type windowRow struct {
-    session, window, name, panes, procs, alerts, gitCol string
-    includeGit                                           bool
+	session, window, name, panes, procs, alerts, gitCol string
+	includeGit                                          bool
 }
 
 func (r windowRow) Fields() []string {
-    base := []string{r.session, r.window, r.name, r.panes, r.procs, r.alerts}
-    if r.includeGit {
-        return append(base, r.gitCol)
-    }
-    return base
+	base := []string{r.session, r.window, r.name, r.panes, r.procs, r.alerts}
+	if r.includeGit {
+		return append(base, r.gitCol)
+	}
+	return base
 }
 
 func runWindows(cmd *cobra.Command, _ []string) error {
-    cfg := loadConfig()
+	cfg := loadConfig()
 
-    panes, err := tmux.ListPanes()
-    if err != nil {
-        return fmt.Errorf("tmux not available: %w", err)
-    }
-    grouped := tmux.GroupBySessions(panes)
-    windows, ok := grouped[windowsSession]
-    if !ok {
-        return fmt.Errorf("session %q not found", windowsSession)
-    }
+	panes, err := tmux.ListPanes()
+	if err != nil {
+		return fmt.Errorf("tmux not available: %w", err)
+	}
+	grouped := tmux.GroupBySessions(panes)
+	windows, ok := grouped[windowsSession]
+	if !ok {
+		return fmt.Errorf("session %q not found", windowsSession)
+	}
 
-    primaryCWD := tmux.PrimaryPaneCWD(windows[0])
+	primaryCWD := tmux.PrimaryPaneCWD(windows[0])
 
-    database, err := openDB()
-    if err != nil {
-        return err
-    }
-    defer database.Close()
-    alerts, err := database.AlertList()
-    if err != nil {
-        demuxlog.Warn("failed to list alerts", "err", err)
-    }
-    alertsByWindow := map[string]int{}
-    for _, a := range alerts {
-        parts := strings.SplitN(a.Target, ":", 2)
-        if len(parts) == 2 && parts[0] == windowsSession {
-            alertsByWindow[parts[1]]++
-        }
-    }
+	database, err := openDB()
+	if err != nil {
+		return err
+	}
+	defer database.Close()
+	alerts, err := database.AlertList()
+	if err != nil {
+		demuxlog.Warn("failed to list alerts", "err", err)
+	}
+	alertsByWindow := map[string]int{}
+	for _, a := range alerts {
+		parts := strings.SplitN(a.Target, ":", 2)
+		if len(parts) == 2 && parts[0] == windowsSession {
+			alertsByWindow[parts[1]]++
+		}
+	}
 
-    headers := []string{"SESSION", "WINDOW", "NAME", "PANES", "PROCS", "ALERTS"}
-    if windowsGit {
-        headers = append(headers, "GIT")
-    }
+	headers := []string{"SESSION", "WINDOW", "NAME", "PANES", "PROCS", "ALERTS"}
+	if windowsGit {
+		headers = append(headers, "GIT")
+	}
 
-    var rows []format.Row
-    for wi, wPanes := range windows {
-        gitCol := "—"
-        if windowsGit {
-            winCWD := tmux.PrimaryPaneCWD(wPanes)
-            if winCWD != "" && !git.IsDescendant(winCWD, primaryCWD) && winCWD != primaryCWD {
-                info, err := git.Fetch(winCWD, cfg.Git.TimeoutMs)
-                if err != nil {
-                    gitCol = cfg.Git.ErrorDisplay
-                } else {
-                    gitCol = "↪ " + info.Branch + " " + git.Indicators(info)
-                }
-            }
-        }
+	var rows []format.Row
+	for wi, wPanes := range windows {
+		gitCol := "—"
+		if windowsGit {
+			winCWD := tmux.PrimaryPaneCWD(wPanes)
+			if winCWD != "" && !git.IsDescendant(winCWD, primaryCWD) && winCWD != primaryCWD {
+				info, err := git.Fetch(winCWD, cfg.Git.TimeoutMs)
+				if err != nil {
+					gitCol = cfg.Git.ErrorDisplay
+				} else {
+					gitCol = "↪ " + info.Branch + " " + git.Indicators(info)
+				}
+			}
+		}
 
-        rows = append(rows, windowRow{
-            session:    windowsSession,
-            window:     fmt.Sprint(wi),
-            name:       wPanes[0].WindowName,
-            panes:      fmt.Sprint(len(wPanes)),
-            procs:      "—",
-            alerts:     fmt.Sprint(alertsByWindow[fmt.Sprint(wi)]),
-            gitCol:     gitCol,
-            includeGit: windowsGit,
-        })
-    }
+		rows = append(rows, windowRow{
+			session:    windowsSession,
+			window:     fmt.Sprint(wi),
+			name:       wPanes[0].WindowName,
+			panes:      fmt.Sprint(len(wPanes)),
+			procs:      "—",
+			alerts:     fmt.Sprint(alertsByWindow[fmt.Sprint(wi)]),
+			gitCol:     gitCol,
+			includeGit: windowsGit,
+		})
+	}
 
-    isTTYVal := isatty.IsTerminal(os.Stdout.Fd())
-    fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
-    return nil
+	isTTYVal := isatty.IsTerminal(os.Stdout.Fd())
+	fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTYVal))
+	return nil
 }
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,287 +1,287 @@
 package config
 
 import (
-    "errors"
-    "fmt"
-    "os"
-    "path/filepath"
-    "sort"
-    "strings"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
-    "github.com/BurntSushi/toml"
+	"github.com/BurntSushi/toml"
 )
 
 var defaultSessionSortOrder = []string{"priority", "last_seen", "alphabetical"}
 
 func normalizeSortKeys(user []string) []string {
-    valid := map[string]bool{"priority": true, "last_seen": true, "alphabetical": true}
-    seen := map[string]bool{}
-    result := make([]string, 0, len(defaultSessionSortOrder))
-    for _, k := range user {
-        if valid[k] && !seen[k] {
-            result = append(result, k)
-            seen[k] = true
-        }
-    }
-    for _, k := range defaultSessionSortOrder {
-        if !seen[k] {
-            result = append(result, k)
-        }
-    }
-    return result
+	valid := map[string]bool{"priority": true, "last_seen": true, "alphabetical": true}
+	seen := map[string]bool{}
+	result := make([]string, 0, len(defaultSessionSortOrder))
+	for _, k := range user {
+		if valid[k] && !seen[k] {
+			result = append(result, k)
+			seen[k] = true
+		}
+	}
+	for _, k := range defaultSessionSortOrder {
+		if !seen[k] {
+			result = append(result, k)
+		}
+	}
+	return result
 }
 
 type PathAlias struct {
-    Prefix  string `toml:"prefix"`
-    Replace string `toml:"replace"`
+	Prefix  string `toml:"prefix"`
+	Replace string `toml:"replace"`
 }
 
 type GitPRConfig struct {
-    Enabled bool `toml:"enabled"`
+	Enabled bool `toml:"enabled"`
 }
 
 type GitConfig struct {
-    Enabled         bool        `toml:"enabled"`
-    ShowSpinner     bool        `toml:"show_spinner"`
-    TimeoutMs       int         `toml:"timeout_ms"`
-    OnTimeout       string      `toml:"on_timeout"`
-    FallbackDisplay string      `toml:"fallback_display"`
-    ErrorDisplay    string      `toml:"error_display"`
-    PR              GitPRConfig `toml:"pr"`
+	Enabled         bool        `toml:"enabled"`
+	ShowSpinner     bool        `toml:"show_spinner"`
+	TimeoutMs       int         `toml:"timeout_ms"`
+	OnTimeout       string      `toml:"on_timeout"`
+	FallbackDisplay string      `toml:"fallback_display"`
+	ErrorDisplay    string      `toml:"error_display"`
+	PR              GitPRConfig `toml:"pr"`
 }
 
 // ThemeConfig holds all theme colour values and process type classification.
 type ThemeConfig struct {
-    Processes ProcessesConfig `toml:"processes"`
+	Processes ProcessesConfig `toml:"processes"`
 
-    ColorBg       string `toml:"color_bg"`
-    ColorSurface  string `toml:"color_surface"`
-    ColorRaised   string `toml:"color_raised"`
-    ColorSelected string `toml:"color_selected"`
-    ColorBorder   string `toml:"color_border"`
+	ColorBg       string `toml:"color_bg"`
+	ColorSurface  string `toml:"color_surface"`
+	ColorRaised   string `toml:"color_raised"`
+	ColorSelected string `toml:"color_selected"`
+	ColorBorder   string `toml:"color_border"`
 
-    ColorFgPrimary string `toml:"color_fg_primary"`
-    ColorFgSubtext string `toml:"color_fg_subtext"`
-    ColorFgMuted   string `toml:"color_fg_muted"`
-    ColorFgDim     string `toml:"color_fg_dim"`
-    ColorFgGhost   string `toml:"color_fg_ghost"`
+	ColorFgPrimary string `toml:"color_fg_primary"`
+	ColorFgSubtext string `toml:"color_fg_subtext"`
+	ColorFgMuted   string `toml:"color_fg_muted"`
+	ColorFgDim     string `toml:"color_fg_dim"`
+	ColorFgGhost   string `toml:"color_fg_ghost"`
 
-    ColorSession    string `toml:"color_session"`
-    ColorProcClaude string `toml:"color_proc_claude"`
-    ColorProcServer string `toml:"color_proc_server"`
-    ColorProcEditor string `toml:"color_proc_editor"`
-    ColorProcChild  string `toml:"color_proc_child"`
+	ColorSession    string `toml:"color_session"`
+	ColorProcClaude string `toml:"color_proc_claude"`
+	ColorProcServer string `toml:"color_proc_server"`
+	ColorProcEditor string `toml:"color_proc_editor"`
+	ColorProcChild  string `toml:"color_proc_child"`
 
-    ColorGitDirty  string `toml:"color_git_dirty"`
-    ColorGitBehind string `toml:"color_git_behind"`
-    ColorGitAhead  string `toml:"color_git_ahead"`
+	ColorGitDirty  string `toml:"color_git_dirty"`
+	ColorGitBehind string `toml:"color_git_behind"`
+	ColorGitAhead  string `toml:"color_git_ahead"`
 
-    ColorAlertInfo   string `toml:"color_alert_info"`
-    ColorAlertWarn   string `toml:"color_alert_warn"`
-    ColorAlertError  string `toml:"color_alert_error"`
-    ColorAlertDefer  string `toml:"color_alert_defer"`
-    ColorAlertInfoBg  string `toml:"color_alert_info_bg"`
-    ColorAlertWarnBg  string `toml:"color_alert_warn_bg"`
-    ColorAlertErrorBg string `toml:"color_alert_error_bg"`
-    ColorAlertDeferBg string `toml:"color_alert_defer_bg"`
+	ColorAlertInfo    string `toml:"color_alert_info"`
+	ColorAlertWarn    string `toml:"color_alert_warn"`
+	ColorAlertError   string `toml:"color_alert_error"`
+	ColorAlertDefer   string `toml:"color_alert_defer"`
+	ColorAlertInfoBg  string `toml:"color_alert_info_bg"`
+	ColorAlertWarnBg  string `toml:"color_alert_warn_bg"`
+	ColorAlertErrorBg string `toml:"color_alert_error_bg"`
+	ColorAlertDeferBg string `toml:"color_alert_defer_bg"`
 
-    IconAlertInfo  string `toml:"icon_alert_info"`
-    IconAlertWarn  string `toml:"icon_alert_warn"`
-    IconAlertError string `toml:"icon_alert_error"`
-    IconAlertDefer string `toml:"icon_alert_defer"`
+	IconAlertInfo  string `toml:"icon_alert_info"`
+	IconAlertWarn  string `toml:"icon_alert_warn"`
+	IconAlertError string `toml:"icon_alert_error"`
+	IconAlertDefer string `toml:"icon_alert_defer"`
 
-    IconTmuxSession string `toml:"icon_tmux_session"`
-    IconCfgSession  string `toml:"icon_cfg_session"`
+	IconTmuxSession string `toml:"icon_tmux_session"`
+	IconCfgSession  string `toml:"icon_cfg_session"`
 
-    ColorPort    string `toml:"color_port"`
-    ColorPortBg  string `toml:"color_port_bg"`
-    ColorClean   string `toml:"color_clean"`
-    ColorCpuLow  string `toml:"color_cpu_low"`
-    ColorCpuMed  string `toml:"color_cpu_med"`
-    ColorCpuHigh string `toml:"color_cpu_high"`
+	ColorPort    string `toml:"color_port"`
+	ColorPortBg  string `toml:"color_port_bg"`
+	ColorClean   string `toml:"color_clean"`
+	ColorCpuLow  string `toml:"color_cpu_low"`
+	ColorCpuMed  string `toml:"color_cpu_med"`
+	ColorCpuHigh string `toml:"color_cpu_high"`
 
-    ColorFgSearchHighlight string `toml:"color_fg_search_highlight"`
+	ColorFgSearchHighlight string `toml:"color_fg_search_highlight"`
 }
 
 // ProcessesConfig defines which process names belong to each display category.
 // Entries are matched case-insensitively against the process's friendly name.
 type ProcessesConfig struct {
-    Editors []string `toml:"editors"`
-    Agents  []string `toml:"agents"`
-    Servers []string `toml:"servers"`
-    Shells  []string `toml:"shells"`
+	Editors []string `toml:"editors"`
+	Agents  []string `toml:"agents"`
+	Servers []string `toml:"servers"`
+	Shells  []string `toml:"shells"`
 }
 
 type SidebarConfig struct {
-    DefaultFilter     string   `toml:"default_filter"`
-    FocusOnOpen       string   `toml:"focus_on_open"`
-    FocusSearchOnOpen bool     `toml:"focus_search_on_open"`
-    SearchSort        string   `toml:"search_sort"`
-    ShowLastSeen      bool     `toml:"show_last_seen"`
-    Sort              []string `toml:"sort"`
-    SwitchFocus       string   `toml:"switch_focus"`
-    Width             int      `toml:"width"`
+	DefaultFilter     string   `toml:"default_filter"`
+	FocusOnOpen       string   `toml:"focus_on_open"`
+	FocusSearchOnOpen bool     `toml:"focus_search_on_open"`
+	SearchSort        string   `toml:"search_sort"`
+	ShowLastSeen      bool     `toml:"show_last_seen"`
+	Sort              []string `toml:"sort"`
+	SwitchFocus       string   `toml:"switch_focus"`
+	Width             int      `toml:"width"`
 }
 
 type ProcessListConfig struct {
-    PathRightAlign bool `toml:"path_right_align"`
+	PathRightAlign bool `toml:"path_right_align"`
 }
 
 type StatusBarConfig struct {
-    Show bool `toml:"show"`
+	Show bool `toml:"show"`
 }
 
 type LogConfig struct {
-    Level string `toml:"level"` // off|error|warn|info|debug
+	Level string `toml:"level"` // off|error|warn|info|debug
 }
 
 type AlertsConfig struct {
-    DeferDefaultReason string `toml:"defer_default_reason"`
+	DeferDefaultReason string `toml:"defer_default_reason"`
 }
 
 type Config struct {
-    RefreshIntervalMs int               `toml:"refresh_interval_ms"`
-    IgnoredSessions   []string          `toml:"ignored_sessions"`
-    IgnoredProcesses  []string          `toml:"ignored_processes"`
-    DefaultFormat     string            `toml:"default_format"`
-    Mode              string            `toml:"mode"`
-    Sidebar           SidebarConfig     `toml:"sidebar"`
-    ProcessList       ProcessListConfig `toml:"process_list"`
-    StatusBar         StatusBarConfig   `toml:"status_bar"`
-    Log               LogConfig         `toml:"log"`
-    Alerts            AlertsConfig      `toml:"alerts"`
-    Git               GitConfig         `toml:"git"`
-    Theme             ThemeConfig       `toml:"theme"`
-    PathAliases       []PathAlias       `toml:"path_aliases"`
+	RefreshIntervalMs int               `toml:"refresh_interval_ms"`
+	IgnoredSessions   []string          `toml:"ignored_sessions"`
+	IgnoredProcesses  []string          `toml:"ignored_processes"`
+	DefaultFormat     string            `toml:"default_format"`
+	Mode              string            `toml:"mode"`
+	Sidebar           SidebarConfig     `toml:"sidebar"`
+	ProcessList       ProcessListConfig `toml:"process_list"`
+	StatusBar         StatusBarConfig   `toml:"status_bar"`
+	Log               LogConfig         `toml:"log"`
+	Alerts            AlertsConfig      `toml:"alerts"`
+	Git               GitConfig         `toml:"git"`
+	Theme             ThemeConfig       `toml:"theme"`
+	PathAliases       []PathAlias       `toml:"path_aliases"`
 }
 
 func Default() Config {
-    return Config{
-        RefreshIntervalMs: DefaultRefreshIntervalMs,
-        IgnoredSessions:   []string{},
-        IgnoredProcesses:  []string{"zsh", "bash", "fish", "sh", "dash", "nu", "pwsh"},
-        DefaultFormat:     "text",
-        Mode:              "full",
-        Sidebar: SidebarConfig{
-            DefaultFilter: "t",
-            FocusOnOpen:   "alert_session",
-            SearchSort:  "score",
-            Sort:        []string{"priority", "last_seen", "alphabetical"},
-            SwitchFocus:  "severity",
-            Width:        DefaultSidebarWidth,
-            ShowLastSeen: true,
-        },
-        StatusBar: StatusBarConfig{Show: true},
-        Log:       LogConfig{Level: "warn"},
-        Alerts: AlertsConfig{
-            DeferDefaultReason: "Come back",
-        },
-        Git: GitConfig{
-            Enabled:         true,
-            ShowSpinner:     true,
-            TimeoutMs:       DefaultGitTimeoutMs,
-            OnTimeout:       "cached",
-            FallbackDisplay: "—",
-            ErrorDisplay:    "git err",
-            PR:              GitPRConfig{Enabled: false},
-        },
-        Theme: ThemeConfig{
-            ColorBg:       "#0d0d14",
-            ColorSurface:  "#13131a",
-            ColorRaised:   "#1e1e2e",
-            ColorSelected: "#2a2a4a",
-            ColorBorder:   "#313244",
+	return Config{
+		RefreshIntervalMs: DefaultRefreshIntervalMs,
+		IgnoredSessions:   []string{},
+		IgnoredProcesses:  []string{"zsh", "bash", "fish", "sh", "dash", "nu", "pwsh"},
+		DefaultFormat:     "text",
+		Mode:              "full",
+		Sidebar: SidebarConfig{
+			DefaultFilter: "t",
+			FocusOnOpen:   "alert_session",
+			SearchSort:    "score",
+			Sort:          []string{"priority", "last_seen", "alphabetical"},
+			SwitchFocus:   "severity",
+			Width:         DefaultSidebarWidth,
+			ShowLastSeen:  true,
+		},
+		StatusBar: StatusBarConfig{Show: true},
+		Log:       LogConfig{Level: "warn"},
+		Alerts: AlertsConfig{
+			DeferDefaultReason: "Come back",
+		},
+		Git: GitConfig{
+			Enabled:         true,
+			ShowSpinner:     true,
+			TimeoutMs:       DefaultGitTimeoutMs,
+			OnTimeout:       "cached",
+			FallbackDisplay: "—",
+			ErrorDisplay:    "git err",
+			PR:              GitPRConfig{Enabled: false},
+		},
+		Theme: ThemeConfig{
+			ColorBg:       "#0d0d14",
+			ColorSurface:  "#13131a",
+			ColorRaised:   "#1e1e2e",
+			ColorSelected: "#2a2a4a",
+			ColorBorder:   "#313244",
 
-            ColorFgPrimary: "#cdd6f4",
-            ColorFgSubtext: "#a6adc8",
-            ColorFgMuted:   "#9399b2",
-            ColorFgDim:     "#6c7086",
-            ColorFgGhost:   "#45475a",
+			ColorFgPrimary: "#cdd6f4",
+			ColorFgSubtext: "#a6adc8",
+			ColorFgMuted:   "#9399b2",
+			ColorFgDim:     "#6c7086",
+			ColorFgGhost:   "#45475a",
 
-            ColorSession:    "#89b4fa",
-            ColorProcClaude: "#cba6f7",
-            ColorProcServer: "#89dceb",
-            ColorProcEditor: "#b4befe",
-            ColorProcChild:  "#a6adc8",
+			ColorSession:    "#89b4fa",
+			ColorProcClaude: "#cba6f7",
+			ColorProcServer: "#89dceb",
+			ColorProcEditor: "#b4befe",
+			ColorProcChild:  "#a6adc8",
 
-            ColorGitDirty:  "#f9e2af",
-            ColorGitBehind: "#74c7ec",
-            ColorGitAhead:  "#a6e3a1",
+			ColorGitDirty:  "#f9e2af",
+			ColorGitBehind: "#74c7ec",
+			ColorGitAhead:  "#a6e3a1",
 
-            ColorAlertInfo:   "#89b4fa",
-            ColorAlertWarn:   "#f9e2af",
-            ColorAlertError:  "#f38ba8",
-            ColorAlertDefer:  "#b4befe",
-            ColorAlertInfoBg:  "#1a2a4d",
-            ColorAlertWarnBg:  "#3d3500",
-            ColorAlertErrorBg: "#3d1020",
-            ColorAlertDeferBg: "#1e1e2e",
+			ColorAlertInfo:    "#89b4fa",
+			ColorAlertWarn:    "#f9e2af",
+			ColorAlertError:   "#f38ba8",
+			ColorAlertDefer:   "#b4befe",
+			ColorAlertInfoBg:  "#1a2a4d",
+			ColorAlertWarnBg:  "#3d3500",
+			ColorAlertErrorBg: "#3d1020",
+			ColorAlertDeferBg: "#1e1e2e",
 
-            IconAlertInfo:  "ℹ️",
-            IconAlertWarn:  "⚠️",
-            IconAlertError: "🚨",
-            IconAlertDefer: "🔖",
+			IconAlertInfo:  "ℹ️",
+			IconAlertWarn:  "⚠️",
+			IconAlertError: "🚨",
+			IconAlertDefer: "🔖",
 
-            IconTmuxSession: "⊞",
-            IconCfgSession:  "⚙︎",
+			IconTmuxSession: "⊞",
+			IconCfgSession:  "⚙︎",
 
-            ColorPort:    "#a6e3a1",
-            ColorPortBg:  "#1a3a2a",
-            ColorClean:   "#a6e3a1",
-            ColorCpuLow:  "#7f849c",
-            ColorCpuMed:  "#f9e2af",
-            ColorCpuHigh: "#f38ba8",
+			ColorPort:    "#a6e3a1",
+			ColorPortBg:  "#1a3a2a",
+			ColorClean:   "#a6e3a1",
+			ColorCpuLow:  "#7f849c",
+			ColorCpuMed:  "#f9e2af",
+			ColorCpuHigh: "#f38ba8",
 
-            ColorFgSearchHighlight: "#f9e2af",
+			ColorFgSearchHighlight: "#f9e2af",
 
-            Processes: ProcessesConfig{
-                Editors: []string{"nvim", "vim", "vi", "nano", "emacs", "hx", "micro", "helix"},
-                Agents:  []string{"claude", "aider", "cursor", "copilot", "continue", "cody"},
-                Servers: []string{
-                    "railway", "rails", "node", "deno", "bun",
-                    "python", "python3", "uvicorn", "gunicorn", "fastapi", "django", "flask",
-                    "cargo", "go", "air", "watchexec",
-                    "vite", "webpack", "next", "nuxt",
-                    "caddy", "nginx", "httpd",
-                },
-                Shells: []string{"zsh", "bash", "sh", "fish", "dash", "nu", "pwsh"},
-            },
-        },
-    }
+			Processes: ProcessesConfig{
+				Editors: []string{"nvim", "vim", "vi", "nano", "emacs", "hx", "micro", "helix"},
+				Agents:  []string{"claude", "aider", "cursor", "copilot", "continue", "cody"},
+				Servers: []string{
+					"railway", "rails", "node", "deno", "bun",
+					"python", "python3", "uvicorn", "gunicorn", "fastapi", "django", "flask",
+					"cargo", "go", "air", "watchexec",
+					"vite", "webpack", "next", "nuxt",
+					"caddy", "nginx", "httpd",
+				},
+				Shells: []string{"zsh", "bash", "sh", "fish", "dash", "nu", "pwsh"},
+			},
+		},
+	}
 }
 
 func Load(path string) (Config, error) {
-    cfg := Default()
-    _, err := toml.DecodeFile(path, &cfg)
-    if err != nil {
-        if errors.Is(err, os.ErrNotExist) {
-            return cfg, nil
-        }
-        return cfg, err
-    }
-    // Expand env vars in path aliases, drop empty prefixes, sort longest-first.
-    filtered := cfg.PathAliases[:0]
-    for _, a := range cfg.PathAliases {
-        a.Prefix = strings.ReplaceAll(os.ExpandEnv(a.Prefix), `\ `, " ")
-        a.Replace = strings.ReplaceAll(os.ExpandEnv(a.Replace), `\ `, " ")
-        if a.Prefix != "" {
-            filtered = append(filtered, a)
-        }
-    }
-    cfg.PathAliases = filtered
-    sort.Slice(cfg.PathAliases, func(i, j int) bool {
-        return len(cfg.PathAliases[i].Prefix) > len(cfg.PathAliases[j].Prefix)
-    })
-    cfg.Sidebar.Sort = normalizeSortKeys(cfg.Sidebar.Sort)
-    return cfg, nil
+	cfg := Default()
+	_, err := toml.DecodeFile(path, &cfg)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, nil
+		}
+		return cfg, err
+	}
+	// Expand env vars in path aliases, drop empty prefixes, sort longest-first.
+	filtered := cfg.PathAliases[:0]
+	for _, a := range cfg.PathAliases {
+		a.Prefix = strings.ReplaceAll(os.ExpandEnv(a.Prefix), `\ `, " ")
+		a.Replace = strings.ReplaceAll(os.ExpandEnv(a.Replace), `\ `, " ")
+		if a.Prefix != "" {
+			filtered = append(filtered, a)
+		}
+	}
+	cfg.PathAliases = filtered
+	sort.Slice(cfg.PathAliases, func(i, j int) bool {
+		return len(cfg.PathAliases[i].Prefix) > len(cfg.PathAliases[j].Prefix)
+	})
+	cfg.Sidebar.Sort = normalizeSortKeys(cfg.Sidebar.Sort)
+	return cfg, nil
 }
 
 // DefaultPath returns ~/.config/demux/demux.toml, or an error if the
 // home directory cannot be determined.
 func DefaultPath() (string, error) {
-    home, err := os.UserHomeDir()
-    if err != nil {
-        return "", fmt.Errorf("home dir: %w", err)
-    }
-    return filepath.Join(home, ".config", "demux", "demux.toml"), nil
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".config", "demux", "demux.toml"), nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,88 +1,88 @@
 package config_test
 
 import (
-    "os"
-    "path/filepath"
-    "strings"
-    "testing"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 func containsStr(s []string, v string) bool {
-    for _, x := range s {
-        if x == v {
-            return true
-        }
-    }
-    return false
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }
 
 func TestDefaults(t *testing.T) {
-    cfg := config.Default()
-    if cfg.RefreshIntervalMs != 3000 {
-        t.Errorf("expected 3000, got %d", cfg.RefreshIntervalMs)
-    }
-    if cfg.Sidebar.Width != 35 {
-        t.Errorf("expected 35, got %d", cfg.Sidebar.Width)
-    }
-    if cfg.Git.TimeoutMs != 500 {
-        t.Errorf("expected 500, got %d", cfg.Git.TimeoutMs)
-    }
-    if cfg.Git.OnTimeout != "cached" {
-        t.Errorf("expected cached, got %s", cfg.Git.OnTimeout)
-    }
-    if cfg.Log.Level != "warn" {
-        t.Errorf("Log.Level default = %q, want \"warn\"", cfg.Log.Level)
-    }
+	cfg := config.Default()
+	if cfg.RefreshIntervalMs != 3000 {
+		t.Errorf("expected 3000, got %d", cfg.RefreshIntervalMs)
+	}
+	if cfg.Sidebar.Width != 35 {
+		t.Errorf("expected 35, got %d", cfg.Sidebar.Width)
+	}
+	if cfg.Git.TimeoutMs != 500 {
+		t.Errorf("expected 500, got %d", cfg.Git.TimeoutMs)
+	}
+	if cfg.Git.OnTimeout != "cached" {
+		t.Errorf("expected cached, got %s", cfg.Git.OnTimeout)
+	}
+	if cfg.Log.Level != "warn" {
+		t.Errorf("Log.Level default = %q, want \"warn\"", cfg.Log.Level)
+	}
 }
 
 func TestDefaults_IgnoredProcesses(t *testing.T) {
-    cfg := config.Default()
-    expected := []string{"zsh", "bash", "fish", "sh", "dash", "nu", "pwsh"}
-    if len(cfg.IgnoredProcesses) != len(expected) {
-        t.Fatalf("expected %d ignored processes, got %d: %v", len(expected), len(cfg.IgnoredProcesses), cfg.IgnoredProcesses)
-    }
-    for i, v := range expected {
-        if cfg.IgnoredProcesses[i] != v {
-            t.Errorf("IgnoredProcesses[%d]: expected %q, got %q", i, v, cfg.IgnoredProcesses[i])
-        }
-    }
+	cfg := config.Default()
+	expected := []string{"zsh", "bash", "fish", "sh", "dash", "nu", "pwsh"}
+	if len(cfg.IgnoredProcesses) != len(expected) {
+		t.Fatalf("expected %d ignored processes, got %d: %v", len(expected), len(cfg.IgnoredProcesses), cfg.IgnoredProcesses)
+	}
+	for i, v := range expected {
+		if cfg.IgnoredProcesses[i] != v {
+			t.Errorf("IgnoredProcesses[%d]: expected %q, got %q", i, v, cfg.IgnoredProcesses[i])
+		}
+	}
 }
 
 func TestDefaults_ProcessesConfig(t *testing.T) {
-    procs := config.Default().Theme.Processes
-    if len(procs.Editors) == 0 {
-        t.Error("expected non-empty default editors list")
-    }
-    if len(procs.Agents) == 0 {
-        t.Error("expected non-empty default agents list")
-    }
-    if len(procs.Servers) == 0 {
-        t.Error("expected non-empty default servers list")
-    }
-    if len(procs.Shells) == 0 {
-        t.Error("expected non-empty default shells list")
-    }
-    // spot-check key entries
-    if !containsStr(procs.Editors, "nvim") {
-        t.Error("expected nvim in default editors")
-    }
-    if !containsStr(procs.Agents, "claude") {
-        t.Error("expected claude in default agents")
-    }
-    if !containsStr(procs.Servers, "node") {
-        t.Error("expected node in default servers")
-    }
-    if !containsStr(procs.Shells, "zsh") {
-        t.Error("expected zsh in default shells")
-    }
+	procs := config.Default().Theme.Processes
+	if len(procs.Editors) == 0 {
+		t.Error("expected non-empty default editors list")
+	}
+	if len(procs.Agents) == 0 {
+		t.Error("expected non-empty default agents list")
+	}
+	if len(procs.Servers) == 0 {
+		t.Error("expected non-empty default servers list")
+	}
+	if len(procs.Shells) == 0 {
+		t.Error("expected non-empty default shells list")
+	}
+	// spot-check key entries
+	if !containsStr(procs.Editors, "nvim") {
+		t.Error("expected nvim in default editors")
+	}
+	if !containsStr(procs.Agents, "claude") {
+		t.Error("expected claude in default agents")
+	}
+	if !containsStr(procs.Servers, "node") {
+		t.Error("expected node in default servers")
+	}
+	if !containsStr(procs.Shells, "zsh") {
+		t.Error("expected zsh in default shells")
+	}
 }
 
 func TestLoadFromFile(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "dmux.toml")
-    os.WriteFile(path, []byte(`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dmux.toml")
+	os.WriteFile(path, []byte(`
 refresh_interval_ms = 1000
 ignored_sessions = ["scratch"]
 
@@ -94,57 +94,57 @@ enabled = false
 timeout_ms = 250
 `), 0644)
 
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if cfg.RefreshIntervalMs != 1000 {
-        t.Errorf("expected 1000, got %d", cfg.RefreshIntervalMs)
-    }
-    if cfg.Sidebar.Width != 40 {
-        t.Errorf("expected 40, got %d", cfg.Sidebar.Width)
-    }
-    if len(cfg.IgnoredSessions) != 1 || cfg.IgnoredSessions[0] != "scratch" {
-        t.Errorf("unexpected ignored_sessions: %v", cfg.IgnoredSessions)
-    }
-    if cfg.Git.Enabled {
-        t.Error("expected git.enabled = false")
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RefreshIntervalMs != 1000 {
+		t.Errorf("expected 1000, got %d", cfg.RefreshIntervalMs)
+	}
+	if cfg.Sidebar.Width != 40 {
+		t.Errorf("expected 40, got %d", cfg.Sidebar.Width)
+	}
+	if len(cfg.IgnoredSessions) != 1 || cfg.IgnoredSessions[0] != "scratch" {
+		t.Errorf("unexpected ignored_sessions: %v", cfg.IgnoredSessions)
+	}
+	if cfg.Git.Enabled {
+		t.Error("expected git.enabled = false")
+	}
 }
 
 func TestMissingFile(t *testing.T) {
-    cfg, err := config.Load("/nonexistent/path/dmux.toml")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if cfg.RefreshIntervalMs != 3000 {
-        t.Errorf("expected defaults, got %d", cfg.RefreshIntervalMs)
-    }
+	cfg, err := config.Load("/nonexistent/path/dmux.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RefreshIntervalMs != 3000 {
+		t.Errorf("expected defaults, got %d", cfg.RefreshIntervalMs)
+	}
 }
 
 func TestLoadFromFile_IgnoredProcesses(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`ignored_processes = ["bash", "zsh"]`), 0644)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`ignored_processes = ["bash", "zsh"]`), 0644)
 
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(cfg.IgnoredProcesses) != 2 {
-        t.Fatalf("expected 2 ignored processes, got %d: %v", len(cfg.IgnoredProcesses), cfg.IgnoredProcesses)
-    }
-    if cfg.IgnoredProcesses[0] != "bash" || cfg.IgnoredProcesses[1] != "zsh" {
-        t.Errorf("unexpected ignored processes: %v", cfg.IgnoredProcesses)
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.IgnoredProcesses) != 2 {
+		t.Fatalf("expected 2 ignored processes, got %d: %v", len(cfg.IgnoredProcesses), cfg.IgnoredProcesses)
+	}
+	if cfg.IgnoredProcesses[0] != "bash" || cfg.IgnoredProcesses[1] != "zsh" {
+		t.Errorf("unexpected ignored processes: %v", cfg.IgnoredProcesses)
+	}
 }
 
 func TestPathAliases_EnvExpansion(t *testing.T) {
-    t.Setenv("MYPROJECTS", "/home/user/projects")
-    t.Setenv("PROJ_ALIAS", "proj")
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`
+	t.Setenv("MYPROJECTS", "/home/user/projects")
+	t.Setenv("PROJ_ALIAS", "proj")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`
 [[path_aliases]]
 prefix = "$MYPROJECTS"
 replace = "$PROJ_ALIAS"
@@ -154,34 +154,34 @@ prefix = "$MYPROJECTS/work"
 replace = "work"
 `), 0644)
 
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(cfg.PathAliases) != 2 {
-        t.Fatalf("expected 2 aliases, got %d", len(cfg.PathAliases))
-    }
-    // longest prefix ("/home/user/projects/work") must come first after sort
-    if cfg.PathAliases[0].Prefix != "/home/user/projects/work" {
-        t.Errorf("expected longest prefix first, got %q", cfg.PathAliases[0].Prefix)
-    }
-    if cfg.PathAliases[1].Prefix != "/home/user/projects" {
-        t.Errorf("expected shorter prefix second, got %q", cfg.PathAliases[1].Prefix)
-    }
-    if cfg.PathAliases[0].Replace != "work" {
-        t.Errorf("unexpected replace for index 0: %q", cfg.PathAliases[0].Replace)
-    }
-    // replace values are also env-expanded
-    if cfg.PathAliases[1].Replace != "proj" {
-        t.Errorf("expected Replace to be env-expanded to %q, got %q", "proj", cfg.PathAliases[1].Replace)
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.PathAliases) != 2 {
+		t.Fatalf("expected 2 aliases, got %d", len(cfg.PathAliases))
+	}
+	// longest prefix ("/home/user/projects/work") must come first after sort
+	if cfg.PathAliases[0].Prefix != "/home/user/projects/work" {
+		t.Errorf("expected longest prefix first, got %q", cfg.PathAliases[0].Prefix)
+	}
+	if cfg.PathAliases[1].Prefix != "/home/user/projects" {
+		t.Errorf("expected shorter prefix second, got %q", cfg.PathAliases[1].Prefix)
+	}
+	if cfg.PathAliases[0].Replace != "work" {
+		t.Errorf("unexpected replace for index 0: %q", cfg.PathAliases[0].Replace)
+	}
+	// replace values are also env-expanded
+	if cfg.PathAliases[1].Replace != "proj" {
+		t.Errorf("expected Replace to be env-expanded to %q, got %q", "proj", cfg.PathAliases[1].Replace)
+	}
 }
 
 func TestPathAliases_EmptyPrefixDropped(t *testing.T) {
-    t.Setenv("UNSET_VAR", "")
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`
+	t.Setenv("UNSET_VAR", "")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`
 [[path_aliases]]
 prefix = "$UNSET_VAR"
 replace = "x"
@@ -191,264 +191,264 @@ prefix = "/real/path"
 replace = "rp"
 `), 0644)
 
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(cfg.PathAliases) != 1 {
-        t.Fatalf("expected empty-prefix alias to be dropped, got %d aliases", len(cfg.PathAliases))
-    }
-    if cfg.PathAliases[0].Prefix != "/real/path" {
-        t.Errorf("unexpected alias: %+v", cfg.PathAliases[0])
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.PathAliases) != 1 {
+		t.Fatalf("expected empty-prefix alias to be dropped, got %d aliases", len(cfg.PathAliases))
+	}
+	if cfg.PathAliases[0].Prefix != "/real/path" {
+		t.Errorf("unexpected alias: %+v", cfg.PathAliases[0])
+	}
 }
 
 func TestDefaults_NewIconFields(t *testing.T) {
-    cfg := config.Default()
-    if cfg.Theme.IconTmuxSession != "⊞" {
-        t.Errorf("expected ⊞, got %q", cfg.Theme.IconTmuxSession)
-    }
-    if cfg.Theme.IconCfgSession != "⚙︎" {
-        t.Errorf("expected ⚙︎, got %q", cfg.Theme.IconCfgSession)
-    }
+	cfg := config.Default()
+	if cfg.Theme.IconTmuxSession != "⊞" {
+		t.Errorf("expected ⊞, got %q", cfg.Theme.IconTmuxSession)
+	}
+	if cfg.Theme.IconCfgSession != "⚙︎" {
+		t.Errorf("expected ⚙︎, got %q", cfg.Theme.IconCfgSession)
+	}
 }
 
 func TestDefaults_DefaultFilter(t *testing.T) {
-    cfg := config.Default()
-    if cfg.Sidebar.DefaultFilter != "t" {
-        t.Errorf("expected t, got %q", cfg.Sidebar.DefaultFilter)
-    }
+	cfg := config.Default()
+	if cfg.Sidebar.DefaultFilter != "t" {
+		t.Errorf("expected t, got %q", cfg.Sidebar.DefaultFilter)
+	}
 }
 
 func TestLoadFromFile_DefaultFilter(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`[sidebar]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`[sidebar]
 default_filter = "a"`), 0644)
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if cfg.Sidebar.DefaultFilter != "a" {
-        t.Errorf("expected a, got %q", cfg.Sidebar.DefaultFilter)
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Sidebar.DefaultFilter != "a" {
+		t.Errorf("expected a, got %q", cfg.Sidebar.DefaultFilter)
+	}
 }
 
 func TestDefaults_SidebarSort(t *testing.T) {
-    cfg := config.Default()
-    want := []string{"priority", "last_seen", "alphabetical"}
-    if len(cfg.Sidebar.Sort) != len(want) {
-        t.Fatalf("expected Sidebar.Sort=%v, got %v", want, cfg.Sidebar.Sort)
-    }
-    for i, v := range want {
-        if cfg.Sidebar.Sort[i] != v {
-            t.Errorf("Sidebar.Sort[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
-        }
-    }
+	cfg := config.Default()
+	want := []string{"priority", "last_seen", "alphabetical"}
+	if len(cfg.Sidebar.Sort) != len(want) {
+		t.Fatalf("expected Sidebar.Sort=%v, got %v", want, cfg.Sidebar.Sort)
+	}
+	for i, v := range want {
+		if cfg.Sidebar.Sort[i] != v {
+			t.Errorf("Sidebar.Sort[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
+		}
+	}
 }
 
 func TestLoadFromFile_SidebarSort_SingleKey(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`[sidebar]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`[sidebar]
 sort = ["last_seen"]`), 0644)
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    want := []string{"last_seen", "priority", "alphabetical"}
-    if len(cfg.Sidebar.Sort) != len(want) {
-        t.Fatalf("expected %v, got %v", want, cfg.Sidebar.Sort)
-    }
-    for i, v := range want {
-        if cfg.Sidebar.Sort[i] != v {
-            t.Errorf("[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
-        }
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"last_seen", "priority", "alphabetical"}
+	if len(cfg.Sidebar.Sort) != len(want) {
+		t.Fatalf("expected %v, got %v", want, cfg.Sidebar.Sort)
+	}
+	for i, v := range want {
+		if cfg.Sidebar.Sort[i] != v {
+			t.Errorf("[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
+		}
+	}
 }
 
 func TestLoadFromFile_SidebarSort_PartialCustom(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`[sidebar]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`[sidebar]
 sort = ["alphabetical", "priority"]`), 0644)
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    want := []string{"alphabetical", "priority", "last_seen"}
-    for i, v := range want {
-        if cfg.Sidebar.Sort[i] != v {
-            t.Errorf("[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
-        }
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"alphabetical", "priority", "last_seen"}
+	for i, v := range want {
+		if cfg.Sidebar.Sort[i] != v {
+			t.Errorf("[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
+		}
+	}
 }
 
 func TestLoadFromFile_SidebarSort_InvalidDropped(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`[sidebar]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`[sidebar]
 sort = ["bogus", "last_seen"]`), 0644)
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    // "bogus" dropped; "last_seen" first; "priority", "alphabetical" filled in
-    want := []string{"last_seen", "priority", "alphabetical"}
-    for i, v := range want {
-        if cfg.Sidebar.Sort[i] != v {
-            t.Errorf("[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
-        }
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "bogus" dropped; "last_seen" first; "priority", "alphabetical" filled in
+	want := []string{"last_seen", "priority", "alphabetical"}
+	for i, v := range want {
+		if cfg.Sidebar.Sort[i] != v {
+			t.Errorf("[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
+		}
+	}
 }
 
 func TestLoadFromFile_SidebarSort_Empty(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`[sidebar]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`[sidebar]
 sort = []`), 0644)
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    want := []string{"priority", "last_seen", "alphabetical"}
-    for i, v := range want {
-        if cfg.Sidebar.Sort[i] != v {
-            t.Errorf("[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
-        }
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"priority", "last_seen", "alphabetical"}
+	for i, v := range want {
+		if cfg.Sidebar.Sort[i] != v {
+			t.Errorf("[%d]: expected %q, got %q", i, v, cfg.Sidebar.Sort[i])
+		}
+	}
 }
 
 func TestPathAliases_BackslashEscapedSpace(t *testing.T) {
-    t.Setenv("MY_DIR", `/home/user/some\ dir`)
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`
+	t.Setenv("MY_DIR", `/home/user/some\ dir`)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`
 [[path_aliases]]
 prefix = "$MY_DIR"
 replace = "mydir"
 `), 0644)
 
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(cfg.PathAliases) != 1 {
-        t.Fatalf("expected 1 alias, got %d", len(cfg.PathAliases))
-    }
-    if cfg.PathAliases[0].Prefix != "/home/user/some dir" {
-        t.Errorf("unexpected prefix: %q", cfg.PathAliases[0].Prefix)
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.PathAliases) != 1 {
+		t.Fatalf("expected 1 alias, got %d", len(cfg.PathAliases))
+	}
+	if cfg.PathAliases[0].Prefix != "/home/user/some dir" {
+		t.Errorf("unexpected prefix: %q", cfg.PathAliases[0].Prefix)
+	}
 }
 
 func TestDefaults_FocusOnOpen(t *testing.T) {
-    cfg := config.Default()
-    if cfg.Sidebar.FocusOnOpen != "alert_session" {
-        t.Errorf("expected default Sidebar.FocusOnOpen=\"alert_session\", got %q", cfg.Sidebar.FocusOnOpen)
-    }
+	cfg := config.Default()
+	if cfg.Sidebar.FocusOnOpen != "alert_session" {
+		t.Errorf("expected default Sidebar.FocusOnOpen=\"alert_session\", got %q", cfg.Sidebar.FocusOnOpen)
+	}
 }
 
 func TestLoadFromFile_FocusOnOpen(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`[sidebar]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`[sidebar]
 focus_on_open = "alert_window"`), 0644)
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if cfg.Sidebar.FocusOnOpen != "alert_window" {
-        t.Errorf("expected \"alert_window\", got %q", cfg.Sidebar.FocusOnOpen)
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Sidebar.FocusOnOpen != "alert_window" {
+		t.Errorf("expected \"alert_window\", got %q", cfg.Sidebar.FocusOnOpen)
+	}
 }
 
 func TestDefaultPath_ContainsExpectedSuffix(t *testing.T) {
-    path, err := config.DefaultPath()
-    if err != nil {
-        t.Skipf("UserHomeDir not available: %v", err)
-    }
-    const suffix = ".config/demux/demux.toml"
-    if !strings.HasSuffix(path, suffix) {
-        t.Errorf("DefaultPath() = %q, want suffix %q", path, suffix)
-    }
+	path, err := config.DefaultPath()
+	if err != nil {
+		t.Skipf("UserHomeDir not available: %v", err)
+	}
+	const suffix = ".config/demux/demux.toml"
+	if !strings.HasSuffix(path, suffix) {
+		t.Errorf("DefaultPath() = %q, want suffix %q", path, suffix)
+	}
 }
 
 func TestDefaults_SidebarSwitchFocus(t *testing.T) {
-    cfg := config.Default()
-    if cfg.Sidebar.SwitchFocus != "severity" {
-        t.Errorf("expected default Sidebar.SwitchFocus=\"severity\", got %q", cfg.Sidebar.SwitchFocus)
-    }
+	cfg := config.Default()
+	if cfg.Sidebar.SwitchFocus != "severity" {
+		t.Errorf("expected default Sidebar.SwitchFocus=\"severity\", got %q", cfg.Sidebar.SwitchFocus)
+	}
 }
 
 func TestLoadFromFile_SidebarSwitchFocus(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`[sidebar]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`[sidebar]
 switch_focus = "newest"`), 0644)
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if cfg.Sidebar.SwitchFocus != "newest" {
-        t.Errorf("expected \"newest\", got %q", cfg.Sidebar.SwitchFocus)
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Sidebar.SwitchFocus != "newest" {
+		t.Errorf("expected \"newest\", got %q", cfg.Sidebar.SwitchFocus)
+	}
 }
 
 func TestDefault_Mode(t *testing.T) {
-    cfg := config.Default()
-    if cfg.Mode != "full" {
-        t.Errorf("expected default Mode %q, got %q", "full", cfg.Mode)
-    }
+	cfg := config.Default()
+	if cfg.Mode != "full" {
+		t.Errorf("expected default Mode %q, got %q", "full", cfg.Mode)
+	}
 }
 
 func TestLoad_ModeCompact(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    if err := os.WriteFile(path, []byte(`mode = "compact"`), 0644); err != nil {
-        t.Fatal(err)
-    }
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if cfg.Mode != "compact" {
-        t.Errorf("expected Mode %q, got %q", "compact", cfg.Mode)
-    }
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	if err := os.WriteFile(path, []byte(`mode = "compact"`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Mode != "compact" {
+		t.Errorf("expected Mode %q, got %q", "compact", cfg.Mode)
+	}
 }
 
 func TestDefault_StatusBarShow(t *testing.T) {
-    cfg := config.Default()
-    if !cfg.StatusBar.Show {
-        t.Error("expected StatusBar.Show to default to true")
-    }
+	cfg := config.Default()
+	if !cfg.StatusBar.Show {
+		t.Error("expected StatusBar.Show to default to true")
+	}
 }
 
 func TestDefaults_SidebarShowLastSeen(t *testing.T) {
-    cfg := config.Default()
-    if !cfg.Sidebar.ShowLastSeen {
-        t.Error("expected Sidebar.ShowLastSeen to default to true")
-    }
+	cfg := config.Default()
+	if !cfg.Sidebar.ShowLastSeen {
+		t.Error("expected Sidebar.ShowLastSeen to default to true")
+	}
 }
 
 func TestLoad_StatusBarShowFalse(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    if err := os.WriteFile(path, []byte("[status_bar]\nshow = false"), 0644); err != nil {
-        t.Fatal(err)
-    }
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if cfg.StatusBar.Show {
-        t.Error("expected StatusBar.Show = false when set in config")
-    }
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	if err := os.WriteFile(path, []byte("[status_bar]\nshow = false"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.StatusBar.Show {
+		t.Error("expected StatusBar.Show = false when set in config")
+	}
 }
 
 func TestLoadFromFile_ProcessesConfig(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "demux.toml")
-    os.WriteFile(path, []byte(`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	os.WriteFile(path, []byte(`
 [theme.processes]
 editors = ["hx"]
 agents  = ["aider"]
@@ -456,21 +456,21 @@ servers = ["bun"]
 shells  = ["fish"]
 `), 0644)
 
-    cfg, err := config.Load(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    procs := cfg.Theme.Processes
-    if len(procs.Editors) != 1 || procs.Editors[0] != "hx" {
-        t.Errorf("unexpected editors: %v", procs.Editors)
-    }
-    if len(procs.Agents) != 1 || procs.Agents[0] != "aider" {
-        t.Errorf("unexpected agents: %v", procs.Agents)
-    }
-    if len(procs.Servers) != 1 || procs.Servers[0] != "bun" {
-        t.Errorf("unexpected servers: %v", procs.Servers)
-    }
-    if len(procs.Shells) != 1 || procs.Shells[0] != "fish" {
-        t.Errorf("unexpected shells: %v", procs.Shells)
-    }
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	procs := cfg.Theme.Processes
+	if len(procs.Editors) != 1 || procs.Editors[0] != "hx" {
+		t.Errorf("unexpected editors: %v", procs.Editors)
+	}
+	if len(procs.Agents) != 1 || procs.Agents[0] != "aider" {
+		t.Errorf("unexpected agents: %v", procs.Agents)
+	}
+	if len(procs.Servers) != 1 || procs.Servers[0] != "bun" {
+		t.Errorf("unexpected servers: %v", procs.Servers)
+	}
+	if len(procs.Shells) != 1 || procs.Shells[0] != "fish" {
+		t.Errorf("unexpected shells: %v", procs.Shells)
+	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -4,16 +4,16 @@ import "time"
 
 // Exported defaults for use by other packages (e.g. TUI tick interval).
 const (
-    DefaultRefreshIntervalMs = 3000
-    DefaultGitTimeoutMs      = 500
-    DefaultSidebarWidth      = 35
+	DefaultRefreshIntervalMs = 3000
+	DefaultGitTimeoutMs      = 500
+	DefaultSidebarWidth      = 35
 
-    // MinRefreshIntervalMs is the minimum accepted value for RefreshIntervalMs.
-    MinRefreshIntervalMs = 100
-    // MinSidebarWidth is the minimum accepted value for Sidebar.Width.
-    MinSidebarWidth = 10
-    // MinGitTimeoutWarnMs is the threshold below which a git timeout warning is issued.
-    MinGitTimeoutWarnMs = 50
+	// MinRefreshIntervalMs is the minimum accepted value for RefreshIntervalMs.
+	MinRefreshIntervalMs = 100
+	// MinSidebarWidth is the minimum accepted value for Sidebar.Width.
+	MinSidebarWidth = 10
+	// MinGitTimeoutWarnMs is the threshold below which a git timeout warning is issued.
+	MinGitTimeoutWarnMs = 50
 )
 
 // TickInterval is the TUI refresh tick derived from the default refresh interval.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,20 +1,20 @@
 package config
 
 import (
-    "fmt"
-    "regexp"
-    "strings"
+	"fmt"
+	"regexp"
+	"strings"
 )
 
 // ValidationIssue represents a single config problem found by Validate.
 type ValidationIssue struct {
-    Field   string // TOML key path, e.g. "theme.color_bg"
-    Level   string // "error" or "warn"
-    Message string
+	Field   string // TOML key path, e.g. "theme.color_bg"
+	Level   string // "error" or "warn"
+	Message string
 }
 
 func (v ValidationIssue) String() string {
-    return fmt.Sprintf("[%s] %s: %s", v.Level, v.Field, v.Message)
+	return fmt.Sprintf("[%s] %s: %s", v.Level, v.Field, v.Message)
 }
 
 var hexColorRE = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
@@ -23,90 +23,90 @@ var hexColorRE = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
 // An empty slice means the config is valid. Errors prevent correct operation;
 // warns indicate degraded behavior or non-obvious defaults.
 func (c Config) Validate() []ValidationIssue {
-    var issues []ValidationIssue
-    add := func(level, field, msg string) {
-        issues = append(issues, ValidationIssue{Field: field, Level: level, Message: msg})
-    }
+	var issues []ValidationIssue
+	add := func(level, field, msg string) {
+		issues = append(issues, ValidationIssue{Field: field, Level: level, Message: msg})
+	}
 
-    // RefreshIntervalMs
-    if c.RefreshIntervalMs < MinRefreshIntervalMs {
-        add("error", "refresh_interval_ms", fmt.Sprintf("must be ≥ 100, got %d", c.RefreshIntervalMs))
-    }
+	// RefreshIntervalMs
+	if c.RefreshIntervalMs < MinRefreshIntervalMs {
+		add("error", "refresh_interval_ms", fmt.Sprintf("must be ≥ 100, got %d", c.RefreshIntervalMs))
+	}
 
-    // Mode
-    validModes := map[string]bool{"full": true, "compact": true}
-    if c.Mode != "" && !validModes[c.Mode] {
-        add("error", "mode", fmt.Sprintf("must be \"full\" or \"compact\", got %q", c.Mode))
-    }
+	// Mode
+	validModes := map[string]bool{"full": true, "compact": true}
+	if c.Mode != "" && !validModes[c.Mode] {
+		add("error", "mode", fmt.Sprintf("must be \"full\" or \"compact\", got %q", c.Mode))
+	}
 
-    // DefaultFormat
-    validFormats := map[string]bool{"text": true, "table": true, "json": true, "": true}
-    if !validFormats[c.DefaultFormat] {
-        add("error", "default_format", fmt.Sprintf("must be text|table|json, got %q", c.DefaultFormat))
-    }
+	// DefaultFormat
+	validFormats := map[string]bool{"text": true, "table": true, "json": true, "": true}
+	if !validFormats[c.DefaultFormat] {
+		add("error", "default_format", fmt.Sprintf("must be text|table|json, got %q", c.DefaultFormat))
+	}
 
-    // Log level
-    validLevels := map[string]bool{"off": true, "error": true, "warn": true, "info": true, "debug": true}
-    if c.Log.Level != "" && !validLevels[strings.ToLower(c.Log.Level)] {
-        add("error", "log.level", fmt.Sprintf("must be off|error|warn|info|debug, got %q", c.Log.Level))
-    }
+	// Log level
+	validLevels := map[string]bool{"off": true, "error": true, "warn": true, "info": true, "debug": true}
+	if c.Log.Level != "" && !validLevels[strings.ToLower(c.Log.Level)] {
+		add("error", "log.level", fmt.Sprintf("must be off|error|warn|info|debug, got %q", c.Log.Level))
+	}
 
-    // Sidebar
-    if c.Sidebar.Width < MinSidebarWidth {
-        add("error", "sidebar.width", fmt.Sprintf("must be ≥ 10, got %d", c.Sidebar.Width))
-    }
+	// Sidebar
+	if c.Sidebar.Width < MinSidebarWidth {
+		add("error", "sidebar.width", fmt.Sprintf("must be ≥ 10, got %d", c.Sidebar.Width))
+	}
 
-    // Git timeout
-    if c.Git.TimeoutMs > 0 && c.Git.TimeoutMs < MinGitTimeoutWarnMs {
-        add("warn", "git.timeout_ms", fmt.Sprintf("very low timeout (%dms) may cause frequent git errors", c.Git.TimeoutMs))
-    }
+	// Git timeout
+	if c.Git.TimeoutMs > 0 && c.Git.TimeoutMs < MinGitTimeoutWarnMs {
+		add("warn", "git.timeout_ms", fmt.Sprintf("very low timeout (%dms) may cause frequent git errors", c.Git.TimeoutMs))
+	}
 
-    // Theme colors
-    colorFields := map[string]string{
-        "color_bg":       c.Theme.ColorBg,
-        "color_surface":  c.Theme.ColorSurface,
-        "color_raised":   c.Theme.ColorRaised,
-        "color_selected": c.Theme.ColorSelected,
-        "color_border":   c.Theme.ColorBorder,
+	// Theme colors
+	colorFields := map[string]string{
+		"color_bg":       c.Theme.ColorBg,
+		"color_surface":  c.Theme.ColorSurface,
+		"color_raised":   c.Theme.ColorRaised,
+		"color_selected": c.Theme.ColorSelected,
+		"color_border":   c.Theme.ColorBorder,
 
-        "color_fg_primary": c.Theme.ColorFgPrimary,
-        "color_fg_subtext": c.Theme.ColorFgSubtext,
-        "color_fg_muted":   c.Theme.ColorFgMuted,
-        "color_fg_dim":     c.Theme.ColorFgDim,
-        "color_fg_ghost":   c.Theme.ColorFgGhost,
+		"color_fg_primary": c.Theme.ColorFgPrimary,
+		"color_fg_subtext": c.Theme.ColorFgSubtext,
+		"color_fg_muted":   c.Theme.ColorFgMuted,
+		"color_fg_dim":     c.Theme.ColorFgDim,
+		"color_fg_ghost":   c.Theme.ColorFgGhost,
 
-        "color_session":     c.Theme.ColorSession,
-        "color_proc_claude": c.Theme.ColorProcClaude,
-        "color_proc_server": c.Theme.ColorProcServer,
-        "color_proc_editor": c.Theme.ColorProcEditor,
-        "color_proc_child":  c.Theme.ColorProcChild,
+		"color_session":     c.Theme.ColorSession,
+		"color_proc_claude": c.Theme.ColorProcClaude,
+		"color_proc_server": c.Theme.ColorProcServer,
+		"color_proc_editor": c.Theme.ColorProcEditor,
+		"color_proc_child":  c.Theme.ColorProcChild,
 
-        "color_git_dirty":  c.Theme.ColorGitDirty,
-        "color_git_behind": c.Theme.ColorGitBehind,
-        "color_git_ahead":  c.Theme.ColorGitAhead,
+		"color_git_dirty":  c.Theme.ColorGitDirty,
+		"color_git_behind": c.Theme.ColorGitBehind,
+		"color_git_ahead":  c.Theme.ColorGitAhead,
 
-        "color_alert_info":     c.Theme.ColorAlertInfo,
-        "color_alert_warn":     c.Theme.ColorAlertWarn,
-        "color_alert_error":    c.Theme.ColorAlertError,
-        "color_alert_defer":    c.Theme.ColorAlertDefer,
-        "color_alert_info_bg":  c.Theme.ColorAlertInfoBg,
-        "color_alert_warn_bg":  c.Theme.ColorAlertWarnBg,
-        "color_alert_error_bg": c.Theme.ColorAlertErrorBg,
-        "color_alert_defer_bg": c.Theme.ColorAlertDeferBg,
+		"color_alert_info":     c.Theme.ColorAlertInfo,
+		"color_alert_warn":     c.Theme.ColorAlertWarn,
+		"color_alert_error":    c.Theme.ColorAlertError,
+		"color_alert_defer":    c.Theme.ColorAlertDefer,
+		"color_alert_info_bg":  c.Theme.ColorAlertInfoBg,
+		"color_alert_warn_bg":  c.Theme.ColorAlertWarnBg,
+		"color_alert_error_bg": c.Theme.ColorAlertErrorBg,
+		"color_alert_defer_bg": c.Theme.ColorAlertDeferBg,
 
-        "color_port":               c.Theme.ColorPort,
-        "color_port_bg":            c.Theme.ColorPortBg,
-        "color_clean":              c.Theme.ColorClean,
-        "color_cpu_low":            c.Theme.ColorCpuLow,
-        "color_cpu_med":            c.Theme.ColorCpuMed,
-        "color_cpu_high":           c.Theme.ColorCpuHigh,
-        "color_fg_search_highlight": c.Theme.ColorFgSearchHighlight,
-    }
-    for field, val := range colorFields {
-        if val != "" && !hexColorRE.MatchString(val) {
-            add("warn", field, fmt.Sprintf("expected #rrggbb hex color, got %q", val))
-        }
-    }
+		"color_port":                c.Theme.ColorPort,
+		"color_port_bg":             c.Theme.ColorPortBg,
+		"color_clean":               c.Theme.ColorClean,
+		"color_cpu_low":             c.Theme.ColorCpuLow,
+		"color_cpu_med":             c.Theme.ColorCpuMed,
+		"color_cpu_high":            c.Theme.ColorCpuHigh,
+		"color_fg_search_highlight": c.Theme.ColorFgSearchHighlight,
+	}
+	for field, val := range colorFields {
+		if val != "" && !hexColorRE.MatchString(val) {
+			add("warn", field, fmt.Sprintf("expected #rrggbb hex color, got %q", val))
+		}
+	}
 
-    return issues
+	return issues
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,72 +1,72 @@
 package config_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 func TestValidate_defaults_clean(t *testing.T) {
-    cfg := config.Default()
-    issues := cfg.Validate()
-    errors := filterLevel(issues, "error")
-    if len(errors) != 0 {
-        t.Errorf("Default config should have no errors, got: %v", errors)
-    }
+	cfg := config.Default()
+	issues := cfg.Validate()
+	errors := filterLevel(issues, "error")
+	if len(errors) != 0 {
+		t.Errorf("Default config should have no errors, got: %v", errors)
+	}
 }
 
 func TestValidate_bad_mode(t *testing.T) {
-    cfg := config.Default()
-    cfg.Mode = "ultrawide"
-    issues := cfg.Validate()
-    if !hasIssue(issues, "error", "mode") {
-        t.Error("expected error for invalid mode")
-    }
+	cfg := config.Default()
+	cfg.Mode = "ultrawide"
+	issues := cfg.Validate()
+	if !hasIssue(issues, "error", "mode") {
+		t.Error("expected error for invalid mode")
+	}
 }
 
 func TestValidate_bad_refresh(t *testing.T) {
-    cfg := config.Default()
-    cfg.RefreshIntervalMs = 10
-    issues := cfg.Validate()
-    if !hasIssue(issues, "error", "refresh_interval_ms") {
-        t.Error("expected error for refresh_interval_ms < 100")
-    }
+	cfg := config.Default()
+	cfg.RefreshIntervalMs = 10
+	issues := cfg.Validate()
+	if !hasIssue(issues, "error", "refresh_interval_ms") {
+		t.Error("expected error for refresh_interval_ms < 100")
+	}
 }
 
 func TestValidate_bad_color(t *testing.T) {
-    cfg := config.Default()
-    cfg.Theme.ColorBg = "notahex"
-    issues := cfg.Validate()
-    if !hasIssue(issues, "warn", "color_bg") {
-        t.Error("expected warn for invalid color_bg")
-    }
+	cfg := config.Default()
+	cfg.Theme.ColorBg = "notahex"
+	issues := cfg.Validate()
+	if !hasIssue(issues, "warn", "color_bg") {
+		t.Error("expected warn for invalid color_bg")
+	}
 }
 
 func TestValidate_bad_log_level(t *testing.T) {
-    cfg := config.Default()
-    cfg.Log.Level = "verbose"
-    issues := cfg.Validate()
-    if !hasIssue(issues, "error", "log.level") {
-        t.Error("expected error for invalid log level")
-    }
+	cfg := config.Default()
+	cfg.Log.Level = "verbose"
+	issues := cfg.Validate()
+	if !hasIssue(issues, "error", "log.level") {
+		t.Error("expected error for invalid log level")
+	}
 }
 
 // helpers
 func filterLevel(issues []config.ValidationIssue, level string) []config.ValidationIssue {
-    var out []config.ValidationIssue
-    for _, i := range issues {
-        if i.Level == level {
-            out = append(out, i)
-        }
-    }
-    return out
+	var out []config.ValidationIssue
+	for _, i := range issues {
+		if i.Level == level {
+			out = append(out, i)
+		}
+	}
+	return out
 }
 
 func hasIssue(issues []config.ValidationIssue, level, field string) bool {
-    for _, i := range issues {
-        if i.Level == level && i.Field == field {
-            return true
-        }
-    }
-    return false
+	for _, i := range issues {
+		if i.Level == level && i.Field == field {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/db/alerts.go
+++ b/internal/db/alerts.go
@@ -1,41 +1,41 @@
 package db
 
 import (
-    "database/sql"
-    "errors"
-    "time"
+	"database/sql"
+	"errors"
+	"time"
 )
 
 // parseTS handles the varying timestamp formats returned by modernc.org/sqlite.
 func parseTS(s string) time.Time {
-    for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02T15:04:05"} {
-        if t, err := time.ParseInLocation(layout, s, time.UTC); err == nil {
-            return t.UTC()
-        }
-    }
-    return time.Time{}
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02T15:04:05"} {
+		if t, err := time.ParseInLocation(layout, s, time.UTC); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
 }
 
 // AlertLevel represents the severity of an alert. Higher values are more severe.
 type AlertLevel = string
 
 const (
-    LevelInfo  AlertLevel = "info"
-    LevelWarn  AlertLevel = "warn"
-    LevelError AlertLevel = "error"
-    LevelDefer AlertLevel = "defer"
+	LevelInfo  AlertLevel = "info"
+	LevelWarn  AlertLevel = "warn"
+	LevelError AlertLevel = "error"
+	LevelDefer AlertLevel = "defer"
 )
 
 type Alert struct {
-    ID        int
-    Target    string
-    Reason    string
-    Level     AlertLevel
-    CreatedAt time.Time
+	ID        int
+	Target    string
+	Reason    string
+	Level     AlertLevel
+	CreatedAt time.Time
 }
 
 func (d *DB) AlertSet(target, reason, level string) error {
-    _, err := d.sql.Exec(`
+	_, err := d.sql.Exec(`
         INSERT INTO alerts (target, reason, level, created_at)
         VALUES (?, ?, ?, CURRENT_TIMESTAMP)
         ON CONFLICT(target) DO UPDATE SET
@@ -45,52 +45,52 @@ func (d *DB) AlertSet(target, reason, level string) error {
         WHERE (CASE excluded.level WHEN 'error' THEN 3 WHEN 'warn' THEN 2 WHEN 'info' THEN 1 ELSE 0 END)
             >= (CASE alerts.level WHEN 'error' THEN 3 WHEN 'warn' THEN 2 WHEN 'info' THEN 1 ELSE 0 END)
     `, target, reason, level)
-    return err
+	return err
 }
 
 func (d *DB) AlertRemove(target string) error {
-    _, err := d.sql.Exec(`DELETE FROM alerts WHERE target = ?`, target)
-    return err
+	_, err := d.sql.Exec(`DELETE FROM alerts WHERE target = ?`, target)
+	return err
 }
 
 func (d *DB) AlertList() ([]Alert, error) {
-    rows, err := d.sql.Query(`
+	rows, err := d.sql.Query(`
         SELECT id, target, reason, level, created_at
         FROM alerts ORDER BY created_at ASC
     `)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var alerts []Alert
-    for rows.Next() {
-        var a Alert
-        var createdAt string
-        if err := rows.Scan(&a.ID, &a.Target, &a.Reason, &a.Level, &createdAt); err != nil {
-            return nil, err
-        }
-        a.CreatedAt = parseTS(createdAt)
-        alerts = append(alerts, a)
-    }
-    return alerts, rows.Err()
+	var alerts []Alert
+	for rows.Next() {
+		var a Alert
+		var createdAt string
+		if err := rows.Scan(&a.ID, &a.Target, &a.Reason, &a.Level, &createdAt); err != nil {
+			return nil, err
+		}
+		a.CreatedAt = parseTS(createdAt)
+		alerts = append(alerts, a)
+	}
+	return alerts, rows.Err()
 }
 
 // AlertByTarget returns the alert for a target, or nil if not found.
 func (d *DB) AlertByTarget(target string) (*Alert, error) {
-    row := d.sql.QueryRow(`
+	row := d.sql.QueryRow(`
         SELECT id, target, reason, level, created_at
         FROM alerts WHERE target = ?
     `, target)
-    var a Alert
-    var createdAt string
-    err := row.Scan(&a.ID, &a.Target, &a.Reason, &a.Level, &createdAt)
-    if err != nil {
-        if errors.Is(err, sql.ErrNoRows) {
-            return nil, nil
-        }
-        return nil, err
-    }
-    a.CreatedAt = parseTS(createdAt)
-    return &a, nil
+	var a Alert
+	var createdAt string
+	err := row.Scan(&a.ID, &a.Target, &a.Reason, &a.Level, &createdAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	a.CreatedAt = parseTS(createdAt)
+	return &a, nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,41 +1,41 @@
 package db
 
 import (
-    "database/sql"
-    "fmt"
-    "os"
-    "path/filepath"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
 
-    _ "modernc.org/sqlite"
+	_ "modernc.org/sqlite"
 )
 
 type DB struct {
-    sql *sql.DB
+	sql *sql.DB
 }
 
 func Open(path string) (*DB, error) {
-    if path != ":memory:" {
-        if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-            return nil, fmt.Errorf("db dir: %w", err)
-        }
-    }
-    sqldb, err := sql.Open("sqlite", path)
-    if err != nil {
-        return nil, err
-    }
-    d := &DB{sql: sqldb}
-    if err := d.migrate(); err != nil {
-        return nil, err
-    }
-    return d, nil
+	if path != ":memory:" {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return nil, fmt.Errorf("db dir: %w", err)
+		}
+	}
+	sqldb, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, err
+	}
+	d := &DB{sql: sqldb}
+	if err := d.migrate(); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 func (d *DB) Close() error {
-    return d.sql.Close()
+	return d.sql.Close()
 }
 
 func (d *DB) migrate() error {
-    _, err := d.sql.Exec(`
+	_, err := d.sql.Exec(`
         CREATE TABLE IF NOT EXISTS alerts (
             id         INTEGER PRIMARY KEY AUTOINCREMENT,
             target     TEXT NOT NULL UNIQUE,
@@ -44,15 +44,15 @@ func (d *DB) migrate() error {
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
         )
     `)
-    return err
+	return err
 }
 
 // DefaultPath returns ~/.local/share/demux/state.db, or an error if the
 // home directory cannot be determined.
 func DefaultPath() (string, error) {
-    home, err := os.UserHomeDir()
-    if err != nil {
-        return "", fmt.Errorf("home dir: %w", err)
-    }
-    return filepath.Join(home, ".local", "share", "demux", "state.db"), nil
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".local", "share", "demux", "state.db"), nil
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,164 +1,164 @@
 package db_test
 
 import (
-    "os"
-    "path/filepath"
-    "strings"
-    "testing"
-    "time"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
 
-    "github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/db"
 )
 
 func openTestDB(t *testing.T) *db.DB {
-    t.Helper()
-    d, err := db.Open(":memory:")
-    if err != nil {
-        t.Fatal(err)
-    }
-    t.Cleanup(func() { d.Close() })
-    return d
+	t.Helper()
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
 }
 
 func TestAlertSetAndList(t *testing.T) {
-    d := openTestDB(t)
+	d := openTestDB(t)
 
-    err := d.AlertSet("feature-auth:2", "waiting for input", "info")
-    if err != nil {
-        t.Fatal(err)
-    }
+	err := d.AlertSet("feature-auth:2", "waiting for input", "info")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    alerts, err := d.AlertList()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(alerts) != 1 {
-        t.Fatalf("expected 1 alert, got %d", len(alerts))
-    }
-    a := alerts[0]
-    if a.Target != "feature-auth:2" {
-        t.Errorf("unexpected target: %s", a.Target)
-    }
-    if a.Level != "info" {
-        t.Errorf("unexpected level: %s", a.Level)
-    }
+	alerts, err := d.AlertList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	a := alerts[0]
+	if a.Target != "feature-auth:2" {
+		t.Errorf("unexpected target: %s", a.Target)
+	}
+	if a.Level != "info" {
+		t.Errorf("unexpected level: %s", a.Level)
+	}
 }
 
 func TestAlertSetReplacesExisting(t *testing.T) {
-    d := openTestDB(t)
+	d := openTestDB(t)
 
-    d.AlertSet("s:1", "reason 1", "info")
-    d.AlertSet("s:1", "reason 2", "error")
+	d.AlertSet("s:1", "reason 1", "info")
+	d.AlertSet("s:1", "reason 2", "error")
 
-    alerts, _ := d.AlertList()
-    if len(alerts) != 1 {
-        t.Fatalf("expected 1, got %d", len(alerts))
-    }
-    if alerts[0].Reason != "reason 2" {
-        t.Errorf("expected updated reason, got %s", alerts[0].Reason)
-    }
+	alerts, _ := d.AlertList()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1, got %d", len(alerts))
+	}
+	if alerts[0].Reason != "reason 2" {
+		t.Errorf("expected updated reason, got %s", alerts[0].Reason)
+	}
 }
 
 func TestAlertSetDoesNotDowngrade(t *testing.T) {
-    d := openTestDB(t)
+	d := openTestDB(t)
 
-    d.AlertSet("s:1", "reason 1", "error")
-    d.AlertSet("s:1", "reason 2", "defer")
+	d.AlertSet("s:1", "reason 1", "error")
+	d.AlertSet("s:1", "reason 2", "defer")
 
-    alerts, _ := d.AlertList()
-    if len(alerts) != 1 {
-        t.Fatalf("expected 1, got %d", len(alerts))
-    }
-    if alerts[0].Level != "error" {
-        t.Errorf("expected level=error to be preserved, got %s", alerts[0].Level)
-    }
-    if alerts[0].Reason != "reason 1" {
-        t.Errorf("expected reason to be preserved, got %s", alerts[0].Reason)
-    }
+	alerts, _ := d.AlertList()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1, got %d", len(alerts))
+	}
+	if alerts[0].Level != "error" {
+		t.Errorf("expected level=error to be preserved, got %s", alerts[0].Level)
+	}
+	if alerts[0].Reason != "reason 1" {
+		t.Errorf("expected reason to be preserved, got %s", alerts[0].Reason)
+	}
 }
 
 func TestAlertRemove(t *testing.T) {
-    d := openTestDB(t)
+	d := openTestDB(t)
 
-    d.AlertSet("s:1", "r", "info")
-    err := d.AlertRemove("s:1")
-    if err != nil {
-        t.Fatal(err)
-    }
+	d.AlertSet("s:1", "r", "info")
+	err := d.AlertRemove("s:1")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    alerts, _ := d.AlertList()
-    if len(alerts) != 0 {
-        t.Errorf("expected 0 alerts, got %d", len(alerts))
-    }
+	alerts, _ := d.AlertList()
+	if len(alerts) != 0 {
+		t.Errorf("expected 0 alerts, got %d", len(alerts))
+	}
 }
 
 func TestAlertCreatedAt(t *testing.T) {
-    d := openTestDB(t)
-    before := time.Now().UTC().Truncate(time.Second)
-    d.AlertSet("s:1", "r", "warn")
-    alerts, _ := d.AlertList()
-    if alerts[0].CreatedAt.Before(before) {
-        t.Error("created_at is before insert time")
-    }
+	d := openTestDB(t)
+	before := time.Now().UTC().Truncate(time.Second)
+	d.AlertSet("s:1", "r", "warn")
+	alerts, _ := d.AlertList()
+	if alerts[0].CreatedAt.Before(before) {
+		t.Error("created_at is before insert time")
+	}
 }
 
 func TestOpen_DirPermissions(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "subdir", "state.db")
-    d, err := db.Open(path)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if err := d.Close(); err != nil {
-        t.Fatalf("close: %v", err)
-    }
-    info, err := os.Stat(filepath.Dir(path))
-    if err != nil {
-        t.Fatal(err)
-    }
-    // 0700 has no bits in common with any standard umask, so the
-    // kernel will not mask any bits away.
-    if got := info.Mode().Perm(); got != 0700 {
-        t.Errorf("dir perm = %04o, want 0700", got)
-    }
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "state.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	info, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 0700 has no bits in common with any standard umask, so the
+	// kernel will not mask any bits away.
+	if got := info.Mode().Perm(); got != 0700 {
+		t.Errorf("dir perm = %04o, want 0700", got)
+	}
 }
 
 func TestDefaultPath_ContainsExpectedSuffix(t *testing.T) {
-    path, err := db.DefaultPath()
-    if err != nil {
-        t.Skipf("UserHomeDir not available: %v", err)
-    }
-    const suffix = ".local/share/demux/state.db"
-    if !strings.HasSuffix(path, suffix) {
-        t.Errorf("DefaultPath() = %q, want suffix %q", path, suffix)
-    }
+	path, err := db.DefaultPath()
+	if err != nil {
+		t.Skipf("UserHomeDir not available: %v", err)
+	}
+	const suffix = ".local/share/demux/state.db"
+	if !strings.HasSuffix(path, suffix) {
+		t.Errorf("DefaultPath() = %q, want suffix %q", path, suffix)
+	}
 }
 
 func TestAlertByTarget(t *testing.T) {
-    d := openTestDB(t)
+	d := openTestDB(t)
 
-    // not found
-    a, err := d.AlertByTarget("s:1")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if a != nil {
-        t.Error("expected nil for missing target")
-    }
+	// not found
+	a, err := d.AlertByTarget("s:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != nil {
+		t.Error("expected nil for missing target")
+	}
 
-    // found
-    d.AlertSet("s:1", "reason", "warn")
-    a, err = d.AlertByTarget("s:1")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if a == nil {
-        t.Fatal("expected alert, got nil")
-    }
-    if a.Target != "s:1" || a.Level != "warn" {
-        t.Errorf("unexpected alert: %+v", a)
-    }
-    if a.CreatedAt.IsZero() {
-        t.Error("CreatedAt should not be zero")
-    }
+	// found
+	d.AlertSet("s:1", "reason", "warn")
+	a, err = d.AlertByTarget("s:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == nil {
+		t.Fatal("expected alert, got nil")
+	}
+	if a.Target != "s:1" || a.Level != "warn" {
+		t.Errorf("unexpected alert: %+v", a)
+	}
+	if a.CreatedAt.IsZero() {
+		t.Error("CreatedAt should not be zero")
+	}
 }

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -4,17 +4,17 @@ import "strings"
 
 // Row is implemented by any struct that can produce ordered field values.
 type Row interface {
-    Fields() []string
+	Fields() []string
 }
 
 // Render dispatches to the correct formatter.
 func Render(fmtName string, headers []string, rows []Row, isTTY bool) string {
-    switch strings.ToLower(fmtName) {
-    case "table":
-        return Table(headers, rows, isTTY)
-    case "json":
-        return JSON(headers, rows)
-    default:
-        return Text(headers, rows)
-    }
+	switch strings.ToLower(fmtName) {
+	case "table":
+		return Table(headers, rows, isTTY)
+	case "json":
+		return JSON(headers, rows)
+	default:
+		return Text(headers, rows)
+	}
 }

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,10 +1,10 @@
 package format_test
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/format"
 )
 
 type row struct{ A, B string }
@@ -12,67 +12,67 @@ type row struct{ A, B string }
 func (r row) Fields() []string { return []string{r.A, r.B} }
 
 func TestTextFormat(t *testing.T) {
-    rows := []format.Row{row{"hello", "world"}, row{"foo", "bar"}}
-    out := format.Text([]string{"COL1", "COL2"}, rows)
-    if !strings.Contains(out, "hello") || !strings.Contains(out, "world") {
-        t.Errorf("unexpected output: %s", out)
-    }
-    if !strings.Contains(out, "COL1") {
-        t.Errorf("header missing in text output: %s", out)
-    }
+	rows := []format.Row{row{"hello", "world"}, row{"foo", "bar"}}
+	out := format.Text([]string{"COL1", "COL2"}, rows)
+	if !strings.Contains(out, "hello") || !strings.Contains(out, "world") {
+		t.Errorf("unexpected output: %s", out)
+	}
+	if !strings.Contains(out, "COL1") {
+		t.Errorf("header missing in text output: %s", out)
+	}
 }
 
 func TestTableFormat(t *testing.T) {
-    rows := []format.Row{row{"hello", "world"}}
-    out := format.Table([]string{"COL1", "COL2"}, rows, false) // false = no TTY bold
-    lines := strings.Split(strings.TrimSpace(out), "\n")
-    if len(lines) != 2 {
-        t.Errorf("expected 2 lines (header + row), got %d: %s", len(lines), out)
-    }
-    if !strings.Contains(lines[0], "COL1") {
-        t.Errorf("header missing COL1: %s", lines[0])
-    }
-    if !strings.Contains(lines[1], "hello") {
-        t.Errorf("row missing hello: %s", lines[1])
-    }
+	rows := []format.Row{row{"hello", "world"}}
+	out := format.Table([]string{"COL1", "COL2"}, rows, false) // false = no TTY bold
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines (header + row), got %d: %s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "COL1") {
+		t.Errorf("header missing COL1: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "hello") {
+		t.Errorf("row missing hello: %s", lines[1])
+	}
 }
 
 func TestTableBoldTTY(t *testing.T) {
-    rows := []format.Row{row{"v", "w"}}
-    out := format.Table([]string{"A", "B"}, rows, true) // TTY mode
-    if !strings.Contains(out, "\033[1m") {
-        t.Errorf("expected bold ANSI in TTY mode: %s", out)
-    }
+	rows := []format.Row{row{"v", "w"}}
+	out := format.Table([]string{"A", "B"}, rows, true) // TTY mode
+	if !strings.Contains(out, "\033[1m") {
+		t.Errorf("expected bold ANSI in TTY mode: %s", out)
+	}
 }
 
 func TestJSONFormat(t *testing.T) {
-    rows := []format.Row{row{"hello", "world"}}
-    out := format.JSON([]string{"col1", "col2"}, rows)
-    if !strings.Contains(out, `"col1"`) || !strings.Contains(out, `"hello"`) {
-        t.Errorf("unexpected json: %s", out)
-    }
-    // should be newline-delimited (one JSON object per line)
-    lines := strings.Split(strings.TrimSpace(out), "\n")
-    if len(lines) != 1 {
-        t.Errorf("expected 1 line for 1 row, got %d", len(lines))
-    }
+	rows := []format.Row{row{"hello", "world"}}
+	out := format.JSON([]string{"col1", "col2"}, rows)
+	if !strings.Contains(out, `"col1"`) || !strings.Contains(out, `"hello"`) {
+		t.Errorf("unexpected json: %s", out)
+	}
+	// should be newline-delimited (one JSON object per line)
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line for 1 row, got %d", len(lines))
+	}
 }
 
 func TestRenderDispatcher(t *testing.T) {
-    rows := []format.Row{row{"a", "b"}}
-    headers := []string{"X", "Y"}
+	rows := []format.Row{row{"a", "b"}}
+	headers := []string{"X", "Y"}
 
-    if out := format.Render("text", headers, rows, false); !strings.Contains(out, "a") {
-        t.Errorf("text render failed: %s", out)
-    }
-    if out := format.Render("table", headers, rows, false); !strings.Contains(out, "X") {
-        t.Errorf("table render failed: %s", out)
-    }
-    if out := format.Render("json", headers, rows, false); !strings.Contains(out, `"X"`) {
-        t.Errorf("json render failed: %s", out)
-    }
-    // unknown format falls back to text
-    if out := format.Render("unknown", headers, rows, false); !strings.Contains(out, "a") {
-        t.Errorf("unknown format fallback failed: %s", out)
-    }
+	if out := format.Render("text", headers, rows, false); !strings.Contains(out, "a") {
+		t.Errorf("text render failed: %s", out)
+	}
+	if out := format.Render("table", headers, rows, false); !strings.Contains(out, "X") {
+		t.Errorf("table render failed: %s", out)
+	}
+	if out := format.Render("json", headers, rows, false); !strings.Contains(out, `"X"`) {
+		t.Errorf("json render failed: %s", out)
+	}
+	// unknown format falls back to text
+	if out := format.Render("unknown", headers, rows, false); !strings.Contains(out, "a") {
+		t.Errorf("unknown format fallback failed: %s", out)
+	}
 }

--- a/internal/format/human.go
+++ b/internal/format/human.go
@@ -1,43 +1,43 @@
 package format
 
 import (
-    "fmt"
-    "time"
+	"fmt"
+	"time"
 )
 
 // Age returns a human-readable relative time string (e.g. "5m ago").
 func Age(t time.Time) string {
-    d := time.Since(t)
-    switch {
-    case d < time.Minute:
-        return fmt.Sprintf("%ds ago", int(d.Seconds()))
-    case d < time.Hour:
-        return fmt.Sprintf("%dm ago", int(d.Minutes()))
-    case d < 24*time.Hour:
-        return fmt.Sprintf("%dh ago", int(d.Hours()))
-    default:
-        return fmt.Sprintf("%dd ago", int(d.Hours()/24))
-    }
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
 }
 
 // Mem formats a byte count as megabytes (e.g. "12.3MB").
 func Mem(bytes uint64) string {
-    return fmt.Sprintf("%.1fMB", float64(bytes)/1024/1024)
+	return fmt.Sprintf("%.1fMB", float64(bytes)/1024/1024)
 }
 
 // Duration formats a duration as a compact string (e.g. "2h30m", "45s").
 func Duration(d time.Duration) string {
-    h := int(d.Hours())
-    m := int(d.Minutes()) % 60
-    s := int(d.Seconds()) % 60
-    switch {
-    case h >= 24:
-        return fmt.Sprintf("%dd%dh", h/24, h%24)
-    case h > 0:
-        return fmt.Sprintf("%dh%dm", h, m)
-    case m > 0:
-        return fmt.Sprintf("%dm", m)
-    default:
-        return fmt.Sprintf("%ds", s)
-    }
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	switch {
+	case h >= 24:
+		return fmt.Sprintf("%dd%dh", h/24, h%24)
+	case h > 0:
+		return fmt.Sprintf("%dh%dm", h, m)
+	case m > 0:
+		return fmt.Sprintf("%dm", m)
+	default:
+		return fmt.Sprintf("%ds", s)
+	}
 }

--- a/internal/format/human_test.go
+++ b/internal/format/human_test.go
@@ -1,62 +1,62 @@
 package format_test
 
 import (
-    "testing"
-    "time"
+	"testing"
+	"time"
 
-    "github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/format"
 )
 
 func TestAge(t *testing.T) {
-    now := time.Now()
-    cases := []struct {
-        t    time.Time
-        want string
-    }{
-        {now.Add(-30 * time.Second), "30s ago"},
-        {now.Add(-5 * time.Minute), "5m ago"},
-        {now.Add(-3 * time.Hour), "3h ago"},
-        {now.Add(-49 * time.Hour), "2d ago"},
-    }
-    for _, c := range cases {
-        got := format.Age(c.t)
-        if got != c.want {
-            t.Errorf("Age(%v) = %q, want %q", c.t, got, c.want)
-        }
-    }
+	now := time.Now()
+	cases := []struct {
+		t    time.Time
+		want string
+	}{
+		{now.Add(-30 * time.Second), "30s ago"},
+		{now.Add(-5 * time.Minute), "5m ago"},
+		{now.Add(-3 * time.Hour), "3h ago"},
+		{now.Add(-49 * time.Hour), "2d ago"},
+	}
+	for _, c := range cases {
+		got := format.Age(c.t)
+		if got != c.want {
+			t.Errorf("Age(%v) = %q, want %q", c.t, got, c.want)
+		}
+	}
 }
 
 func TestMem(t *testing.T) {
-    cases := []struct {
-        bytes uint64
-        want  string
-    }{
-        {0, "0.0MB"},
-        {1024 * 1024, "1.0MB"},
-        {512 * 1024 * 1024, "512.0MB"},
-    }
-    for _, c := range cases {
-        got := format.Mem(c.bytes)
-        if got != c.want {
-            t.Errorf("Mem(%d) = %q, want %q", c.bytes, got, c.want)
-        }
-    }
+	cases := []struct {
+		bytes uint64
+		want  string
+	}{
+		{0, "0.0MB"},
+		{1024 * 1024, "1.0MB"},
+		{512 * 1024 * 1024, "512.0MB"},
+	}
+	for _, c := range cases {
+		got := format.Mem(c.bytes)
+		if got != c.want {
+			t.Errorf("Mem(%d) = %q, want %q", c.bytes, got, c.want)
+		}
+	}
 }
 
 func TestDuration(t *testing.T) {
-    cases := []struct {
-        d    time.Duration
-        want string
-    }{
-        {45 * time.Second, "45s"},
-        {5 * time.Minute, "5m"},
-        {2*time.Hour + 30*time.Minute, "2h30m"},
-        {50 * time.Hour, "2d2h"},
-    }
-    for _, c := range cases {
-        got := format.Duration(c.d)
-        if got != c.want {
-            t.Errorf("Duration(%v) = %q, want %q", c.d, got, c.want)
-        }
-    }
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{45 * time.Second, "45s"},
+		{5 * time.Minute, "5m"},
+		{2*time.Hour + 30*time.Minute, "2h30m"},
+		{50 * time.Hour, "2d2h"},
+	}
+	for _, c := range cases {
+		got := format.Duration(c.d)
+		if got != c.want {
+			t.Errorf("Duration(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
 }

--- a/internal/format/json.go
+++ b/internal/format/json.go
@@ -1,25 +1,25 @@
 package format
 
 import (
-    "encoding/json"
-    "strings"
+	"encoding/json"
+	"strings"
 )
 
 func JSON(headers []string, rows []Row) string {
-    var sb strings.Builder
-    for i, row := range rows {
-        fields := row.Fields()
-        m := make(map[string]string, len(headers))
-        for j, h := range headers {
-            if j < len(fields) {
-                m[h] = fields[j]
-            }
-        }
-        b, _ := json.Marshal(m)
-        sb.Write(b)
-        if i < len(rows)-1 {
-            sb.WriteString("\n")
-        }
-    }
-    return sb.String()
+	var sb strings.Builder
+	for i, row := range rows {
+		fields := row.Fields()
+		m := make(map[string]string, len(headers))
+		for j, h := range headers {
+			if j < len(fields) {
+				m[h] = fields[j]
+			}
+		}
+		b, _ := json.Marshal(m)
+		sb.Write(b)
+		if i < len(rows)-1 {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
 }

--- a/internal/format/path.go
+++ b/internal/format/path.go
@@ -1,23 +1,23 @@
 package format
 
 import (
-    "strings"
+	"strings"
 
-    "github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 // ShortenPath replaces the longest matching prefix in path with its alias.
 // aliases must be pre-sorted longest-prefix-first (guaranteed by config.Load).
 func ShortenPath(path string, aliases []config.PathAlias) string {
-    for _, a := range aliases {
-        rest := strings.TrimPrefix(path, a.Prefix)
-        if rest == path {
-            continue // no prefix match
-        }
-        if rest != "" && rest[0] != '/' {
-            continue // matched across a directory name boundary
-        }
-        return a.Replace + rest
-    }
-    return path
+	for _, a := range aliases {
+		rest := strings.TrimPrefix(path, a.Prefix)
+		if rest == path {
+			continue // no prefix match
+		}
+		if rest != "" && rest[0] != '/' {
+			continue // matched across a directory name boundary
+		}
+		return a.Replace + rest
+	}
+	return path
 }

--- a/internal/format/path_test.go
+++ b/internal/format/path_test.go
@@ -1,80 +1,80 @@
 package format_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/format"
 )
 
 func TestShortenPath_NoAliases(t *testing.T) {
-    got := format.ShortenPath("/home/user/projects/foo", nil)
-    if got != "/home/user/projects/foo" {
-        t.Errorf("expected unchanged, got %q", got)
-    }
+	got := format.ShortenPath("/home/user/projects/foo", nil)
+	if got != "/home/user/projects/foo" {
+		t.Errorf("expected unchanged, got %q", got)
+	}
 }
 
 func TestShortenPath_NoMatch(t *testing.T) {
-    aliases := []config.PathAlias{
-        {Prefix: "/other", Replace: "o"},
-    }
-    got := format.ShortenPath("/home/user/projects/foo", aliases)
-    if got != "/home/user/projects/foo" {
-        t.Errorf("expected unchanged, got %q", got)
-    }
+	aliases := []config.PathAlias{
+		{Prefix: "/other", Replace: "o"},
+	}
+	got := format.ShortenPath("/home/user/projects/foo", aliases)
+	if got != "/home/user/projects/foo" {
+		t.Errorf("expected unchanged, got %q", got)
+	}
 }
 
 func TestShortenPath_ExactMatch(t *testing.T) {
-    aliases := []config.PathAlias{
-        {Prefix: "/home/user", Replace: "~"},
-    }
-    got := format.ShortenPath("/home/user", aliases)
-    if got != "~" {
-        t.Errorf("expected ~, got %q", got)
-    }
+	aliases := []config.PathAlias{
+		{Prefix: "/home/user", Replace: "~"},
+	}
+	got := format.ShortenPath("/home/user", aliases)
+	if got != "~" {
+		t.Errorf("expected ~, got %q", got)
+	}
 }
 
 func TestShortenPath_PrefixMatch(t *testing.T) {
-    aliases := []config.PathAlias{
-        {Prefix: "/home/user", Replace: "~"},
-    }
-    got := format.ShortenPath("/home/user/projects/foo", aliases)
-    if got != "~/projects/foo" {
-        t.Errorf("expected ~/projects/foo, got %q", got)
-    }
+	aliases := []config.PathAlias{
+		{Prefix: "/home/user", Replace: "~"},
+	}
+	got := format.ShortenPath("/home/user/projects/foo", aliases)
+	if got != "~/projects/foo" {
+		t.Errorf("expected ~/projects/foo, got %q", got)
+	}
 }
 
 func TestShortenPath_LongestPrefixWins(t *testing.T) {
-    // Aliases must arrive pre-sorted longest-first (as config.Load guarantees).
-    aliases := []config.PathAlias{
-        {Prefix: "/home/user/projects", Replace: "proj"},
-        {Prefix: "/home/user", Replace: "~"},
-    }
-    got := format.ShortenPath("/home/user/projects/foo", aliases)
-    if got != "proj/foo" {
-        t.Errorf("expected proj/foo, got %q", got)
-    }
+	// Aliases must arrive pre-sorted longest-first (as config.Load guarantees).
+	aliases := []config.PathAlias{
+		{Prefix: "/home/user/projects", Replace: "proj"},
+		{Prefix: "/home/user", Replace: "~"},
+	}
+	got := format.ShortenPath("/home/user/projects/foo", aliases)
+	if got != "proj/foo" {
+		t.Errorf("expected proj/foo, got %q", got)
+	}
 }
 
 func TestShortenPath_FirstAliasApplied(t *testing.T) {
-    // Shorter prefix is first — it should still match (not skip to longer one).
-    aliases := []config.PathAlias{
-        {Prefix: "/home/user", Replace: "~"},
-        {Prefix: "/home/user/projects", Replace: "proj"},
-    }
-    got := format.ShortenPath("/home/user/projects/foo", aliases)
-    // First match wins: ~ wins here because it comes first in this list.
-    if got != "~/projects/foo" {
-        t.Errorf("expected ~/projects/foo, got %q", got)
-    }
+	// Shorter prefix is first — it should still match (not skip to longer one).
+	aliases := []config.PathAlias{
+		{Prefix: "/home/user", Replace: "~"},
+		{Prefix: "/home/user/projects", Replace: "proj"},
+	}
+	got := format.ShortenPath("/home/user/projects/foo", aliases)
+	// First match wins: ~ wins here because it comes first in this list.
+	if got != "~/projects/foo" {
+		t.Errorf("expected ~/projects/foo, got %q", got)
+	}
 }
 
 func TestShortenPath_NoFalsePartialMatch(t *testing.T) {
-    aliases := []config.PathAlias{
-        {Prefix: "/home/user", Replace: "~"},
-    }
-    got := format.ShortenPath("/home/userdata/foo", aliases)
-    if got != "/home/userdata/foo" {
-        t.Errorf("expected unchanged path, got %q", got)
-    }
+	aliases := []config.PathAlias{
+		{Prefix: "/home/user", Replace: "~"},
+	}
+	got := format.ShortenPath("/home/userdata/foo", aliases)
+	if got != "/home/userdata/foo" {
+		t.Errorf("expected unchanged path, got %q", got)
+	}
 }

--- a/internal/format/table.go
+++ b/internal/format/table.go
@@ -1,56 +1,56 @@
 package format
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 )
 
 const ansibold = "\033[1m"
 const ansireset = "\033[0m"
 
 func Table(headers []string, rows []Row, isTTY bool) string {
-    widths := make([]int, len(headers))
-    for i, h := range headers {
-        widths[i] = len(h)
-    }
-    allFields := make([][]string, len(rows))
-    for r, row := range rows {
-        fields := row.Fields()
-        allFields[r] = fields
-        for i := 0; i < len(headers) && i < len(fields); i++ {
-            if len(fields[i]) > widths[i] {
-                widths[i] = len(fields[i])
-            }
-        }
-    }
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	allFields := make([][]string, len(rows))
+	for r, row := range rows {
+		fields := row.Fields()
+		allFields[r] = fields
+		for i := 0; i < len(headers) && i < len(fields); i++ {
+			if len(fields[i]) > widths[i] {
+				widths[i] = len(fields[i])
+			}
+		}
+	}
 
-    var sb strings.Builder
-    for i, h := range headers {
-        if isTTY {
-            sb.WriteString(ansibold)
-        }
-        sb.WriteString(fmt.Sprintf("%-*s", widths[i], h))
-        if isTTY {
-            sb.WriteString(ansireset)
-        }
-        if i < len(headers)-1 {
-            sb.WriteString("  ")
-        }
-    }
-    sb.WriteString("\n")
+	var sb strings.Builder
+	for i, h := range headers {
+		if isTTY {
+			sb.WriteString(ansibold)
+		}
+		sb.WriteString(fmt.Sprintf("%-*s", widths[i], h))
+		if isTTY {
+			sb.WriteString(ansireset)
+		}
+		if i < len(headers)-1 {
+			sb.WriteString("  ")
+		}
+	}
+	sb.WriteString("\n")
 
-    for _, fields := range allFields {
-        for i := 0; i < len(headers); i++ {
-            val := ""
-            if i < len(fields) {
-                val = fields[i]
-            }
-            sb.WriteString(fmt.Sprintf("%-*s", widths[i], val))
-            if i < len(headers)-1 {
-                sb.WriteString("  ")
-            }
-        }
-        sb.WriteString("\n")
-    }
-    return strings.TrimRight(sb.String(), "\n")
+	for _, fields := range allFields {
+		for i := 0; i < len(headers); i++ {
+			val := ""
+			if i < len(fields) {
+				val = fields[i]
+			}
+			sb.WriteString(fmt.Sprintf("%-*s", widths[i], val))
+			if i < len(headers)-1 {
+				sb.WriteString("  ")
+			}
+		}
+		sb.WriteString("\n")
+	}
+	return strings.TrimRight(sb.String(), "\n")
 }

--- a/internal/format/text.go
+++ b/internal/format/text.go
@@ -3,19 +3,19 @@ package format
 import "strings"
 
 func Text(headers []string, rows []Row) string {
-    var sb strings.Builder
-    for i, row := range rows {
-        fields := row.Fields()
-        for j, h := range headers {
-            val := ""
-            if j < len(fields) {
-                val = fields[j]
-            }
-            sb.WriteString(h + ": " + val + "\n")
-        }
-        if i < len(rows)-1 {
-            sb.WriteString("\n")
-        }
-    }
-    return sb.String()
+	var sb strings.Builder
+	for i, row := range rows {
+		fields := row.Fields()
+		for j, h := range headers {
+			val := ""
+			if j < len(fields) {
+				val = fields[j]
+			}
+			sb.WriteString(h + ": " + val + "\n")
+		}
+		if i < len(rows)-1 {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
 }

--- a/internal/git/concurrent.go
+++ b/internal/git/concurrent.go
@@ -1,7 +1,7 @@
 package git
 
 import (
-    "sync"
+	"sync"
 )
 
 // concurrencyCap limits parallel git subprocesses.
@@ -9,36 +9,36 @@ const concurrencyCap = 8
 
 // ConcurrentWork is one unit of work for FetchConcurrent.
 type ConcurrentWork struct {
-    Key string // arbitrary key for the result map (e.g. session name or "session:wi:pi")
-    Dir string // directory to run git in
+	Key string // arbitrary key for the result map (e.g. session name or "session:wi:pi")
+	Dir string // directory to run git in
 }
 
 // FetchConcurrent runs git.Fetch for each work item in parallel, capped at
 // concurrencyCap goroutines. Results that error are silently omitted from the
 // returned map — callers should log if needed.
 func FetchConcurrent(work []ConcurrentWork, timeoutMs int) map[string]Info {
-    results := make(map[string]Info, len(work))
-    if len(work) == 0 {
-        return results
-    }
-    var mu sync.Mutex
-    var wg sync.WaitGroup
-    sem := make(chan struct{}, concurrencyCap)
-    for _, w := range work {
-        wg.Add(1)
-        w := w
-        go func() {
-            defer wg.Done()
-            sem <- struct{}{}
-            defer func() { <-sem }()
-            info, err := Fetch(w.Dir, timeoutMs)
-            if err == nil {
-                mu.Lock()
-                results[w.Key] = info
-                mu.Unlock()
-            }
-        }()
-    }
-    wg.Wait()
-    return results
+	results := make(map[string]Info, len(work))
+	if len(work) == 0 {
+		return results
+	}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrencyCap)
+	for _, w := range work {
+		wg.Add(1)
+		w := w
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			info, err := Fetch(w.Dir, timeoutMs)
+			if err == nil {
+				mu.Lock()
+				results[w.Key] = info
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	return results
 }

--- a/internal/git/concurrent_test.go
+++ b/internal/git/concurrent_test.go
@@ -1,25 +1,25 @@
 package git_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/git"
 )
 
 func TestFetchConcurrent_empty(t *testing.T) {
-    result := git.FetchConcurrent(nil, 200)
-    if len(result) != 0 {
-        t.Errorf("expected empty result, got %d entries", len(result))
-    }
+	result := git.FetchConcurrent(nil, 200)
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d entries", len(result))
+	}
 }
 
 func TestFetchConcurrent_invalidPath(t *testing.T) {
-    work := []git.ConcurrentWork{
-        {Key: "a", Dir: "/nonexistent/path/xyz"},
-    }
-    result := git.FetchConcurrent(work, 200)
-    // Should return empty map (errors are silently skipped — callers log if needed)
-    if len(result) != 0 {
-        t.Errorf("expected empty result for invalid path, got %d entries", len(result))
-    }
+	work := []git.ConcurrentWork{
+		{Key: "a", Dir: "/nonexistent/path/xyz"},
+	}
+	result := git.FetchConcurrent(work, 200)
+	// Should return empty map (errors are silently skipped — callers log if needed)
+	if len(result) != 0 {
+		t.Errorf("expected empty result for invalid path, got %d entries", len(result))
+	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,118 +1,118 @@
 package git
 
 import (
-    "context"
-    "fmt"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "regexp"
-    "strconv"
-    "strings"
-    "time"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type Info struct {
-    Branch   string
-    Dirty    bool
-    Ahead    int
-    Behind   int
-    Dir            string // directory passed to Fetch; set even when git is unavailable
-    IsWorktreeRoot bool   // true when Dir contains a .bare/ subdirectory
-    RepoRoot       string
-    Worktree string // non-empty when inside a linked worktree (name of the worktree)
-    PR       string
-    Loading  bool
+	Branch         string
+	Dirty          bool
+	Ahead          int
+	Behind         int
+	Dir            string // directory passed to Fetch; set even when git is unavailable
+	IsWorktreeRoot bool   // true when Dir contains a .bare/ subdirectory
+	RepoRoot       string
+	Worktree       string // non-empty when inside a linked worktree (name of the worktree)
+	PR             string
+	Loading        bool
 }
 
 var (
-    aheadRe  = regexp.MustCompile(`ahead (\d+)`)
-    behindRe = regexp.MustCompile(`behind (\d+)`)
+	aheadRe  = regexp.MustCompile(`ahead (\d+)`)
+	behindRe = regexp.MustCompile(`behind (\d+)`)
 )
 
 func ParseStatus(raw string) (Info, error) {
-    var info Info
-    lines := strings.Split(raw, "\n")
-    if len(lines) == 0 {
-        return info, fmt.Errorf("empty output")
-    }
+	var info Info
+	lines := strings.Split(raw, "\n")
+	if len(lines) == 0 {
+		return info, fmt.Errorf("empty output")
+	}
 
-    branchLine := strings.TrimPrefix(lines[0], "## ")
-    if strings.HasPrefix(branchLine, "HEAD") {
-        info.Branch = "HEAD"
-    } else {
-        parts := strings.SplitN(branchLine, "...", 2)
-        info.Branch = parts[0]
-    }
+	branchLine := strings.TrimPrefix(lines[0], "## ")
+	if strings.HasPrefix(branchLine, "HEAD") {
+		info.Branch = "HEAD"
+	} else {
+		parts := strings.SplitN(branchLine, "...", 2)
+		info.Branch = parts[0]
+	}
 
-    if m := aheadRe.FindStringSubmatch(branchLine); m != nil {
-        info.Ahead, _ = strconv.Atoi(m[1])
-    }
-    if m := behindRe.FindStringSubmatch(branchLine); m != nil {
-        info.Behind, _ = strconv.Atoi(m[1])
-    }
+	if m := aheadRe.FindStringSubmatch(branchLine); m != nil {
+		info.Ahead, _ = strconv.Atoi(m[1])
+	}
+	if m := behindRe.FindStringSubmatch(branchLine); m != nil {
+		info.Behind, _ = strconv.Atoi(m[1])
+	}
 
-    for _, line := range lines[1:] {
-        if strings.TrimSpace(line) != "" {
-            info.Dirty = true
-            break
-        }
-    }
-    return info, nil
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) != "" {
+			info.Dirty = true
+			break
+		}
+	}
+	return info, nil
 }
 
 func Fetch(dir string, timeoutMs int) (Info, error) {
-    ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
-    defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
+	defer cancel()
 
-    out, err := exec.CommandContext(ctx, "git", "-C", dir, "status", "--porcelain=v1", "-b").Output()
-    if err != nil {
-        info := Info{Dir: dir}
-        if fi, statErr := os.Stat(filepath.Join(dir, ".bare")); statErr == nil && fi.IsDir() {
-            info.IsWorktreeRoot = true
-        }
-        return info, fmt.Errorf("git status: %w", err)
-    }
-    info, err := ParseStatus(string(out))
-    if err != nil {
-        return info, err
-    }
-    info.Dir = dir
+	out, err := exec.CommandContext(ctx, "git", "-C", dir, "status", "--porcelain=v1", "-b").Output()
+	if err != nil {
+		info := Info{Dir: dir}
+		if fi, statErr := os.Stat(filepath.Join(dir, ".bare")); statErr == nil && fi.IsDir() {
+			info.IsWorktreeRoot = true
+		}
+		return info, fmt.Errorf("git status: %w", err)
+	}
+	info, err := ParseStatus(string(out))
+	if err != nil {
+		return info, err
+	}
+	info.Dir = dir
 
-    rootOut, _ := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--show-toplevel").Output()
-    info.RepoRoot = strings.TrimSpace(string(rootOut))
+	rootOut, _ := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--show-toplevel").Output()
+	info.RepoRoot = strings.TrimSpace(string(rootOut))
 
-    gitDirOut, _ := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--git-dir").Output()
-    gitDir := strings.TrimSpace(string(gitDirOut))
-    if idx := strings.Index(gitDir, "/worktrees/"); idx >= 0 {
-        info.Worktree = gitDir[idx+len("/worktrees/"):]
-    }
+	gitDirOut, _ := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--git-dir").Output()
+	gitDir := strings.TrimSpace(string(gitDirOut))
+	if idx := strings.Index(gitDir, "/worktrees/"); idx >= 0 {
+		info.Worktree = gitDir[idx+len("/worktrees/"):]
+	}
 
-    return info, nil
+	return info, nil
 }
 
 func FetchPR(dir, branch string, timeoutMs int) string {
-    ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
-    defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
+	defer cancel()
 
-    out, err := exec.CommandContext(ctx, "gh", "pr", "list",
-        "--head", branch,
-        "--state", "open",
-        "--json", "number",
-        "--jq", ".[0].number",
-    ).Output()
-    if err != nil || strings.TrimSpace(string(out)) == "" {
-        return ""
-    }
-    return "#" + strings.TrimSpace(string(out)) + " open"
+	out, err := exec.CommandContext(ctx, "gh", "pr", "list",
+		"--head", branch,
+		"--state", "open",
+		"--json", "number",
+		"--jq", ".[0].number",
+	).Output()
+	if err != nil || strings.TrimSpace(string(out)) == "" {
+		return ""
+	}
+	return "#" + strings.TrimSpace(string(out)) + " open"
 }
 
 func IsDescendant(child, parent string) bool {
-    if child == "" || parent == "" {
-        return false
-    }
-    if !strings.HasSuffix(parent, "/") {
-        parent += "/"
-    }
-    return strings.HasPrefix(child, parent)
+	if child == "" || parent == "" {
+		return false
+	}
+	if !strings.HasSuffix(parent, "/") {
+		parent += "/"
+	}
+	return strings.HasPrefix(child, parent)
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,88 +1,88 @@
 package git_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/git"
 )
 
 func TestParseStatusAheadBehindDirty(t *testing.T) {
-    raw := "## main...origin/main [ahead 2, behind 1]\n M file.go\n"
-    info, err := git.ParseStatus(raw)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if info.Branch != "main" {
-        t.Errorf("expected main, got %s", info.Branch)
-    }
-    if info.Ahead != 2 {
-        t.Errorf("expected ahead=2, got %d", info.Ahead)
-    }
-    if info.Behind != 1 {
-        t.Errorf("expected behind=1, got %d", info.Behind)
-    }
-    if !info.Dirty {
-        t.Error("expected dirty=true")
-    }
+	raw := "## main...origin/main [ahead 2, behind 1]\n M file.go\n"
+	info, err := git.ParseStatus(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Branch != "main" {
+		t.Errorf("expected main, got %s", info.Branch)
+	}
+	if info.Ahead != 2 {
+		t.Errorf("expected ahead=2, got %d", info.Ahead)
+	}
+	if info.Behind != 1 {
+		t.Errorf("expected behind=1, got %d", info.Behind)
+	}
+	if !info.Dirty {
+		t.Error("expected dirty=true")
+	}
 }
 
 func TestParseStatusClean(t *testing.T) {
-    raw := "## feat/thing...origin/feat/thing\n"
-    info, err := git.ParseStatus(raw)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if info.Dirty {
-        t.Error("expected clean")
-    }
-    if info.Ahead != 0 || info.Behind != 0 {
-        t.Errorf("expected 0/0, got %d/%d", info.Ahead, info.Behind)
-    }
-    if info.Branch != "feat/thing" {
-        t.Errorf("expected feat/thing, got %s", info.Branch)
-    }
+	raw := "## feat/thing...origin/feat/thing\n"
+	info, err := git.ParseStatus(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Dirty {
+		t.Error("expected clean")
+	}
+	if info.Ahead != 0 || info.Behind != 0 {
+		t.Errorf("expected 0/0, got %d/%d", info.Ahead, info.Behind)
+	}
+	if info.Branch != "feat/thing" {
+		t.Errorf("expected feat/thing, got %s", info.Branch)
+	}
 }
 
 func TestParseStatusDetached(t *testing.T) {
-    raw := "## HEAD (no branch)\n"
-    info, err := git.ParseStatus(raw)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if info.Branch != "HEAD" {
-        t.Errorf("expected HEAD, got %s", info.Branch)
-    }
+	raw := "## HEAD (no branch)\n"
+	info, err := git.ParseStatus(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Branch != "HEAD" {
+		t.Errorf("expected HEAD, got %s", info.Branch)
+	}
 }
 
 func TestParseStatusNoRemote(t *testing.T) {
-    // local branch with no remote tracking
-    raw := "## localonly\n"
-    info, err := git.ParseStatus(raw)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if info.Branch != "localonly" {
-        t.Errorf("expected localonly, got %s", info.Branch)
-    }
-    if info.Ahead != 0 || info.Behind != 0 {
-        t.Errorf("expected 0/0, got %d/%d", info.Ahead, info.Behind)
-    }
+	// local branch with no remote tracking
+	raw := "## localonly\n"
+	info, err := git.ParseStatus(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Branch != "localonly" {
+		t.Errorf("expected localonly, got %s", info.Branch)
+	}
+	if info.Ahead != 0 || info.Behind != 0 {
+		t.Errorf("expected 0/0, got %d/%d", info.Ahead, info.Behind)
+	}
 }
 
 func TestIsDescendant(t *testing.T) {
-    if !git.IsDescendant("/home/dev/project/ui", "/home/dev/project") {
-        t.Error("expected ui to be descendant of project")
-    }
-    if git.IsDescendant("/home/dev/other", "/home/dev/project") {
-        t.Error("expected other NOT to be descendant of project")
-    }
-    if git.IsDescendant("/home/dev/project", "/home/dev/project") {
-        t.Error("exact match should not count as descendant")
-    }
-    if git.IsDescendant("/home/dev/projectx", "/home/dev/project") {
-        t.Error("prefix-but-not-path-component should not count as descendant")
-    }
-    if git.IsDescendant("", "/home/dev/project") {
-        t.Error("empty child should not be descendant")
-    }
+	if !git.IsDescendant("/home/dev/project/ui", "/home/dev/project") {
+		t.Error("expected ui to be descendant of project")
+	}
+	if git.IsDescendant("/home/dev/other", "/home/dev/project") {
+		t.Error("expected other NOT to be descendant of project")
+	}
+	if git.IsDescendant("/home/dev/project", "/home/dev/project") {
+		t.Error("exact match should not count as descendant")
+	}
+	if git.IsDescendant("/home/dev/projectx", "/home/dev/project") {
+		t.Error("prefix-but-not-path-component should not count as descendant")
+	}
+	if git.IsDescendant("", "/home/dev/project") {
+		t.Error("empty child should not be descendant")
+	}
 }

--- a/internal/git/indicators.go
+++ b/internal/git/indicators.go
@@ -1,21 +1,21 @@
 package git
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 )
 
 // Indicators returns a compact string of git status indicators (e.g. "↑1 ↓2 *").
 func Indicators(info Info) string {
-    var parts []string
-    if info.Ahead > 0 {
-        parts = append(parts, fmt.Sprintf("↑%d", info.Ahead))
-    }
-    if info.Behind > 0 {
-        parts = append(parts, fmt.Sprintf("↓%d", info.Behind))
-    }
-    if info.Dirty {
-        parts = append(parts, "*")
-    }
-    return strings.Join(parts, " ")
+	var parts []string
+	if info.Ahead > 0 {
+		parts = append(parts, fmt.Sprintf("↑%d", info.Ahead))
+	}
+	if info.Behind > 0 {
+		parts = append(parts, fmt.Sprintf("↓%d", info.Behind))
+	}
+	if info.Dirty {
+		parts = append(parts, "*")
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/git/indicators_test.go
+++ b/internal/git/indicators_test.go
@@ -1,26 +1,26 @@
 package git_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/git"
 )
 
 func TestIndicators(t *testing.T) {
-    cases := []struct {
-        info git.Info
-        want string
-    }{
-        {git.Info{}, ""},
-        {git.Info{Ahead: 2}, "↑2"},
-        {git.Info{Behind: 1}, "↓1"},
-        {git.Info{Dirty: true}, "*"},
-        {git.Info{Ahead: 1, Behind: 2, Dirty: true}, "↑1 ↓2 *"},
-    }
-    for _, c := range cases {
-        got := git.Indicators(c.info)
-        if got != c.want {
-            t.Errorf("Indicators(%+v) = %q, want %q", c.info, got, c.want)
-        }
-    }
+	cases := []struct {
+		info git.Info
+		want string
+	}{
+		{git.Info{}, ""},
+		{git.Info{Ahead: 2}, "↑2"},
+		{git.Info{Behind: 1}, "↓1"},
+		{git.Info{Dirty: true}, "*"},
+		{git.Info{Ahead: 1, Behind: 2, Dirty: true}, "↑1 ↓2 *"},
+	}
+	for _, c := range cases {
+		got := git.Indicators(c.info)
+		if got != c.want {
+			t.Errorf("Indicators(%+v) = %q, want %q", c.info, got, c.want)
+		}
+	}
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,41 +1,41 @@
 package log
 
 import (
-    "fmt"
-    "io"
-    "log/slog"
-    "os"
-    "path/filepath"
-    "strings"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 // Level mirrors slog.Level but adds LevelOff.
 type Level = slog.Level
 
 const (
-    LevelDebug = slog.LevelDebug
-    LevelInfo  = slog.LevelInfo
-    LevelWarn  = slog.LevelWarn
-    LevelError = slog.LevelError
-    LevelOff   = slog.Level(100) // above all real levels
+	LevelDebug = slog.LevelDebug
+	LevelInfo  = slog.LevelInfo
+	LevelWarn  = slog.LevelWarn
+	LevelError = slog.LevelError
+	LevelOff   = slog.Level(100) // above all real levels
 )
 
 // ParseLevel converts a string to a Level. Case-insensitive.
 func ParseLevel(s string) (Level, error) {
-    switch strings.ToLower(s) {
-    case "off":
-        return LevelOff, nil
-    case "error":
-        return LevelError, nil
-    case "warn":
-        return LevelWarn, nil
-    case "info":
-        return LevelInfo, nil
-    case "debug":
-        return LevelDebug, nil
-    default:
-        return LevelWarn, fmt.Errorf("unknown log level %q: must be off|error|warn|info|debug", s)
-    }
+	switch strings.ToLower(s) {
+	case "off":
+		return LevelOff, nil
+	case "error":
+		return LevelError, nil
+	case "warn":
+		return LevelWarn, nil
+	case "info":
+		return LevelInfo, nil
+	case "debug":
+		return LevelDebug, nil
+	default:
+		return LevelWarn, fmt.Errorf("unknown log level %q: must be off|error|warn|info|debug", s)
+	}
 }
 
 var logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: LevelOff}))
@@ -43,37 +43,37 @@ var logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level
 // SetOutput reconfigures the global logger to write to w at the given level.
 // Passing LevelOff discards all output.
 func SetOutput(w io.Writer, level Level) {
-    if level >= LevelOff {
-        logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: LevelOff}))
-        return
-    }
-    logger = slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level}))
+	if level >= LevelOff {
+		logger = slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: LevelOff}))
+		return
+	}
+	logger = slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level}))
 }
 
 // DefaultPath returns the default log file path: ~/.local/share/demux/demux.log.
 func DefaultPath() (string, error) {
-    home, err := os.UserHomeDir()
-    if err != nil {
-        return "", fmt.Errorf("home dir: %w", err)
-    }
-    return filepath.Join(home, ".local", "share", "demux", "demux.log"), nil
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".local", "share", "demux", "demux.log"), nil
 }
 
 // Open opens the log file at path (creating parent dirs as needed) and calls SetOutput.
 // Returns an io.Closer the caller should defer-close. On error, logging is silently disabled.
 func Open(path string, level Level) (io.Closer, error) {
-    if level >= LevelOff {
-        return io.NopCloser(strings.NewReader("")), nil
-    }
-    if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-        return nil, fmt.Errorf("log dir: %w", err)
-    }
-    f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
-    if err != nil {
-        return nil, fmt.Errorf("open log file: %w", err)
-    }
-    SetOutput(f, level)
-    return f, nil
+	if level >= LevelOff {
+		return io.NopCloser(strings.NewReader("")), nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("log dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+	SetOutput(f, level)
+	return f, nil
 }
 
 func Debug(msg string, args ...any) { logger.Debug(msg, args...) }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,80 +1,80 @@
 package log_test
 
 import (
-    "bytes"
-    "strings"
-    "testing"
+	"bytes"
+	"strings"
+	"testing"
 
-    demuxlog "github.com/rtalexk/demux/internal/log"
+	demuxlog "github.com/rtalexk/demux/internal/log"
 )
 
 func TestLevels(t *testing.T) {
-    var buf bytes.Buffer
-    demuxlog.SetOutput(&buf, demuxlog.LevelWarn)
+	var buf bytes.Buffer
+	demuxlog.SetOutput(&buf, demuxlog.LevelWarn)
 
-    demuxlog.Debug("debug msg")
-    demuxlog.Info("info msg")
-    demuxlog.Warn("warn msg", "key", "val")
-    demuxlog.Error("error msg")
+	demuxlog.Debug("debug msg")
+	demuxlog.Info("info msg")
+	demuxlog.Warn("warn msg", "key", "val")
+	demuxlog.Error("error msg")
 
-    out := buf.String()
-    if strings.Contains(out, "debug msg") {
-        t.Error("debug should be suppressed at warn level")
-    }
-    if strings.Contains(out, "info msg") {
-        t.Error("info should be suppressed at warn level")
-    }
-    if !strings.Contains(out, "warn msg") {
-        t.Error("warn should appear at warn level")
-    }
-    if !strings.Contains(out, "error msg") {
-        t.Error("error should appear at warn level")
-    }
+	out := buf.String()
+	if strings.Contains(out, "debug msg") {
+		t.Error("debug should be suppressed at warn level")
+	}
+	if strings.Contains(out, "info msg") {
+		t.Error("info should be suppressed at warn level")
+	}
+	if !strings.Contains(out, "warn msg") {
+		t.Error("warn should appear at warn level")
+	}
+	if !strings.Contains(out, "error msg") {
+		t.Error("error should appear at warn level")
+	}
 }
 
 func TestOff(t *testing.T) {
-    var buf bytes.Buffer
-    demuxlog.SetOutput(&buf, demuxlog.LevelOff)
-    demuxlog.Error("should not appear")
-    if buf.Len() > 0 {
-        t.Errorf("expected no output at LevelOff, got: %s", buf.String())
-    }
+	var buf bytes.Buffer
+	demuxlog.SetOutput(&buf, demuxlog.LevelOff)
+	demuxlog.Error("should not appear")
+	if buf.Len() > 0 {
+		t.Errorf("expected no output at LevelOff, got: %s", buf.String())
+	}
 }
 
 func TestDefaultPath(t *testing.T) {
-    p, err := demuxlog.DefaultPath()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if !strings.HasSuffix(p, "demux.log") {
-        t.Errorf("unexpected path: %s", p)
-    }
+	p, err := demuxlog.DefaultPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(p, "demux.log") {
+		t.Errorf("unexpected path: %s", p)
+	}
 }
 
 func TestParseLevel(t *testing.T) {
-    cases := []struct {
-        input string
-        want  demuxlog.Level
-        ok    bool
-    }{
-        {"off", demuxlog.LevelOff, true},
-        {"error", demuxlog.LevelError, true},
-        {"warn", demuxlog.LevelWarn, true},
-        {"info", demuxlog.LevelInfo, true},
-        {"debug", demuxlog.LevelDebug, true},
-        {"WARN", demuxlog.LevelWarn, true},
-        {"bad", demuxlog.LevelWarn, false},
-    }
-    for _, c := range cases {
-        got, err := demuxlog.ParseLevel(c.input)
-        if c.ok && err != nil {
-            t.Errorf("ParseLevel(%q): unexpected error: %v", c.input, err)
-        }
-        if !c.ok && err == nil {
-            t.Errorf("ParseLevel(%q): expected error", c.input)
-        }
-        if c.ok && got != c.want {
-            t.Errorf("ParseLevel(%q) = %v, want %v", c.input, got, c.want)
-        }
-    }
+	cases := []struct {
+		input string
+		want  demuxlog.Level
+		ok    bool
+	}{
+		{"off", demuxlog.LevelOff, true},
+		{"error", demuxlog.LevelError, true},
+		{"warn", demuxlog.LevelWarn, true},
+		{"info", demuxlog.LevelInfo, true},
+		{"debug", demuxlog.LevelDebug, true},
+		{"WARN", demuxlog.LevelWarn, true},
+		{"bad", demuxlog.LevelWarn, false},
+	}
+	for _, c := range cases {
+		got, err := demuxlog.ParseLevel(c.input)
+		if c.ok && err != nil {
+			t.Errorf("ParseLevel(%q): unexpected error: %v", c.input, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("ParseLevel(%q): expected error", c.input)
+		}
+		if c.ok && got != c.want {
+			t.Errorf("ParseLevel(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
 }

--- a/internal/proc/cwd.go
+++ b/internal/proc/cwd.go
@@ -1,43 +1,43 @@
 package proc
 
 import (
-    "fmt"
-    "os"
-    "os/exec"
-    "runtime"
-    "strconv"
-    "strings"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
 
-    gops "github.com/shirou/gopsutil/v3/process"
+	gops "github.com/shirou/gopsutil/v3/process"
 )
 
 // CWD returns the working directory of the given PID.
 func CWD(pid int32) (string, error) {
-    p, err := gops.NewProcess(pid)
-    if err != nil {
-        return "", err
-    }
-    cwd, err := p.Cwd()
-    if err == nil && cwd != "" {
-        return cwd, nil
-    }
-    if runtime.GOOS == "darwin" {
-        return cwdLsof(pid)
-    }
-    return "", fmt.Errorf("cwd not available for pid %d", pid)
+	p, err := gops.NewProcess(pid)
+	if err != nil {
+		return "", err
+	}
+	cwd, err := p.Cwd()
+	if err == nil && cwd != "" {
+		return cwd, nil
+	}
+	if runtime.GOOS == "darwin" {
+		return cwdLsof(pid)
+	}
+	return "", fmt.Errorf("cwd not available for pid %d", pid)
 }
 
 func cwdLsof(pid int32) (string, error) {
-    out, err := exec.Command("lsof", "-p", fmt.Sprint(pid), "-d", "cwd", "-Fn").Output()
-    if err != nil {
-        return "", err
-    }
-    for _, line := range strings.Split(string(out), "\n") {
-        if strings.HasPrefix(line, "n") {
-            return strings.TrimPrefix(line, "n"), nil
-        }
-    }
-    return "", fmt.Errorf("cwd not found in lsof output")
+	out, err := exec.Command("lsof", "-p", fmt.Sprint(pid), "-d", "cwd", "-Fn").Output()
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "n") {
+			return strings.TrimPrefix(line, "n"), nil
+		}
+	}
+	return "", fmt.Errorf("cwd not found in lsof output")
 }
 
 // CWDAll returns a map of PID -> CWD for all accessible processes using a
@@ -45,73 +45,73 @@ func cwdLsof(pid int32) (string, error) {
 // falling back to per-process gopsutil on other platforms.
 // Use this instead of calling CWD in a loop.
 func CWDAll() (map[int32]string, error) {
-    switch runtime.GOOS {
-    case "darwin":
-        return cwdAllLsof()
-    case "linux":
-        return cwdAllProc()
-    default:
-        return cwdAllGops()
-    }
+	switch runtime.GOOS {
+	case "darwin":
+		return cwdAllLsof()
+	case "linux":
+		return cwdAllProc()
+	default:
+		return cwdAllGops()
+	}
 }
 
 func cwdAllLsof() (map[int32]string, error) {
-    out, err := exec.Command("lsof", "-d", "cwd", "-Fpn").Output()
-    if err != nil {
-        return nil, fmt.Errorf("lsof: %w", err)
-    }
-    m := make(map[int32]string)
-    var currentPID int32
-    for _, line := range strings.Split(string(out), "\n") {
-        if strings.HasPrefix(line, "p") {
-            pid, err := strconv.ParseInt(strings.TrimPrefix(line, "p"), 10, 32)
-            if err == nil {
-                currentPID = int32(pid)
-            }
-        } else if strings.HasPrefix(line, "n") && currentPID != 0 {
-            m[currentPID] = strings.TrimPrefix(line, "n")
-        }
-    }
-    return m, nil
+	out, err := exec.Command("lsof", "-d", "cwd", "-Fpn").Output()
+	if err != nil {
+		return nil, fmt.Errorf("lsof: %w", err)
+	}
+	m := make(map[int32]string)
+	var currentPID int32
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "p") {
+			pid, err := strconv.ParseInt(strings.TrimPrefix(line, "p"), 10, 32)
+			if err == nil {
+				currentPID = int32(pid)
+			}
+		} else if strings.HasPrefix(line, "n") && currentPID != 0 {
+			m[currentPID] = strings.TrimPrefix(line, "n")
+		}
+	}
+	return m, nil
 }
 
 func cwdAllGops() (map[int32]string, error) {
-    pids, err := gops.Pids()
-    if err != nil {
-        return nil, fmt.Errorf("pids: %w", err)
-    }
-    m := make(map[int32]string, len(pids))
-    for _, pid := range pids {
-        p, err := gops.NewProcess(pid)
-        if err != nil {
-            continue
-        }
-        cwd, err := p.Cwd()
-        if err == nil && cwd != "" {
-            m[pid] = cwd
-        }
-    }
-    return m, nil
+	pids, err := gops.Pids()
+	if err != nil {
+		return nil, fmt.Errorf("pids: %w", err)
+	}
+	m := make(map[int32]string, len(pids))
+	for _, pid := range pids {
+		p, err := gops.NewProcess(pid)
+		if err != nil {
+			continue
+		}
+		cwd, err := p.Cwd()
+		if err == nil && cwd != "" {
+			m[pid] = cwd
+		}
+	}
+	return m, nil
 }
 
 // cwdAllProc reads /proc/{pid}/cwd symlinks directly — Linux only.
 // Faster than cwdAllGops: no gopsutil allocations, just readdir + readlink.
 func cwdAllProc() (map[int32]string, error) {
-    entries, err := os.ReadDir("/proc")
-    if err != nil {
-        return nil, fmt.Errorf("readdir /proc: %w", err)
-    }
-    m := make(map[int32]string, len(entries))
-    for _, e := range entries {
-        pid, err := strconv.ParseInt(e.Name(), 10, 32)
-        if err != nil {
-            continue // skip non-numeric entries (e.g. "self", "net")
-        }
-        link, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
-        if err != nil {
-            continue // process may have exited between readdir and readlink
-        }
-        m[int32(pid)] = link
-    }
-    return m, nil
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("readdir /proc: %w", err)
+	}
+	m := make(map[int32]string, len(entries))
+	for _, e := range entries {
+		pid, err := strconv.ParseInt(e.Name(), 10, 32)
+		if err != nil {
+			continue // skip non-numeric entries (e.g. "self", "net")
+		}
+		link, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+		if err != nil {
+			continue // process may have exited between readdir and readlink
+		}
+		m[int32(pid)] = link
+	}
+	return m, nil
 }

--- a/internal/proc/cwd_test.go
+++ b/internal/proc/cwd_test.go
@@ -1,42 +1,42 @@
 package proc_test
 
 import (
-    "os"
-    "testing"
+	"os"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/proc"
 )
 
 func TestCWDCurrentProcess(t *testing.T) {
-    pid := int32(os.Getpid())
-    cwd, err := proc.CWD(pid)
-    if err != nil {
-        t.Skipf("CWD not resolvable on this platform: %v", err)
-    }
-    if cwd == "" {
-        t.Error("expected non-empty cwd")
-    }
+	pid := int32(os.Getpid())
+	cwd, err := proc.CWD(pid)
+	if err != nil {
+		t.Skipf("CWD not resolvable on this platform: %v", err)
+	}
+	if cwd == "" {
+		t.Error("expected non-empty cwd")
+	}
 }
 
 func TestCWDAll_ContainsSelf(t *testing.T) {
-    m, err := proc.CWDAll()
-    if err != nil {
-        t.Skipf("CWDAll not available: %v", err)
-    }
-    pid := int32(os.Getpid())
-    cwd, ok := m[pid]
-    if !ok {
-        t.Fatalf("own PID %d not in CWDAll result", pid)
-    }
-    if cwd == "" {
-        t.Error("expected non-empty cwd for own PID")
-    }
+	m, err := proc.CWDAll()
+	if err != nil {
+		t.Skipf("CWDAll not available: %v", err)
+	}
+	pid := int32(os.Getpid())
+	cwd, ok := m[pid]
+	if !ok {
+		t.Fatalf("own PID %d not in CWDAll result", pid)
+	}
+	if cwd == "" {
+		t.Error("expected non-empty cwd for own PID")
+	}
 }
 
 func BenchmarkCWDAll(b *testing.B) {
-    for b.Loop() {
-        if _, err := proc.CWDAll(); err != nil {
-            b.Fatal(err)
-        }
-    }
+	for b.Loop() {
+		if _, err := proc.CWDAll(); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/internal/proc/ports.go
+++ b/internal/proc/ports.go
@@ -1,83 +1,83 @@
 package proc
 
 import (
-    "fmt"
-    "os/exec"
-    "runtime"
-    "strconv"
-    "strings"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
 )
 
 type PortInfo struct {
-    Port int
-    PID  int32
+	Port int
+	PID  int32
 }
 
 func ListeningPorts() ([]PortInfo, error) {
-    if runtime.GOOS == "darwin" {
-        out, err := exec.Command("lsof", "-iTCP", "-sTCP:LISTEN", "-n", "-P").Output()
-        if err != nil {
-            return nil, fmt.Errorf("lsof: %w", err)
-        }
-        return ParseLsofPorts(string(out))
-    }
-    out, err := exec.Command("ss", "-tlnp").Output()
-    if err != nil {
-        return nil, fmt.Errorf("ss: %w", err)
-    }
-    return parseSsPorts(string(out))
+	if runtime.GOOS == "darwin" {
+		out, err := exec.Command("lsof", "-iTCP", "-sTCP:LISTEN", "-n", "-P").Output()
+		if err != nil {
+			return nil, fmt.Errorf("lsof: %w", err)
+		}
+		return ParseLsofPorts(string(out))
+	}
+	out, err := exec.Command("ss", "-tlnp").Output()
+	if err != nil {
+		return nil, fmt.Errorf("ss: %w", err)
+	}
+	return parseSsPorts(string(out))
 }
 
 func ParseLsofPorts(raw string) ([]PortInfo, error) {
-    var ports []PortInfo
-    for i, line := range strings.Split(strings.TrimSpace(raw), "\n") {
-        if i == 0 || strings.TrimSpace(line) == "" {
-            continue // skip header
-        }
-        fields := strings.Fields(line)
-        if len(fields) < 9 {
-            continue
-        }
-        pid, err := strconv.Atoi(fields[1])
-        if err != nil {
-            continue
-        }
-        // NAME field is fields[8]: "*:3000" or "127.0.0.1:3000" — strip trailing " (LISTEN)" if present
-        name := fields[8]
-        colonIdx := strings.LastIndex(name, ":")
-        if colonIdx < 0 {
-            continue
-        }
-        portStr := name[colonIdx+1:]
-        port, err := strconv.Atoi(portStr)
-        if err != nil {
-            continue
-        }
-        ports = append(ports, PortInfo{Port: port, PID: int32(pid)})
-    }
-    return ports, nil
+	var ports []PortInfo
+	for i, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		if i == 0 || strings.TrimSpace(line) == "" {
+			continue // skip header
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 9 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[1])
+		if err != nil {
+			continue
+		}
+		// NAME field is fields[8]: "*:3000" or "127.0.0.1:3000" — strip trailing " (LISTEN)" if present
+		name := fields[8]
+		colonIdx := strings.LastIndex(name, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		portStr := name[colonIdx+1:]
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			continue
+		}
+		ports = append(ports, PortInfo{Port: port, PID: int32(pid)})
+	}
+	return ports, nil
 }
 
 func parseSsPorts(raw string) ([]PortInfo, error) {
-    var ports []PortInfo
-    for i, line := range strings.Split(strings.TrimSpace(raw), "\n") {
-        if i == 0 || strings.TrimSpace(line) == "" {
-            continue
-        }
-        fields := strings.Fields(line)
-        if len(fields) < 4 {
-            continue
-        }
-        addr := fields[3]
-        colonIdx := strings.LastIndex(addr, ":")
-        if colonIdx < 0 {
-            continue
-        }
-        port, err := strconv.Atoi(addr[colonIdx+1:])
-        if err != nil {
-            continue
-        }
-        ports = append(ports, PortInfo{Port: port})
-    }
-    return ports, nil
+	var ports []PortInfo
+	for i, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		if i == 0 || strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		addr := fields[3]
+		colonIdx := strings.LastIndex(addr, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		port, err := strconv.Atoi(addr[colonIdx+1:])
+		if err != nil {
+			continue
+		}
+		ports = append(ports, PortInfo{Port: port})
+	}
+	return ports, nil
 }

--- a/internal/proc/ports_test.go
+++ b/internal/proc/ports_test.go
@@ -1,31 +1,31 @@
 package proc_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/proc"
 )
 
 func TestParseLsofPorts(t *testing.T) {
-    // Simulate `lsof -iTCP -sTCP:LISTEN -n -P` output
-    raw := `COMMAND  PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
+	// Simulate `lsof -iTCP -sTCP:LISTEN -n -P` output
+	raw := `COMMAND  PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
 node    1234  dev  23u  IPv4 0x1      0t0  TCP *:3000 (LISTEN)
 node    5678  dev  24u  IPv6 0x2      0t0  TCP *:5173 (LISTEN)`
 
-    ports, err := proc.ParseLsofPorts(raw)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(ports) != 2 {
-        t.Fatalf("expected 2, got %d", len(ports))
-    }
-    if ports[0].Port != 3000 {
-        t.Errorf("expected 3000, got %d", ports[0].Port)
-    }
-    if ports[0].PID != 1234 {
-        t.Errorf("expected 1234, got %d", ports[0].PID)
-    }
-    if ports[1].Port != 5173 {
-        t.Errorf("expected 5173, got %d", ports[1].Port)
-    }
+	ports, err := proc.ParseLsofPorts(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 2 {
+		t.Fatalf("expected 2, got %d", len(ports))
+	}
+	if ports[0].Port != 3000 {
+		t.Errorf("expected 3000, got %d", ports[0].Port)
+	}
+	if ports[0].PID != 1234 {
+		t.Errorf("expected 1234, got %d", ports[0].PID)
+	}
+	if ports[1].Port != 5173 {
+		t.Errorf("expected 5173, got %d", ports[1].Port)
+	}
 }

--- a/internal/proc/snapshot.go
+++ b/internal/proc/snapshot.go
@@ -1,91 +1,91 @@
 package proc
 
 import (
-    "fmt"
-    "path/filepath"
-    "regexp"
-    "strings"
-    "time"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
 
-    gops "github.com/shirou/gopsutil/v3/process"
+	gops "github.com/shirou/gopsutil/v3/process"
 )
 
 var versionRe = regexp.MustCompile(`^\d+\.\d+`)
 
 type Process struct {
-    PID     int32
-    PPID    int32
-    Name    string
-    Cmdline string
-    CPU     float64
-    MemRSS  uint64
-    Uptime  time.Duration
+	PID     int32
+	PPID    int32
+	Name    string
+	Cmdline string
+	CPU     float64
+	MemRSS  uint64
+	Uptime  time.Duration
 }
 
 func Snapshot() ([]Process, error) {
-    pids, err := gops.Pids()
-    if err != nil {
-        return nil, fmt.Errorf("pids: %w", err)
-    }
+	pids, err := gops.Pids()
+	if err != nil {
+		return nil, fmt.Errorf("pids: %w", err)
+	}
 
-    procs := make([]Process, 0, len(pids))
-    for _, pid := range pids {
-        p, err := gops.NewProcess(pid)
-        if err != nil {
-            continue
-        }
-        name, _ := p.Name()
-        ppid, _ := p.Ppid()
-        cmdline, _ := p.Cmdline()
-        cpu, _ := p.CPUPercent()
-        mem, _ := p.MemoryInfo()
-        created, _ := p.CreateTime()
+	procs := make([]Process, 0, len(pids))
+	for _, pid := range pids {
+		p, err := gops.NewProcess(pid)
+		if err != nil {
+			continue
+		}
+		name, _ := p.Name()
+		ppid, _ := p.Ppid()
+		cmdline, _ := p.Cmdline()
+		cpu, _ := p.CPUPercent()
+		mem, _ := p.MemoryInfo()
+		created, _ := p.CreateTime()
 
-        var rss uint64
-        if mem != nil {
-            rss = mem.RSS
-        }
-        var uptime time.Duration
-        if created > 0 {
-            uptime = time.Since(time.UnixMilli(created))
-        }
+		var rss uint64
+		if mem != nil {
+			rss = mem.RSS
+		}
+		var uptime time.Duration
+		if created > 0 {
+			uptime = time.Since(time.UnixMilli(created))
+		}
 
-        procs = append(procs, Process{
-            PID:     pid,
-            PPID:    ppid,
-            Name:    name,
-            Cmdline: cmdline,
-            CPU:     cpu,
-            MemRSS:  rss,
-            Uptime:  uptime,
-        })
-    }
-    return procs, nil
+		procs = append(procs, Process{
+			PID:     pid,
+			PPID:    ppid,
+			Name:    name,
+			Cmdline: cmdline,
+			CPU:     cpu,
+			MemRSS:  rss,
+			Uptime:  uptime,
+		})
+	}
+	return procs, nil
 }
 
 // FriendlyName returns a human-readable process name. The OS-level Name is
 // often a truncated or version-string form (e.g. "2.1.83" for Claude Code).
 // When Name looks like a version number we parse argv[0] from Cmdline instead.
 func (p Process) FriendlyName() string {
-    if p.Name != "" && !versionRe.MatchString(p.Name) {
-        return p.Name
-    }
-    // argv[0] is the first whitespace-delimited token of cmdline
-    argv0 := strings.Fields(p.Cmdline)
-    if len(argv0) == 0 {
-        return p.Name
-    }
-    base := filepath.Base(argv0[0])
-    if base == "" || base == "." {
-        return p.Name
-    }
-    return base
+	if p.Name != "" && !versionRe.MatchString(p.Name) {
+		return p.Name
+	}
+	// argv[0] is the first whitespace-delimited token of cmdline
+	argv0 := strings.Fields(p.Cmdline)
+	if len(argv0) == 0 {
+		return p.Name
+	}
+	base := filepath.Base(argv0[0])
+	if base == "" || base == "." {
+		return p.Name
+	}
+	return base
 }
 
 func BuildTree(procs []Process) map[int32][]Process {
-    tree := make(map[int32][]Process, len(procs))
-    for _, p := range procs {
-        tree[p.PPID] = append(tree[p.PPID], p)
-    }
-    return tree
+	tree := make(map[int32][]Process, len(procs))
+	for _, p := range procs {
+		tree[p.PPID] = append(tree[p.PPID], p)
+	}
+	return tree
 }

--- a/internal/proc/snapshot_test.go
+++ b/internal/proc/snapshot_test.go
@@ -1,44 +1,44 @@
 package proc_test
 
 import (
-    "os"
-    "testing"
+	"os"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/proc"
 )
 
 func TestSnapshot(t *testing.T) {
-    procs, err := proc.Snapshot()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(procs) == 0 {
-        t.Error("expected at least one process")
-    }
-    found := false
-    for _, p := range procs {
-        if p.PID == int32(os.Getpid()) {
-            found = true
-            break
-        }
-    }
-    if !found {
-        t.Error("current process not found in snapshot")
-    }
+	procs, err := proc.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(procs) == 0 {
+		t.Error("expected at least one process")
+	}
+	found := false
+	for _, p := range procs {
+		if p.PID == int32(os.Getpid()) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("current process not found in snapshot")
+	}
 }
 
 func TestBuildTree(t *testing.T) {
-    procs := []proc.Process{
-        {PID: 1, PPID: 0, Name: "init"},
-        {PID: 10, PPID: 1, Name: "shell"},
-        {PID: 20, PPID: 10, Name: "node"},
-    }
-    tree := proc.BuildTree(procs)
-    children := tree[10]
-    if len(children) != 1 || children[0].PID != 20 {
-        t.Errorf("unexpected children of pid 10: %v", children)
-    }
-    if len(tree[1]) != 1 || tree[1][0].PID != 10 {
-        t.Errorf("unexpected children of pid 1: %v", tree[1])
-    }
+	procs := []proc.Process{
+		{PID: 1, PPID: 0, Name: "init"},
+		{PID: 10, PPID: 1, Name: "shell"},
+		{PID: 20, PPID: 10, Name: "node"},
+	}
+	tree := proc.BuildTree(procs)
+	children := tree[10]
+	if len(children) != 1 || children[0].PID != 20 {
+		t.Errorf("unexpected children of pid 10: %v", children)
+	}
+	if len(tree[1]) != 1 || tree[1][0].PID != 10 {
+		t.Errorf("unexpected children of pid 1: %v", tree[1])
+	}
 }

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -1,196 +1,196 @@
 package query
 
 import (
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/tmux"
-    "github.com/sahilm/fuzzy"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+	"github.com/sahilm/fuzzy"
 )
 
 type QueryScope int
 
 const (
-    ScopeSession QueryScope = iota
-    ScopeWindow
-    ScopeProcess
+	ScopeSession QueryScope = iota
+	ScopeWindow
+	ScopeProcess
 )
 
 type ParsedQuery struct {
-    Raw          string
-    Scope        QueryScope
-    Term         string
-    ExtraSessions []string // non-live sessions to include in ScopeSession matching
+	Raw           string
+	Scope         QueryScope
+	Term          string
+	ExtraSessions []string // non-live sessions to include in ScopeSession matching
 }
 
 type Result struct {
-    Sessions []SessionMatch
+	Sessions []SessionMatch
 }
 
 type SessionMatch struct {
-    Name     string
-    Score    int
-    MatchPos []int
-    Windows  []WindowMatch
-    Procs    []ProcMatch
+	Name     string
+	Score    int
+	MatchPos []int
+	Windows  []WindowMatch
+	Procs    []ProcMatch
 }
 
 type WindowMatch struct {
-    Index    int
-    Name     string
-    Score    int
-    MatchPos []int
+	Index    int
+	Name     string
+	Score    int
+	MatchPos []int
 }
 
 type ProcMatch struct {
-    PID      int32
-    Name     string
-    Score    int
-    MatchPos []int
+	PID      int32
+	Name     string
+	Score    int
+	MatchPos []int
 }
 
 // Parse extracts scope and term from a raw query string.
 // A scope tag (w:, p:) must appear at the start; mid-string tags are ignored.
 // Bare text defaults to ScopeSession.
 func Parse(raw string) ParsedQuery {
-    pq := ParsedQuery{Raw: raw}
-    switch {
-    case len(raw) >= 2 && raw[:2] == "w:":
-        pq.Scope = ScopeWindow
-        pq.Term = raw[2:]
-    case len(raw) >= 2 && raw[:2] == "p:":
-        pq.Scope = ScopeProcess
-        pq.Term = raw[2:]
-    default:
-        pq.Scope = ScopeSession
-        pq.Term = raw
-    }
-    return pq
+	pq := ParsedQuery{Raw: raw}
+	switch {
+	case len(raw) >= 2 && raw[:2] == "w:":
+		pq.Scope = ScopeWindow
+		pq.Term = raw[2:]
+	case len(raw) >= 2 && raw[:2] == "p:":
+		pq.Scope = ScopeProcess
+		pq.Term = raw[2:]
+	default:
+		pq.Scope = ScopeSession
+		pq.Term = raw
+	}
+	return pq
 }
 
 // RunWith is the pure core: accepts pre-fetched data, safe to use in tests.
 func RunWith(pq ParsedQuery, panes []tmux.Pane, procs []proc.Process) Result {
-    if pq.Term == "" {
-        return Result{}
-    }
+	if pq.Term == "" {
+		return Result{}
+	}
 
-    sessions := tmux.GroupBySessions(panes)
-    tree := proc.BuildTree(procs)
+	sessions := tmux.GroupBySessions(panes)
+	tree := proc.BuildTree(procs)
 
-    acc := make(map[string]*SessionMatch, len(sessions))
-    ensure := func(name string) *SessionMatch {
-        if acc[name] == nil {
-            acc[name] = &SessionMatch{Name: name}
-        }
-        return acc[name]
-    }
-    maxScore := func(a, b int) int {
-        if a > b {
-            return a
-        }
-        return b
-    }
+	acc := make(map[string]*SessionMatch, len(sessions))
+	ensure := func(name string) *SessionMatch {
+		if acc[name] == nil {
+			acc[name] = &SessionMatch{Name: name}
+		}
+		return acc[name]
+	}
+	maxScore := func(a, b int) int {
+		if a > b {
+			return a
+		}
+		return b
+	}
 
-    // session name matching
-    if pq.Scope == ScopeSession {
-        names := make([]string, 0, len(sessions)+len(pq.ExtraSessions))
-        for name := range sessions {
-            names = append(names, name)
-        }
-        for _, name := range pq.ExtraSessions {
-            if _, exists := sessions[name]; !exists {
-                names = append(names, name)
-            }
-        }
-        for _, m := range fuzzy.Find(pq.Term, names) {
-            sm := ensure(m.Str)
-            sm.Score = maxScore(sm.Score, m.Score)
-            sm.MatchPos = m.MatchedIndexes
-        }
-    }
+	// session name matching
+	if pq.Scope == ScopeSession {
+		names := make([]string, 0, len(sessions)+len(pq.ExtraSessions))
+		for name := range sessions {
+			names = append(names, name)
+		}
+		for _, name := range pq.ExtraSessions {
+			if _, exists := sessions[name]; !exists {
+				names = append(names, name)
+			}
+		}
+		for _, m := range fuzzy.Find(pq.Term, names) {
+			sm := ensure(m.Str)
+			sm.Score = maxScore(sm.Score, m.Score)
+			sm.MatchPos = m.MatchedIndexes
+		}
+	}
 
-    // window name matching
-    if pq.Scope == ScopeWindow {
-        for sessionName, windows := range sessions {
-            winNames := make([]string, 0, len(windows))
-            // winIdxOrder maps dense slice positions → real tmux window indices,
-            // since fuzzy.Find returns m.Index as position in the input slice.
-            winIdxOrder := make([]int, 0, len(windows))
-            for idx, wPanes := range windows {
-                if len(wPanes) > 0 {
-                    winNames = append(winNames, wPanes[0].WindowName)
-                    winIdxOrder = append(winIdxOrder, idx)
-                }
-            }
-            for _, m := range fuzzy.Find(pq.Term, winNames) {
-                sm := ensure(sessionName)
-                wm := WindowMatch{
-                    Index:    winIdxOrder[m.Index],
-                    Name:     m.Str,
-                    Score:    m.Score,
-                    MatchPos: m.MatchedIndexes,
-                }
-                sm.Windows = append(sm.Windows, wm)
-                sm.Score = maxScore(sm.Score, m.Score)
-            }
-        }
-    }
+	// window name matching
+	if pq.Scope == ScopeWindow {
+		for sessionName, windows := range sessions {
+			winNames := make([]string, 0, len(windows))
+			// winIdxOrder maps dense slice positions → real tmux window indices,
+			// since fuzzy.Find returns m.Index as position in the input slice.
+			winIdxOrder := make([]int, 0, len(windows))
+			for idx, wPanes := range windows {
+				if len(wPanes) > 0 {
+					winNames = append(winNames, wPanes[0].WindowName)
+					winIdxOrder = append(winIdxOrder, idx)
+				}
+			}
+			for _, m := range fuzzy.Find(pq.Term, winNames) {
+				sm := ensure(sessionName)
+				wm := WindowMatch{
+					Index:    winIdxOrder[m.Index],
+					Name:     m.Str,
+					Score:    m.Score,
+					MatchPos: m.MatchedIndexes,
+				}
+				sm.Windows = append(sm.Windows, wm)
+				sm.Score = maxScore(sm.Score, m.Score)
+			}
+		}
+	}
 
-    // process name matching
-    if pq.Scope == ScopeProcess {
-        for sessionName, windows := range sessions {
-            var descendants []proc.Process
-            for _, wPanes := range windows {
-                for _, pane := range wPanes {
-                    descendants = append(descendants, collectDescendants(pane.PanePID, tree)...)
-                }
-            }
-            procNames := make([]string, len(descendants))
-            for i, p := range descendants {
-                procNames[i] = p.FriendlyName()
-            }
-            for _, m := range fuzzy.Find(pq.Term, procNames) {
-                sm := ensure(sessionName)
-                p := descendants[m.Index]
-                pm := ProcMatch{
-                    PID:      p.PID,
-                    Name:     m.Str,
-                    Score:    m.Score,
-                    MatchPos: m.MatchedIndexes,
-                }
-                sm.Procs = append(sm.Procs, pm)
-                sm.Score = maxScore(sm.Score, m.Score)
-            }
-        }
-    }
+	// process name matching
+	if pq.Scope == ScopeProcess {
+		for sessionName, windows := range sessions {
+			var descendants []proc.Process
+			for _, wPanes := range windows {
+				for _, pane := range wPanes {
+					descendants = append(descendants, collectDescendants(pane.PanePID, tree)...)
+				}
+			}
+			procNames := make([]string, len(descendants))
+			for i, p := range descendants {
+				procNames[i] = p.FriendlyName()
+			}
+			for _, m := range fuzzy.Find(pq.Term, procNames) {
+				sm := ensure(sessionName)
+				p := descendants[m.Index]
+				pm := ProcMatch{
+					PID:      p.PID,
+					Name:     m.Str,
+					Score:    m.Score,
+					MatchPos: m.MatchedIndexes,
+				}
+				sm.Procs = append(sm.Procs, pm)
+				sm.Score = maxScore(sm.Score, m.Score)
+			}
+		}
+	}
 
-    result := Result{Sessions: make([]SessionMatch, 0, len(acc))}
-    for _, sm := range acc {
-        result.Sessions = append(result.Sessions, *sm)
-    }
-    return result
+	result := Result{Sessions: make([]SessionMatch, 0, len(acc))}
+	for _, sm := range acc {
+		result.Sessions = append(result.Sessions, *sm)
+	}
+	return result
 }
 
 // Run fetches live tmux panes and (if needed) processes, then calls RunWith.
 func Run(pq ParsedQuery) (Result, error) {
-    panes, err := tmux.ListPanes()
-    if err != nil {
-        return Result{}, err
-    }
-    var procs []proc.Process
-    if pq.Scope == ScopeProcess {
-        procs, err = proc.Snapshot()
-        if err != nil {
-            return Result{}, err
-        }
-    }
-    return RunWith(pq, panes, procs), nil
+	panes, err := tmux.ListPanes()
+	if err != nil {
+		return Result{}, err
+	}
+	var procs []proc.Process
+	if pq.Scope == ScopeProcess {
+		procs, err = proc.Snapshot()
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	return RunWith(pq, panes, procs), nil
 }
 
 // collectDescendants does a depth-first walk of the process tree from pid.
 func collectDescendants(pid int32, tree map[int32][]proc.Process) []proc.Process {
-    var result []proc.Process
-    for _, child := range tree[pid] {
-        result = append(result, child)
-        result = append(result, collectDescendants(child.PID, tree)...)
-    }
-    return result
+	var result []proc.Process
+	for _, child := range tree[pid] {
+		result = append(result, child)
+		result = append(result, collectDescendants(child.PID, tree)...)
+	}
+	return result
 }

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,233 +1,233 @@
 package query_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/query"
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/query"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func TestParse(t *testing.T) {
-    tests := []struct {
-        raw   string
-        scope query.QueryScope
-        term  string
-    }{
-        {"", query.ScopeSession, ""},
-        {"foo", query.ScopeSession, "foo"},
-        {"w:baz", query.ScopeWindow, "baz"},
-        {"p:qux", query.ScopeProcess, "qux"},
-        {"w:my project", query.ScopeWindow, "my project"},
-        {"query1 w:query2", query.ScopeSession, "query1 w:query2"},
-    }
-    for _, tt := range tests {
-        pq := query.Parse(tt.raw)
-        if pq.Scope != tt.scope {
-            t.Errorf("Parse(%q).Scope = %v, want %v", tt.raw, pq.Scope, tt.scope)
-        }
-        if pq.Term != tt.term {
-            t.Errorf("Parse(%q).Term = %q, want %q", tt.raw, pq.Term, tt.term)
-        }
-        if pq.Raw != tt.raw {
-            t.Errorf("Parse(%q).Raw = %q, want %q", tt.raw, pq.Raw, tt.raw)
-        }
-    }
+	tests := []struct {
+		raw   string
+		scope query.QueryScope
+		term  string
+	}{
+		{"", query.ScopeSession, ""},
+		{"foo", query.ScopeSession, "foo"},
+		{"w:baz", query.ScopeWindow, "baz"},
+		{"p:qux", query.ScopeProcess, "qux"},
+		{"w:my project", query.ScopeWindow, "my project"},
+		{"query1 w:query2", query.ScopeSession, "query1 w:query2"},
+	}
+	for _, tt := range tests {
+		pq := query.Parse(tt.raw)
+		if pq.Scope != tt.scope {
+			t.Errorf("Parse(%q).Scope = %v, want %v", tt.raw, pq.Scope, tt.scope)
+		}
+		if pq.Term != tt.term {
+			t.Errorf("Parse(%q).Term = %q, want %q", tt.raw, pq.Term, tt.term)
+		}
+		if pq.Raw != tt.raw {
+			t.Errorf("Parse(%q).Raw = %q, want %q", tt.raw, pq.Raw, tt.raw)
+		}
+	}
 }
 
 func TestRun_EmptyTerm(t *testing.T) {
-    panes := []tmux.Pane{{Session: "work", WindowIndex: 0, WindowName: "main"}}
-    result := query.RunWith(query.Parse(""), panes, nil)
-    if len(result.Sessions) != 0 {
-        t.Errorf("empty term should return empty result, got %d sessions", len(result.Sessions))
-    }
+	panes := []tmux.Pane{{Session: "work", WindowIndex: 0, WindowName: "main"}}
+	result := query.RunWith(query.Parse(""), panes, nil)
+	if len(result.Sessions) != 0 {
+		t.Errorf("empty term should return empty result, got %d sessions", len(result.Sessions))
+	}
 }
 
 func TestRun_SessionScope(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "work", WindowIndex: 0, WindowName: "main", PanePID: 100},
-        {Session: "personal", WindowIndex: 0, WindowName: "vim", PanePID: 200},
-        {Session: "dots", WindowIndex: 0, WindowName: "sh", PanePID: 300},
-    }
-    result := query.RunWith(query.Parse("wor"), panes, nil)
-    if len(result.Sessions) != 1 {
-        t.Fatalf("expected 1 session match, got %d", len(result.Sessions))
-    }
-    if result.Sessions[0].Name != "work" {
-        t.Errorf("expected 'work', got %q", result.Sessions[0].Name)
-    }
-    if result.Sessions[0].Score <= 0 {
-        t.Errorf("expected positive score, got %d", result.Sessions[0].Score)
-    }
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 0, WindowName: "main", PanePID: 100},
+		{Session: "personal", WindowIndex: 0, WindowName: "vim", PanePID: 200},
+		{Session: "dots", WindowIndex: 0, WindowName: "sh", PanePID: 300},
+	}
+	result := query.RunWith(query.Parse("wor"), panes, nil)
+	if len(result.Sessions) != 1 {
+		t.Fatalf("expected 1 session match, got %d", len(result.Sessions))
+	}
+	if result.Sessions[0].Name != "work" {
+		t.Errorf("expected 'work', got %q", result.Sessions[0].Name)
+	}
+	if result.Sessions[0].Score <= 0 {
+		t.Errorf("expected positive score, got %d", result.Sessions[0].Score)
+	}
 }
 
 func TestRun_WindowScope(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "work", WindowIndex: 0, WindowName: "vim-config", PanePID: 100},
-        {Session: "work", WindowIndex: 1, WindowName: "shell", PanePID: 101},
-        {Session: "personal", WindowIndex: 0, WindowName: "htop", PanePID: 200},
-    }
-    result := query.RunWith(query.Parse("w:vim"), panes, nil)
-    if len(result.Sessions) != 1 {
-        t.Fatalf("expected 1 session, got %d", len(result.Sessions))
-    }
-    if result.Sessions[0].Name != "work" {
-        t.Errorf("expected 'work', got %q", result.Sessions[0].Name)
-    }
-    if len(result.Sessions[0].Windows) != 1 {
-        t.Fatalf("expected 1 window match, got %d", len(result.Sessions[0].Windows))
-    }
-    if result.Sessions[0].Windows[0].Name != "vim-config" {
-        t.Errorf("expected 'vim-config', got %q", result.Sessions[0].Windows[0].Name)
-    }
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 0, WindowName: "vim-config", PanePID: 100},
+		{Session: "work", WindowIndex: 1, WindowName: "shell", PanePID: 101},
+		{Session: "personal", WindowIndex: 0, WindowName: "htop", PanePID: 200},
+	}
+	result := query.RunWith(query.Parse("w:vim"), panes, nil)
+	if len(result.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(result.Sessions))
+	}
+	if result.Sessions[0].Name != "work" {
+		t.Errorf("expected 'work', got %q", result.Sessions[0].Name)
+	}
+	if len(result.Sessions[0].Windows) != 1 {
+		t.Fatalf("expected 1 window match, got %d", len(result.Sessions[0].Windows))
+	}
+	if result.Sessions[0].Windows[0].Name != "vim-config" {
+		t.Errorf("expected 'vim-config', got %q", result.Sessions[0].Windows[0].Name)
+	}
 }
 
 func TestRun_ProcessScope(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "work", WindowIndex: 0, WindowName: "main", PanePID: 100},
-        {Session: "personal", WindowIndex: 0, WindowName: "sh", PanePID: 200},
-    }
-    procs := []proc.Process{
-        {PID: 101, PPID: 100, Name: "nvim"},
-        {PID: 201, PPID: 200, Name: "bash"},
-    }
-    result := query.RunWith(query.Parse("p:nvi"), panes, procs)
-    if len(result.Sessions) != 1 {
-        t.Fatalf("expected 1 session, got %d", len(result.Sessions))
-    }
-    if result.Sessions[0].Name != "work" {
-        t.Errorf("expected 'work', got %q", result.Sessions[0].Name)
-    }
-    if len(result.Sessions[0].Procs) != 1 {
-        t.Fatalf("expected 1 proc match, got %d", len(result.Sessions[0].Procs))
-    }
-    if result.Sessions[0].Procs[0].Name != "nvim" {
-        t.Errorf("expected 'nvim', got %q", result.Sessions[0].Procs[0].Name)
-    }
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 0, WindowName: "main", PanePID: 100},
+		{Session: "personal", WindowIndex: 0, WindowName: "sh", PanePID: 200},
+	}
+	procs := []proc.Process{
+		{PID: 101, PPID: 100, Name: "nvim"},
+		{PID: 201, PPID: 200, Name: "bash"},
+	}
+	result := query.RunWith(query.Parse("p:nvi"), panes, procs)
+	if len(result.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(result.Sessions))
+	}
+	if result.Sessions[0].Name != "work" {
+		t.Errorf("expected 'work', got %q", result.Sessions[0].Name)
+	}
+	if len(result.Sessions[0].Procs) != 1 {
+		t.Fatalf("expected 1 proc match, got %d", len(result.Sessions[0].Procs))
+	}
+	if result.Sessions[0].Procs[0].Name != "nvim" {
+		t.Errorf("expected 'nvim', got %q", result.Sessions[0].Procs[0].Name)
+	}
 }
 
 func TestRun_SessionScope_Default(t *testing.T) {
-    // Bare text searches sessions only — window names are not matched.
-    panes := []tmux.Pane{
-        {Session: "vim-session", WindowIndex: 0, WindowName: "editor", PanePID: 100},
-        {Session: "work", WindowIndex: 0, WindowName: "vim-win", PanePID: 200},
-    }
-    result := query.RunWith(query.Parse("vim"), panes, nil)
-    if len(result.Sessions) != 1 {
-        t.Fatalf("expected 1 session (vim-session), got %d", len(result.Sessions))
-    }
-    if result.Sessions[0].Name != "vim-session" {
-        t.Errorf("expected 'vim-session', got %q", result.Sessions[0].Name)
-    }
-    if len(result.Sessions[0].Windows) != 0 {
-        t.Errorf("expected no window matches for bare-text search, got %d", len(result.Sessions[0].Windows))
-    }
-    if len(result.Sessions[0].Procs) != 0 {
-        t.Errorf("expected no proc matches for bare-text search, got %d", len(result.Sessions[0].Procs))
-    }
+	// Bare text searches sessions only — window names are not matched.
+	panes := []tmux.Pane{
+		{Session: "vim-session", WindowIndex: 0, WindowName: "editor", PanePID: 100},
+		{Session: "work", WindowIndex: 0, WindowName: "vim-win", PanePID: 200},
+	}
+	result := query.RunWith(query.Parse("vim"), panes, nil)
+	if len(result.Sessions) != 1 {
+		t.Fatalf("expected 1 session (vim-session), got %d", len(result.Sessions))
+	}
+	if result.Sessions[0].Name != "vim-session" {
+		t.Errorf("expected 'vim-session', got %q", result.Sessions[0].Name)
+	}
+	if len(result.Sessions[0].Windows) != 0 {
+		t.Errorf("expected no window matches for bare-text search, got %d", len(result.Sessions[0].Windows))
+	}
+	if len(result.Sessions[0].Procs) != 0 {
+		t.Errorf("expected no proc matches for bare-text search, got %d", len(result.Sessions[0].Procs))
+	}
 }
 
 func TestRun_MatchPos(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "work", WindowIndex: 0, WindowName: "main", PanePID: 100},
-    }
-    result := query.RunWith(query.Parse("wok"), panes, nil)
-    if len(result.Sessions) != 1 {
-        t.Fatalf("expected 1 session, got %d", len(result.Sessions))
-    }
-    if len(result.Sessions[0].MatchPos) == 0 {
-        t.Error("expected non-empty MatchPos for session match")
-    }
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 0, WindowName: "main", PanePID: 100},
+	}
+	result := query.RunWith(query.Parse("wok"), panes, nil)
+	if len(result.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(result.Sessions))
+	}
+	if len(result.Sessions[0].MatchPos) == 0 {
+		t.Error("expected non-empty MatchPos for session match")
+	}
 }
 
 func TestParse_BareTag(t *testing.T) {
-    // Bare tags with no term should be scoped with empty term, not ScopeSession.
-    tests := []struct {
-        raw   string
-        scope query.QueryScope
-        term  string
-    }{
-        {"w:", query.ScopeWindow, ""},
-        {"p:", query.ScopeProcess, ""},
-    }
-    for _, tt := range tests {
-        pq := query.Parse(tt.raw)
-        if pq.Scope != tt.scope {
-            t.Errorf("Parse(%q).Scope = %v, want %v", tt.raw, pq.Scope, tt.scope)
-        }
-        if pq.Term != tt.term {
-            t.Errorf("Parse(%q).Term = %q, want %q", tt.raw, pq.Term, tt.term)
-        }
-    }
+	// Bare tags with no term should be scoped with empty term, not ScopeSession.
+	tests := []struct {
+		raw   string
+		scope query.QueryScope
+		term  string
+	}{
+		{"w:", query.ScopeWindow, ""},
+		{"p:", query.ScopeProcess, ""},
+	}
+	for _, tt := range tests {
+		pq := query.Parse(tt.raw)
+		if pq.Scope != tt.scope {
+			t.Errorf("Parse(%q).Scope = %v, want %v", tt.raw, pq.Scope, tt.scope)
+		}
+		if pq.Term != tt.term {
+			t.Errorf("Parse(%q).Term = %q, want %q", tt.raw, pq.Term, tt.term)
+		}
+	}
 }
 
 func TestRun_ExtraSessions_Matched(t *testing.T) {
-    // Non-live (config-only) sessions passed via ExtraSessions must be fuzzy-matched.
-    panes := []tmux.Pane{
-        {Session: "work", WindowIndex: 0, WindowName: "main", PanePID: 100},
-    }
-    pq := query.Parse("dotf")
-    pq.ExtraSessions = []string{"dotf-main", "hf-main"}
-    result := query.RunWith(pq, panes, nil)
+	// Non-live (config-only) sessions passed via ExtraSessions must be fuzzy-matched.
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 0, WindowName: "main", PanePID: 100},
+	}
+	pq := query.Parse("dotf")
+	pq.ExtraSessions = []string{"dotf-main", "hf-main"}
+	result := query.RunWith(pq, panes, nil)
 
-    found := false
-    for _, sm := range result.Sessions {
-        if sm.Name == "dotf-main" {
-            found = true
-            break
-        }
-    }
-    if !found {
-        t.Error("expected 'dotf-main' from ExtraSessions to appear in results")
-    }
-    // live session should still be present
-    livefound := false
-    for _, sm := range result.Sessions {
-        if sm.Name == "work" {
-            livefound = true
-            break
-        }
-    }
-    _ = livefound // live session doesn't match "dotf", absence is fine
+	found := false
+	for _, sm := range result.Sessions {
+		if sm.Name == "dotf-main" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'dotf-main' from ExtraSessions to appear in results")
+	}
+	// live session should still be present
+	livefound := false
+	for _, sm := range result.Sessions {
+		if sm.Name == "work" {
+			livefound = true
+			break
+		}
+	}
+	_ = livefound // live session doesn't match "dotf", absence is fine
 }
 
 func TestRun_ExtraSessions_NoDuplicates(t *testing.T) {
-    // A session listed in both live panes and ExtraSessions must not be duplicated.
-    panes := []tmux.Pane{
-        {Session: "dotf-main", WindowIndex: 0, WindowName: "sh", PanePID: 100},
-    }
-    pq := query.Parse("dotf")
-    pq.ExtraSessions = []string{"dotf-main"}
-    result := query.RunWith(pq, panes, nil)
+	// A session listed in both live panes and ExtraSessions must not be duplicated.
+	panes := []tmux.Pane{
+		{Session: "dotf-main", WindowIndex: 0, WindowName: "sh", PanePID: 100},
+	}
+	pq := query.Parse("dotf")
+	pq.ExtraSessions = []string{"dotf-main"}
+	result := query.RunWith(pq, panes, nil)
 
-    count := 0
-    for _, sm := range result.Sessions {
-        if sm.Name == "dotf-main" {
-            count++
-        }
-    }
-    if count != 1 {
-        t.Errorf("expected 'dotf-main' exactly once, got %d", count)
-    }
+	count := 0
+	for _, sm := range result.Sessions {
+		if sm.Name == "dotf-main" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 'dotf-main' exactly once, got %d", count)
+	}
 }
 
 func TestRun_NonContiguousWindowIndices(t *testing.T) {
-    // Windows 0 and 2 (index 1 was deleted) — winIdxOrder mapping must survive this.
-    panes := []tmux.Pane{
-        {Session: "work", WindowIndex: 0, WindowName: "shell", PanePID: 100},
-        {Session: "work", WindowIndex: 2, WindowName: "vim-edit", PanePID: 101},
-    }
-    result := query.RunWith(query.Parse("w:vim"), panes, nil)
-    if len(result.Sessions) != 1 {
-        t.Fatalf("expected 1 session, got %d", len(result.Sessions))
-    }
-    if len(result.Sessions[0].Windows) != 1 {
-        t.Fatalf("expected 1 window match, got %d", len(result.Sessions[0].Windows))
-    }
-    if result.Sessions[0].Windows[0].Index != 2 {
-        t.Errorf("expected window index 2, got %d", result.Sessions[0].Windows[0].Index)
-    }
-    if result.Sessions[0].Windows[0].Name != "vim-edit" {
-        t.Errorf("expected 'vim-edit', got %q", result.Sessions[0].Windows[0].Name)
-    }
+	// Windows 0 and 2 (index 1 was deleted) — winIdxOrder mapping must survive this.
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 0, WindowName: "shell", PanePID: 100},
+		{Session: "work", WindowIndex: 2, WindowName: "vim-edit", PanePID: 101},
+	}
+	result := query.RunWith(query.Parse("w:vim"), panes, nil)
+	if len(result.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(result.Sessions))
+	}
+	if len(result.Sessions[0].Windows) != 1 {
+		t.Fatalf("expected 1 window match, got %d", len(result.Sessions[0].Windows))
+	}
+	if result.Sessions[0].Windows[0].Index != 2 {
+		t.Errorf("expected window index 2, got %d", result.Sessions[0].Windows[0].Index)
+	}
+	if result.Sessions[0].Windows[0].Name != "vim-edit" {
+		t.Errorf("expected 'vim-edit', got %q", result.Sessions[0].Windows[0].Name)
+	}
 }

--- a/internal/session/edit.go
+++ b/internal/session/edit.go
@@ -1,181 +1,181 @@
 package session
 
 import (
-    "errors"
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/BurntSushi/toml"
+	"github.com/BurntSushi/toml"
 )
 
 func AppendEntry(path string, e ConfigEntry) error {
-    if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-        return fmt.Errorf("create config dir: %w", err)
-    }
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
 
-    existing, err := loadRawEntries(path)
-    if err != nil {
-        return err
-    }
-    for _, ex := range existing {
-        if ex.DisplayName() == e.DisplayName() {
-            return fmt.Errorf("session %q already exists in %s", e.DisplayName(), filepath.Base(path))
-        }
-    }
+	existing, err := loadRawEntries(path)
+	if err != nil {
+		return err
+	}
+	for _, ex := range existing {
+		if ex.DisplayName() == e.DisplayName() {
+			return fmt.Errorf("session %q already exists in %s", e.DisplayName(), filepath.Base(path))
+		}
+	}
 
-    f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-    if err != nil {
-        return fmt.Errorf("open %s: %w", path, err)
-    }
-    defer f.Close()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
 
-    if _, err = fmt.Fprint(f, FormatBlock(e)); err != nil {
-        return fmt.Errorf("write %s: %w", filepath.Base(path), err)
-    }
-    return nil
+	if _, err = fmt.Fprint(f, FormatBlock(e)); err != nil {
+		return fmt.Errorf("write %s: %w", filepath.Base(path), err)
+	}
+	return nil
 }
 
 // tomlQuote wraps s in double quotes with only the escapes required for a
 // TOML basic string: backslash and double-quote. Unicode is left as literal.
 func tomlQuote(s string) string {
-    s = strings.ReplaceAll(s, "\\", "\\\\")
-    s = strings.ReplaceAll(s, "\"", "\\\"")
-    return "\"" + s + "\""
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	return "\"" + s + "\""
 }
 
 func FormatBlock(e ConfigEntry) string {
-    var sb strings.Builder
-    sb.WriteString("\n[[session]]\n")
-    sb.WriteString(fmt.Sprintf("name  = %s\n", tomlQuote(e.Name)))
-    if e.Group != "" {
-        sb.WriteString(fmt.Sprintf("group = %s\n", tomlQuote(e.Group)))
-    }
-    sb.WriteString(fmt.Sprintf("path  = %s\n", tomlQuote(e.Path)))
-    if e.Worktree {
-        sb.WriteString("worktree = true\n")
-    }
-    if len(e.Labels) > 0 {
-        quoted := make([]string, len(e.Labels))
-        for i, l := range e.Labels {
-            quoted[i] = tomlQuote(l)
-        }
-        sb.WriteString(fmt.Sprintf("labels   = [%s]\n", strings.Join(quoted, ", ")))
-    }
-    if e.Icon != "" {
-        sb.WriteString(fmt.Sprintf("icon     = %s\n", tomlQuote(e.Icon)))
-    }
-    if len(e.Windows) > 0 {
-        quoted := make([]string, len(e.Windows))
-        for i, w := range e.Windows {
-            quoted[i] = tomlQuote(w)
-        }
-        sb.WriteString(fmt.Sprintf("windows  = [%s]\n", strings.Join(quoted, ", ")))
-    }
-    return sb.String()
+	var sb strings.Builder
+	sb.WriteString("\n[[session]]\n")
+	sb.WriteString(fmt.Sprintf("name  = %s\n", tomlQuote(e.Name)))
+	if e.Group != "" {
+		sb.WriteString(fmt.Sprintf("group = %s\n", tomlQuote(e.Group)))
+	}
+	sb.WriteString(fmt.Sprintf("path  = %s\n", tomlQuote(e.Path)))
+	if e.Worktree {
+		sb.WriteString("worktree = true\n")
+	}
+	if len(e.Labels) > 0 {
+		quoted := make([]string, len(e.Labels))
+		for i, l := range e.Labels {
+			quoted[i] = tomlQuote(l)
+		}
+		sb.WriteString(fmt.Sprintf("labels   = [%s]\n", strings.Join(quoted, ", ")))
+	}
+	if e.Icon != "" {
+		sb.WriteString(fmt.Sprintf("icon     = %s\n", tomlQuote(e.Icon)))
+	}
+	if len(e.Windows) > 0 {
+		quoted := make([]string, len(e.Windows))
+		for i, w := range e.Windows {
+			quoted[i] = tomlQuote(w)
+		}
+		sb.WriteString(fmt.Sprintf("windows  = [%s]\n", strings.Join(quoted, ", ")))
+	}
+	return sb.String()
 }
 
 func loadRawEntries(path string) ([]ConfigEntry, error) {
-    var f sessionsFile
-    _, err := toml.DecodeFile(path, &f)
-    if err != nil {
-        if errors.Is(err, os.ErrNotExist) {
-            return nil, nil
-        }
-        return nil, fmt.Errorf("read %s: %w", filepath.Base(path), err)
-    }
-    return f.Sessions, nil
+	var f sessionsFile
+	_, err := toml.DecodeFile(path, &f)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
+	return f.Sessions, nil
 }
 
 // RemoveEntry removes the [[session]] block matching name from path.
 // Returns an error if the file does not exist or the entry is not found.
 func RemoveEntry(path, name string) error {
-    data, err := os.ReadFile(path)
-    if err != nil {
-        return fmt.Errorf("read %s: %w", filepath.Base(path), err)
-    }
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", filepath.Base(path), err)
+	}
 
-    blocks, preamble := splitBlocks(string(data))
+	blocks, preamble := splitBlocks(string(data))
 
-    target := -1
-    for i, b := range blocks {
-        if blockHasField(b, "name", name) {
-            target = i
-            break
-        }
-    }
-    if target == -1 {
-        return fmt.Errorf("session %q not found in %s", name, filepath.Base(path))
-    }
+	target := -1
+	for i, b := range blocks {
+		if blockHasField(b, "name", name) {
+			target = i
+			break
+		}
+	}
+	if target == -1 {
+		return fmt.Errorf("session %q not found in %s", name, filepath.Base(path))
+	}
 
-    blocks = append(blocks[:target], blocks[target+1:]...)
+	blocks = append(blocks[:target], blocks[target+1:]...)
 
-    var sb strings.Builder
-    sb.WriteString(preamble)
-    for _, b := range blocks {
-        sb.WriteString(b)
-    }
+	var sb strings.Builder
+	sb.WriteString(preamble)
+	for _, b := range blocks {
+		sb.WriteString(b)
+	}
 
-    result := strings.TrimRight(sb.String(), "\n")
-    if result != "" {
-        result += "\n"
-    }
+	result := strings.TrimRight(sb.String(), "\n")
+	if result != "" {
+		result += "\n"
+	}
 
-    return os.WriteFile(path, []byte(result), 0644)
+	return os.WriteFile(path, []byte(result), 0644)
 }
 
 // splitBlocks splits TOML content into a preamble (lines before first [[session]])
 // and a slice of [[session]] block strings (each starting with "[[session]]\n").
 func splitBlocks(content string) (blocks []string, preamble string) {
-    lines := strings.Split(content, "\n")
-    var pre []string
-    var cur []string
-    inBlock := false
+	lines := strings.Split(content, "\n")
+	var pre []string
+	var cur []string
+	inBlock := false
 
-    for _, line := range lines {
-        if strings.TrimSpace(line) == "[[session]]" {
-            if inBlock {
-                blocks = append(blocks, strings.Join(cur, "\n")+"\n")
-                cur = nil
-            }
-            inBlock = true
-            cur = append(cur, line)
-        } else if inBlock {
-            cur = append(cur, line)
-        } else {
-            pre = append(pre, line)
-        }
-    }
-    if inBlock && len(cur) > 0 {
-        blocks = append(blocks, strings.Join(cur, "\n")+"\n")
-    }
-    preamble = strings.Join(pre, "\n")
-    if preamble != "" && !strings.HasSuffix(preamble, "\n") {
-        preamble += "\n"
-    }
-    return blocks, preamble
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "[[session]]" {
+			if inBlock {
+				blocks = append(blocks, strings.Join(cur, "\n")+"\n")
+				cur = nil
+			}
+			inBlock = true
+			cur = append(cur, line)
+		} else if inBlock {
+			cur = append(cur, line)
+		} else {
+			pre = append(pre, line)
+		}
+	}
+	if inBlock && len(cur) > 0 {
+		blocks = append(blocks, strings.Join(cur, "\n")+"\n")
+	}
+	preamble = strings.Join(pre, "\n")
+	if preamble != "" && !strings.HasSuffix(preamble, "\n") {
+		preamble += "\n"
+	}
+	return blocks, preamble
 }
 
 // blockHasField reports whether the block contains key = "value" (handles extra spaces around =).
 func blockHasField(block, key, value string) bool {
-    needle := tomlQuote(value)
-    for _, line := range strings.Split(block, "\n") {
-        trimmed := strings.TrimSpace(line)
-        if !strings.HasPrefix(trimmed, key) {
-            continue
-        }
-        rest := strings.TrimPrefix(trimmed, key)
-        if len(rest) == 0 || (rest[0] != '=' && rest[0] != ' ' && rest[0] != '\t') {
-            continue
-        }
-        rest = strings.TrimSpace(rest)
-        if strings.HasPrefix(rest, "=") {
-            val := strings.TrimSpace(strings.TrimPrefix(rest, "="))
-            if val == needle {
-                return true
-            }
-        }
-    }
-    return false
+	needle := tomlQuote(value)
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, key) {
+			continue
+		}
+		rest := strings.TrimPrefix(trimmed, key)
+		if len(rest) == 0 || (rest[0] != '=' && rest[0] != ' ' && rest[0] != '\t') {
+			continue
+		}
+		rest = strings.TrimSpace(rest)
+		if strings.HasPrefix(rest, "=") {
+			val := strings.TrimSpace(strings.TrimPrefix(rest, "="))
+			if val == needle {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/session/edit_test.go
+++ b/internal/session/edit_test.go
@@ -1,163 +1,163 @@
 package session
 
 import (
-    "os"
-    "path/filepath"
-    "strings"
-    "testing"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 func TestAppendEntry_CreatesFile(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "sessions.toml")
-    e := ConfigEntry{Name: "myproj-main", Group: "myproj", Path: "/home/user/myproj"}
-    if err := AppendEntry(path, e); err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    // Round-trip: verify the stored data is correct.
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatalf("load back: %v", err)
-    }
-    if len(cfg.Entries) != 1 {
-        t.Fatalf("expected 1 entry, got %d", len(cfg.Entries))
-    }
-    got := cfg.Entries[0]
-    if got.Name != "myproj-main" {
-        t.Errorf("name: got %q, want %q", got.Name, "myproj-main")
-    }
-    if got.Group != "myproj" {
-        t.Errorf("group: got %q, want %q", got.Group, "myproj")
-    }
-    if got.Path != "/home/user/myproj" {
-        t.Errorf("path: got %q, want %q", got.Path, "/home/user/myproj")
-    }
-    // Zero-value optional fields should not be written to the file.
-    data, err := os.ReadFile(path)
-    if err != nil {
-        t.Fatalf("read file: %v", err)
-    }
-    s := string(data)
-    if strings.Contains(s, "worktree") {
-        t.Error("worktree=false should be omitted")
-    }
-    if strings.Contains(s, "labels") {
-        t.Error("empty labels should be omitted")
-    }
-    if strings.Contains(s, "icon") {
-        t.Error("empty icon should be omitted")
-    }
-    if strings.Contains(s, "windows") {
-        t.Error("empty windows should be omitted")
-    }
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions.toml")
+	e := ConfigEntry{Name: "myproj-main", Group: "myproj", Path: "/home/user/myproj"}
+	if err := AppendEntry(path, e); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Round-trip: verify the stored data is correct.
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatalf("load back: %v", err)
+	}
+	if len(cfg.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(cfg.Entries))
+	}
+	got := cfg.Entries[0]
+	if got.Name != "myproj-main" {
+		t.Errorf("name: got %q, want %q", got.Name, "myproj-main")
+	}
+	if got.Group != "myproj" {
+		t.Errorf("group: got %q, want %q", got.Group, "myproj")
+	}
+	if got.Path != "/home/user/myproj" {
+		t.Errorf("path: got %q, want %q", got.Path, "/home/user/myproj")
+	}
+	// Zero-value optional fields should not be written to the file.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "worktree") {
+		t.Error("worktree=false should be omitted")
+	}
+	if strings.Contains(s, "labels") {
+		t.Error("empty labels should be omitted")
+	}
+	if strings.Contains(s, "icon") {
+		t.Error("empty icon should be omitted")
+	}
+	if strings.Contains(s, "windows") {
+		t.Error("empty windows should be omitted")
+	}
 }
 
 func TestAppendEntry_AppendsToExistingFile(t *testing.T) {
-    dir := t.TempDir()
-    writeTOML(t, dir, "sessions.toml", `[[session]]
+	dir := t.TempDir()
+	writeTOML(t, dir, "sessions.toml", `[[session]]
 name  = "ex-existing"
 group = "ex"
 path  = "/ex"
 `)
-    e := ConfigEntry{Name: "nw-new", Group: "nw", Path: "/new"}
-    if err := AppendEntry(filepath.Join(dir, "sessions.toml"), e); err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatalf("load back: %v", err)
-    }
-    names := make(map[string]bool, len(cfg.Entries))
-    for _, entry := range cfg.Entries {
-        names[entry.Name] = true
-    }
-    if !names["ex-existing"] {
-        t.Error("existing entry should be preserved")
-    }
-    if !names["nw-new"] {
-        t.Error("new entry should be appended")
-    }
+	e := ConfigEntry{Name: "nw-new", Group: "nw", Path: "/new"}
+	if err := AppendEntry(filepath.Join(dir, "sessions.toml"), e); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatalf("load back: %v", err)
+	}
+	names := make(map[string]bool, len(cfg.Entries))
+	for _, entry := range cfg.Entries {
+		names[entry.Name] = true
+	}
+	if !names["ex-existing"] {
+		t.Error("existing entry should be preserved")
+	}
+	if !names["nw-new"] {
+		t.Error("new entry should be appended")
+	}
 }
 
 func TestAppendEntry_RejectsDuplicate(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "sessions.toml")
-    writeTOML(t, dir, "sessions.toml", `[[session]]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions.toml")
+	writeTOML(t, dir, "sessions.toml", `[[session]]
 name  = "myproj-main"
 group = "myproj"
 path  = "/foo"
 `)
-    e := ConfigEntry{Name: "myproj-main", Group: "myproj", Path: "/bar"}
-    err := AppendEntry(path, e)
-    if err == nil {
-        t.Error("expected duplicate error, got nil")
-    } else if !strings.Contains(err.Error(), "already exists") {
-        t.Errorf("expected 'already exists' in error, got: %v", err)
-    }
+	e := ConfigEntry{Name: "myproj-main", Group: "myproj", Path: "/bar"}
+	err := AppendEntry(path, e)
+	if err == nil {
+		t.Error("expected duplicate error, got nil")
+	} else if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' in error, got: %v", err)
+	}
 }
 
 func TestAppendEntry_OptionalFields(t *testing.T) {
-    dir := t.TempDir()
-    e := ConfigEntry{
-        Name:     "myproj-main",
-        Group:    "myproj",
-        Path:     "/home/user/myproj",
-        Worktree: true,
-        Labels:   []string{"work", "rust"},
-        Icon:     "󰅩",
-    }
-    if err := AppendEntry(filepath.Join(dir, "sessions.toml"), e); err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatalf("load back: %v", err)
-    }
-    if len(cfg.Entries) != 1 {
-        t.Fatalf("expected 1 entry, got %d", len(cfg.Entries))
-    }
-    got := cfg.Entries[0]
-    if !got.Worktree {
-        t.Error("expected Worktree=true")
-    }
-    if len(got.Labels) != 2 || got.Labels[0] != "work" || got.Labels[1] != "rust" {
-        t.Errorf("expected labels [work rust], got %v", got.Labels)
-    }
-    if got.Icon != "󰅩" {
-        t.Errorf("expected icon 󰅩, got %q", got.Icon)
-    }
+	dir := t.TempDir()
+	e := ConfigEntry{
+		Name:     "myproj-main",
+		Group:    "myproj",
+		Path:     "/home/user/myproj",
+		Worktree: true,
+		Labels:   []string{"work", "rust"},
+		Icon:     "󰅩",
+	}
+	if err := AppendEntry(filepath.Join(dir, "sessions.toml"), e); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatalf("load back: %v", err)
+	}
+	if len(cfg.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(cfg.Entries))
+	}
+	got := cfg.Entries[0]
+	if !got.Worktree {
+		t.Error("expected Worktree=true")
+	}
+	if len(got.Labels) != 2 || got.Labels[0] != "work" || got.Labels[1] != "rust" {
+		t.Errorf("expected labels [work rust], got %v", got.Labels)
+	}
+	if got.Icon != "󰅩" {
+		t.Errorf("expected icon 󰅩, got %q", got.Icon)
+	}
 }
 
 func TestAppendEntry_Windows(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "sessions.toml")
-    e := ConfigEntry{
-        Name:    "myproj-main",
-        Group:   "myproj",
-        Path:    "/home/user/myproj",
-        Windows: []string{"editor", "terminal"},
-    }
-    if err := AppendEntry(path, e); err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    // round-trip: load back and verify
-    entries, loadErr := LoadConfigSessions(dir)
-    if loadErr != nil {
-        t.Fatalf("load: %v", loadErr)
-    }
-    if len(entries.Entries) != 1 {
-        t.Fatalf("expected 1 entry, got %d", len(entries.Entries))
-    }
-    got := entries.Entries[0].Windows
-    if len(got) != 2 || got[0] != "editor" || got[1] != "terminal" {
-        t.Errorf("round-trip windows mismatch: %v", got)
-    }
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions.toml")
+	e := ConfigEntry{
+		Name:    "myproj-main",
+		Group:   "myproj",
+		Path:    "/home/user/myproj",
+		Windows: []string{"editor", "terminal"},
+	}
+	if err := AppendEntry(path, e); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// round-trip: load back and verify
+	entries, loadErr := LoadConfigSessions(dir)
+	if loadErr != nil {
+		t.Fatalf("load: %v", loadErr)
+	}
+	if len(entries.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries.Entries))
+	}
+	got := entries.Entries[0].Windows
+	if len(got) != 2 || got[0] != "editor" || got[1] != "terminal" {
+		t.Errorf("round-trip windows mismatch: %v", got)
+	}
 }
 
 func TestRemoveEntry_RemovesMatchingBlock(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "sessions.toml")
-    writeTOML(t, dir, "sessions.toml", `[[session]]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions.toml")
+	writeTOML(t, dir, "sessions.toml", `[[session]]
 name  = "proj-main"
 group = "proj"
 path  = "/proj"
@@ -167,60 +167,60 @@ name  = "oth-other"
 group = "oth"
 path  = "/other"
 `)
-    if err := RemoveEntry(path, "proj-main"); err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    data, err := os.ReadFile(path)
-    if err != nil {
-        t.Fatalf("read file: %v", err)
-    }
-    s := string(data)
-    if strings.Contains(s, `name  = "proj-main"`) {
-        t.Error("removed entry should not be present")
-    }
-    if !strings.Contains(s, `name  = "oth-other"`) {
-        t.Error("other entry should be preserved")
-    }
+	if err := RemoveEntry(path, "proj-main"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, `name  = "proj-main"`) {
+		t.Error("removed entry should not be present")
+	}
+	if !strings.Contains(s, `name  = "oth-other"`) {
+		t.Error("other entry should be preserved")
+	}
 }
 
 func TestRemoveEntry_NotFound(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "sessions.toml")
-    writeTOML(t, dir, "sessions.toml", `[[session]]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions.toml")
+	writeTOML(t, dir, "sessions.toml", `[[session]]
 name  = "proj-main"
 group = "proj"
 path  = "/proj"
 `)
-    err := RemoveEntry(path, "wrong-name")
-    if err == nil {
-        t.Error("expected not-found error")
-    }
+	err := RemoveEntry(path, "wrong-name")
+	if err == nil {
+		t.Error("expected not-found error")
+	}
 }
 
 func TestRemoveEntry_FileNotExist(t *testing.T) {
-    path := filepath.Join(t.TempDir(), "missing.toml")
-    err := RemoveEntry(path, "proj-main")
-    if err == nil {
-        t.Error("expected error for missing file")
-    }
+	path := filepath.Join(t.TempDir(), "missing.toml")
+	err := RemoveEntry(path, "proj-main")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
 }
 
 func TestRemoveEntry_OnlyEntry(t *testing.T) {
-    dir := t.TempDir()
-    path := filepath.Join(dir, "sessions.toml")
-    writeTOML(t, dir, "sessions.toml", `[[session]]
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions.toml")
+	writeTOML(t, dir, "sessions.toml", `[[session]]
 name  = "proj-main"
 group = "proj"
 path  = "/proj"
 `)
-    if err := RemoveEntry(path, "proj-main"); err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    data, err := os.ReadFile(path)
-    if err != nil {
-        t.Fatalf("read file: %v", err)
-    }
-    if strings.Contains(string(data), "[[session]]") {
-        t.Error("session block should be gone")
-    }
+	if err := RemoveEntry(path, "proj-main"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if strings.Contains(string(data), "[[session]]") {
+		t.Error("session block should be gone")
+	}
 }

--- a/internal/session/load.go
+++ b/internal/session/load.go
@@ -1,92 +1,92 @@
 package session
 
 import (
-    "errors"
-    "fmt"
-    "os"
-    "path/filepath"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 
-    "github.com/BurntSushi/toml"
+	"github.com/BurntSushi/toml"
 )
 
 type sessionsFile struct {
-    Sessions        []ConfigEntry    `toml:"session"`
-    WindowTemplates []WindowTemplate `toml:"window_templates"`
+	Sessions        []ConfigEntry    `toml:"session"`
+	WindowTemplates []WindowTemplate `toml:"window_templates"`
 }
 
 // SessionsConfig is the parsed result of sessions.toml and private.toml.
 type SessionsConfig struct {
-    Entries         []ConfigEntry
-    WindowTemplates map[string]WindowTemplate // resolved by id, from-inheritance applied
+	Entries         []ConfigEntry
+	WindowTemplates map[string]WindowTemplate // resolved by id, from-inheritance applied
 }
 
 // LoadConfigSessions loads sessions.toml then private.toml from configDir.
 // Missing files are silently ignored. Invalid entries (missing name/path)
 // are skipped with a message to stderr. Duplicate DisplayNames: last entry wins.
 func LoadConfigSessions(configDir string) (SessionsConfig, error) {
-    var cfg SessionsConfig
-    seen := map[string]int{} // DisplayName → index in cfg.Entries
-    var rawTemplates []WindowTemplate
+	var cfg SessionsConfig
+	seen := map[string]int{} // DisplayName → index in cfg.Entries
+	var rawTemplates []WindowTemplate
 
-    for _, name := range []string{"sessions.toml", "private.toml"} {
-        path := filepath.Join(configDir, name)
-        var f sessionsFile
-        _, err := toml.DecodeFile(path, &f)
-        if err != nil {
-            if errors.Is(err, os.ErrNotExist) {
-                continue
-            }
-            return cfg, fmt.Errorf("load %s: %w", name, err)
-        }
-        for _, e := range f.Sessions {
-            if e.Name == "" || e.Path == "" {
-                fmt.Fprintf(os.Stderr, "demux: skipping session with missing name/path in %s\n", name)
-                continue
-            }
-            dn := e.DisplayName()
-            if i, ok := seen[dn]; ok {
-                fmt.Fprintf(os.Stderr, "demux: duplicate session %q in %s (overrides previous)\n", dn, name)
-                cfg.Entries[i] = e
-            } else {
-                seen[dn] = len(cfg.Entries)
-                cfg.Entries = append(cfg.Entries, e)
-            }
-        }
-        rawTemplates = append(rawTemplates, f.WindowTemplates...)
-    }
+	for _, name := range []string{"sessions.toml", "private.toml"} {
+		path := filepath.Join(configDir, name)
+		var f sessionsFile
+		_, err := toml.DecodeFile(path, &f)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return cfg, fmt.Errorf("load %s: %w", name, err)
+		}
+		for _, e := range f.Sessions {
+			if e.Name == "" || e.Path == "" {
+				fmt.Fprintf(os.Stderr, "demux: skipping session with missing name/path in %s\n", name)
+				continue
+			}
+			dn := e.DisplayName()
+			if i, ok := seen[dn]; ok {
+				fmt.Fprintf(os.Stderr, "demux: duplicate session %q in %s (overrides previous)\n", dn, name)
+				cfg.Entries[i] = e
+			} else {
+				seen[dn] = len(cfg.Entries)
+				cfg.Entries = append(cfg.Entries, e)
+			}
+		}
+		rawTemplates = append(rawTemplates, f.WindowTemplates...)
+	}
 
-    cfg.WindowTemplates = resolveWindowTemplates(rawTemplates)
-    return cfg, nil
+	cfg.WindowTemplates = resolveWindowTemplates(rawTemplates)
+	return cfg, nil
 }
 
 // resolveWindowTemplates builds an id-keyed map of WindowTemplate with
 // single-level from-inheritance applied. Later entries override earlier ones
 // with the same id.
 func resolveWindowTemplates(raw []WindowTemplate) map[string]WindowTemplate {
-    byID := make(map[string]WindowTemplate, len(raw))
-    for _, t := range raw {
-        byID[t.ID] = t
-    }
-    resolved := make(map[string]WindowTemplate, len(raw))
-    for _, t := range raw {
-        if t.From != "" {
-            base, ok := byID[t.From]
-            if !ok {
-                fmt.Fprintf(os.Stderr, "demux: window_template %q references unknown template id %q\n", t.ID, t.From)
-                resolved[t.ID] = t
-                continue
-            }
-            merged := base
-            merged.ID = t.ID
-            merged.Name = t.Name
-            merged.From = ""
-            if t.AfterCreateCmd != "" {
-                merged.AfterCreateCmd = t.AfterCreateCmd
-            }
-            resolved[t.ID] = merged
-        } else {
-            resolved[t.ID] = t
-        }
-    }
-    return resolved
+	byID := make(map[string]WindowTemplate, len(raw))
+	for _, t := range raw {
+		byID[t.ID] = t
+	}
+	resolved := make(map[string]WindowTemplate, len(raw))
+	for _, t := range raw {
+		if t.From != "" {
+			base, ok := byID[t.From]
+			if !ok {
+				fmt.Fprintf(os.Stderr, "demux: window_template %q references unknown template id %q\n", t.ID, t.From)
+				resolved[t.ID] = t
+				continue
+			}
+			merged := base
+			merged.ID = t.ID
+			merged.Name = t.Name
+			merged.From = ""
+			if t.AfterCreateCmd != "" {
+				merged.AfterCreateCmd = t.AfterCreateCmd
+			}
+			resolved[t.ID] = merged
+		} else {
+			resolved[t.ID] = t
+		}
+	}
+	return resolved
 }

--- a/internal/session/load_test.go
+++ b/internal/session/load_test.go
@@ -1,32 +1,32 @@
 package session
 
 import (
-    "os"
-    "path/filepath"
-    "testing"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
 func writeTOML(t *testing.T, dir, name, content string) {
-    t.Helper()
-    if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
-        t.Fatal(err)
-    }
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestLoadConfigSessions_MissingFiles(t *testing.T) {
-    dir := t.TempDir()
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    if len(cfg.Entries) != 0 {
-        t.Errorf("expected 0 entries, got %d", len(cfg.Entries))
-    }
+	dir := t.TempDir()
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(cfg.Entries))
+	}
 }
 
 func TestLoadConfigSessions_SessionsOnly(t *testing.T) {
-    dir := t.TempDir()
-    writeTOML(t, dir, "sessions.toml", `
+	dir := t.TempDir()
+	writeTOML(t, dir, "sessions.toml", `
 [[session]]
 name     = "dotf-main"
 group    = "dotf"
@@ -35,54 +35,54 @@ worktree = true
 labels   = ["work"]
 icon     = "x"
 `)
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(cfg.Entries) != 1 {
-        t.Fatalf("expected 1, got %d", len(cfg.Entries))
-    }
-    e := cfg.Entries[0]
-    if e.DisplayName() != "dotf-main" {
-        t.Errorf("expected dotf-main, got %s", e.DisplayName())
-    }
-    if !e.Worktree {
-        t.Error("expected Worktree=true")
-    }
-    if len(e.Labels) != 1 || e.Labels[0] != "work" {
-        t.Error("expected label work")
-    }
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Entries) != 1 {
+		t.Fatalf("expected 1, got %d", len(cfg.Entries))
+	}
+	e := cfg.Entries[0]
+	if e.DisplayName() != "dotf-main" {
+		t.Errorf("expected dotf-main, got %s", e.DisplayName())
+	}
+	if !e.Worktree {
+		t.Error("expected Worktree=true")
+	}
+	if len(e.Labels) != 1 || e.Labels[0] != "work" {
+		t.Error("expected label work")
+	}
 }
 
 func TestLoadConfigSessions_PrivateOverrides(t *testing.T) {
-    dir := t.TempDir()
-    writeTOML(t, dir, "sessions.toml", `
+	dir := t.TempDir()
+	writeTOML(t, dir, "sessions.toml", `
 [[session]]
 name  = "dotf-main"
 group = "dotf"
 path  = "/public"
 `)
-    writeTOML(t, dir, "private.toml", `
+	writeTOML(t, dir, "private.toml", `
 [[session]]
 name  = "dotf-main"
 group = "dotf"
 path  = "/private"
 `)
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(cfg.Entries) != 1 {
-        t.Fatalf("expected 1 (private overrides), got %d", len(cfg.Entries))
-    }
-    if cfg.Entries[0].Path != "/private" {
-        t.Errorf("expected /private, got %s", cfg.Entries[0].Path)
-    }
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Entries) != 1 {
+		t.Fatalf("expected 1 (private overrides), got %d", len(cfg.Entries))
+	}
+	if cfg.Entries[0].Path != "/private" {
+		t.Errorf("expected /private, got %s", cfg.Entries[0].Path)
+	}
 }
 
 func TestLoadConfigSessions_SkipsInvalidEntries(t *testing.T) {
-    dir := t.TempDir()
-    writeTOML(t, dir, "sessions.toml", `
+	dir := t.TempDir()
+	writeTOML(t, dir, "sessions.toml", `
 [[session]]
 name  = ""
 path  = "/foo"
@@ -92,18 +92,18 @@ name  = "other"
 group = "ok"
 path  = "/bar"
 `)
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(cfg.Entries) != 1 {
-        t.Errorf("expected 1 valid entry, got %d", len(cfg.Entries))
-    }
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Entries) != 1 {
+		t.Errorf("expected 1 valid entry, got %d", len(cfg.Entries))
+	}
 }
 
 func TestLoadConfigSessions_WindowTemplates(t *testing.T) {
-    dir := t.TempDir()
-    writeTOML(t, dir, "sessions.toml", `
+	dir := t.TempDir()
+	writeTOML(t, dir, "sessions.toml", `
 [[window_templates]]
 id              = "editor"
 name            = "Editor"
@@ -120,42 +120,42 @@ group   = "dotf"
 path    = "/foo"
 windows = ["editor", "generic"]
 `)
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(cfg.Entries) != 1 {
-        t.Fatalf("expected 1 entry, got %d", len(cfg.Entries))
-    }
-    if len(cfg.Entries[0].Windows) != 2 {
-        t.Errorf("expected 2 windows, got %d", len(cfg.Entries[0].Windows))
-    }
-    editor, ok := cfg.WindowTemplates["editor"]
-    if !ok {
-        t.Fatal("expected editor template")
-    }
-    if editor.Name != "Editor" {
-        t.Errorf("expected name 'Editor', got %q", editor.Name)
-    }
-    if editor.AfterCreateCmd != "nvim ." {
-        t.Errorf("expected 'nvim .', got %q", editor.AfterCreateCmd)
-    }
-    generic, ok := cfg.WindowTemplates["generic"]
-    if !ok {
-        t.Fatal("expected generic template")
-    }
-    if generic.Name != "Generic" {
-        t.Errorf("expected name 'Generic', got %q", generic.Name)
-    }
-    // generic inherits after_create_cmd from editor
-    if generic.AfterCreateCmd != "nvim ." {
-        t.Errorf("generic should inherit 'nvim .', got %q", generic.AfterCreateCmd)
-    }
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(cfg.Entries))
+	}
+	if len(cfg.Entries[0].Windows) != 2 {
+		t.Errorf("expected 2 windows, got %d", len(cfg.Entries[0].Windows))
+	}
+	editor, ok := cfg.WindowTemplates["editor"]
+	if !ok {
+		t.Fatal("expected editor template")
+	}
+	if editor.Name != "Editor" {
+		t.Errorf("expected name 'Editor', got %q", editor.Name)
+	}
+	if editor.AfterCreateCmd != "nvim ." {
+		t.Errorf("expected 'nvim .', got %q", editor.AfterCreateCmd)
+	}
+	generic, ok := cfg.WindowTemplates["generic"]
+	if !ok {
+		t.Fatal("expected generic template")
+	}
+	if generic.Name != "Generic" {
+		t.Errorf("expected name 'Generic', got %q", generic.Name)
+	}
+	// generic inherits after_create_cmd from editor
+	if generic.AfterCreateCmd != "nvim ." {
+		t.Errorf("generic should inherit 'nvim .', got %q", generic.AfterCreateCmd)
+	}
 }
 
 func TestLoadConfigSessions_WindowTemplateOverride(t *testing.T) {
-    dir := t.TempDir()
-    writeTOML(t, dir, "sessions.toml", `
+	dir := t.TempDir()
+	writeTOML(t, dir, "sessions.toml", `
 [[window_templates]]
 id              = "base"
 name            = "Base"
@@ -167,15 +167,15 @@ name            = "Derived"
 from            = "base"
 after_create_cmd = "echo derived"
 `)
-    cfg, err := LoadConfigSessions(dir)
-    if err != nil {
-        t.Fatal(err)
-    }
-    derived := cfg.WindowTemplates["derived"]
-    if derived.AfterCreateCmd != "echo derived" {
-        t.Errorf("expected 'echo derived', got %q", derived.AfterCreateCmd)
-    }
-    if derived.Name != "Derived" {
-        t.Errorf("expected name 'Derived', got %q", derived.Name)
-    }
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	derived := cfg.WindowTemplates["derived"]
+	if derived.AfterCreateCmd != "echo derived" {
+		t.Errorf("expected 'echo derived', got %q", derived.AfterCreateCmd)
+	}
+	if derived.Name != "Derived" {
+		t.Errorf("expected name 'Derived', got %q", derived.Name)
+	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,99 +1,99 @@
 package session
 
 import (
-    "time"
+	"time"
 
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 // WindowTemplate defines a reusable window configuration in sessions.toml.
 type WindowTemplate struct {
-    ID             string `toml:"id"`
-    Name           string `toml:"name"`
-    AfterCreateCmd string `toml:"after_create_cmd"`
-    From           string `toml:"from"` // inherit by id from another template
+	ID             string `toml:"id"`
+	Name           string `toml:"name"`
+	AfterCreateCmd string `toml:"after_create_cmd"`
+	From           string `toml:"from"` // inherit by id from another template
 }
 
 // ConfigEntry is parsed from sessions.toml / private.toml.
 type ConfigEntry struct {
-    Name     string   `toml:"name"`
-    Path     string   `toml:"path"`
-    Worktree bool     `toml:"worktree"`
-    Group    string   `toml:"group"`
-    Labels   []string `toml:"labels"`
-    Icon     string   `toml:"icon"`
-    Windows  []string `toml:"windows"` // ordered list of window_template names
+	Name     string   `toml:"name"`
+	Path     string   `toml:"path"`
+	Worktree bool     `toml:"worktree"`
+	Group    string   `toml:"group"`
+	Labels   []string `toml:"labels"`
+	Icon     string   `toml:"icon"`
+	Windows  []string `toml:"windows"` // ordered list of window_template names
 }
 
 // DisplayName returns the session identifier used in Tmux and in the TUI.
 func (e ConfigEntry) DisplayName() string {
-    return e.Name
+	return e.Name
 }
 
 // Session is the unified session type for the TUI sidebar.
 type Session struct {
-    DisplayName string              // config name or raw Tmux name
-    IsLive      bool                // currently running in Tmux
-    IsConfig    bool                // has a config entry
-    Panes       map[int][]tmux.Pane // populated when IsLive
-    Activity    time.Time           // populated when IsLive
-    Config      *ConfigEntry        // populated when IsConfig
+	DisplayName string              // config name or raw Tmux name
+	IsLive      bool                // currently running in Tmux
+	IsConfig    bool                // has a config entry
+	Panes       map[int][]tmux.Pane // populated when IsLive
+	Activity    time.Time           // populated when IsLive
+	Config      *ConfigEntry        // populated when IsConfig
 }
 
 // ResolveWindowSpecs maps a list of window template ids to tmux.WindowSpec values.
 // It returns the resolved specs and a slice of ids that were not found.
 func ResolveWindowSpecs(ids []string, templates map[string]WindowTemplate) (specs []tmux.WindowSpec, unknown []string) {
-    for _, id := range ids {
-        t, ok := templates[id]
-        if !ok {
-            unknown = append(unknown, id)
-            continue
-        }
-        specs = append(specs, tmux.WindowSpec{Name: t.Name, AfterCreateCmd: t.AfterCreateCmd})
-    }
-    return specs, unknown
+	for _, id := range ids {
+		t, ok := templates[id]
+		if !ok {
+			unknown = append(unknown, id)
+			continue
+		}
+		specs = append(specs, tmux.WindowSpec{Name: t.Name, AfterCreateCmd: t.AfterCreateCmd})
+	}
+	return specs, unknown
 }
 
 // Merge combines live Tmux panes and config entries into a unified []Session.
 // Match rule: Tmux session name must equal entry.DisplayName() exactly.
 func Merge(panes []tmux.Pane, entries []ConfigEntry) []Session {
-    grouped := tmux.GroupBySessions(panes)
-    activity := tmux.SessionActivityMap(panes)
+	grouped := tmux.GroupBySessions(panes)
+	activity := tmux.SessionActivityMap(panes)
 
-    configByName := make(map[string]*ConfigEntry, len(entries))
-    for i := range entries {
-        configByName[entries[i].DisplayName()] = &entries[i]
-    }
+	configByName := make(map[string]*ConfigEntry, len(entries))
+	for i := range entries {
+		configByName[entries[i].DisplayName()] = &entries[i]
+	}
 
-    matched := make(map[string]bool, len(entries))
-    var sessions []Session
+	matched := make(map[string]bool, len(entries))
+	var sessions []Session
 
-    for name, windows := range grouped {
-        s := Session{
-            DisplayName: name,
-            IsLive:      true,
-            Panes:       windows,
-            Activity:    activity[name],
-        }
-        if ce, ok := configByName[name]; ok {
-            s.IsConfig = true
-            s.Config = ce
-            matched[name] = true
-        }
-        sessions = append(sessions, s)
-    }
+	for name, windows := range grouped {
+		s := Session{
+			DisplayName: name,
+			IsLive:      true,
+			Panes:       windows,
+			Activity:    activity[name],
+		}
+		if ce, ok := configByName[name]; ok {
+			s.IsConfig = true
+			s.Config = ce
+			matched[name] = true
+		}
+		sessions = append(sessions, s)
+	}
 
-    for i := range entries {
-        dn := entries[i].DisplayName()
-        if !matched[dn] {
-            sessions = append(sessions, Session{
-                DisplayName: dn,
-                IsLive:      false,
-                IsConfig:    true,
-                Config:      &entries[i],
-            })
-        }
-    }
+	for i := range entries {
+		dn := entries[i].DisplayName()
+		if !matched[dn] {
+			sessions = append(sessions, Session{
+				DisplayName: dn,
+				IsLive:      false,
+				IsConfig:    true,
+				Config:      &entries[i],
+			})
+		}
+	}
 
-    return sessions
+	return sessions
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,66 +1,66 @@
 package session
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func TestConfigEntry_DisplayName(t *testing.T) {
-    e := ConfigEntry{Group: "dotf", Name: "dotf-main"}
-    if got := e.DisplayName(); got != "dotf-main" {
-        t.Errorf("expected dotf-main, got %s", got)
-    }
+	e := ConfigEntry{Group: "dotf", Name: "dotf-main"}
+	if got := e.DisplayName(); got != "dotf-main" {
+		t.Errorf("expected dotf-main, got %s", got)
+	}
 }
 
 func TestMerge_LiveOnly(t *testing.T) {
-    panes := []tmux.Pane{{Session: "myapp"}}
-    sessions := Merge(panes, nil)
-    if len(sessions) != 1 {
-        t.Fatalf("expected 1, got %d", len(sessions))
-    }
-    if !sessions[0].IsLive || sessions[0].IsConfig {
-        t.Error("expected IsLive=true, IsConfig=false")
-    }
-    if sessions[0].DisplayName != "myapp" {
-        t.Errorf("expected myapp, got %s", sessions[0].DisplayName)
-    }
+	panes := []tmux.Pane{{Session: "myapp"}}
+	sessions := Merge(panes, nil)
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1, got %d", len(sessions))
+	}
+	if !sessions[0].IsLive || sessions[0].IsConfig {
+		t.Error("expected IsLive=true, IsConfig=false")
+	}
+	if sessions[0].DisplayName != "myapp" {
+		t.Errorf("expected myapp, got %s", sessions[0].DisplayName)
+	}
 }
 
 func TestMerge_ConfigOnly(t *testing.T) {
-    entries := []ConfigEntry{{Name: "dotf-main", Group: "dotf", Path: "/foo"}}
-    sessions := Merge(nil, entries)
-    if len(sessions) != 1 {
-        t.Fatalf("expected 1, got %d", len(sessions))
-    }
-    s := sessions[0]
-    if s.IsLive || !s.IsConfig {
-        t.Error("expected IsLive=false, IsConfig=true")
-    }
-    if s.DisplayName != "dotf-main" {
-        t.Errorf("expected dotf-main, got %s", s.DisplayName)
-    }
+	entries := []ConfigEntry{{Name: "dotf-main", Group: "dotf", Path: "/foo"}}
+	sessions := Merge(nil, entries)
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1, got %d", len(sessions))
+	}
+	s := sessions[0]
+	if s.IsLive || !s.IsConfig {
+		t.Error("expected IsLive=false, IsConfig=true")
+	}
+	if s.DisplayName != "dotf-main" {
+		t.Errorf("expected dotf-main, got %s", s.DisplayName)
+	}
 }
 
 func TestMerge_ExactMatch_MergesIntoOne(t *testing.T) {
-    panes := []tmux.Pane{{Session: "dotf-main"}}
-    entries := []ConfigEntry{{Name: "dotf-main", Group: "dotf", Path: "/foo"}}
-    sessions := Merge(panes, entries)
-    if len(sessions) != 1 {
-        t.Fatalf("expected 1 merged session, got %d", len(sessions))
-    }
-    s := sessions[0]
-    if !s.IsLive || !s.IsConfig {
-        t.Error("expected IsLive=true, IsConfig=true")
-    }
+	panes := []tmux.Pane{{Session: "dotf-main"}}
+	entries := []ConfigEntry{{Name: "dotf-main", Group: "dotf", Path: "/foo"}}
+	sessions := Merge(panes, entries)
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 merged session, got %d", len(sessions))
+	}
+	s := sessions[0]
+	if !s.IsLive || !s.IsConfig {
+		t.Error("expected IsLive=true, IsConfig=true")
+	}
 }
 
 func TestMerge_NoPartialMatch(t *testing.T) {
-    // Tmux "dotfiles" does NOT match config "dotf-main"
-    panes := []tmux.Pane{{Session: "dotfiles"}}
-    entries := []ConfigEntry{{Name: "dotf-main", Group: "dotf", Path: "/foo"}}
-    sessions := Merge(panes, entries)
-    if len(sessions) != 2 {
-        t.Fatalf("expected 2 separate sessions, got %d", len(sessions))
-    }
+	// Tmux "dotfiles" does NOT match config "dotf-main"
+	panes := []tmux.Pane{{Session: "dotfiles"}}
+	entries := []ConfigEntry{{Name: "dotf-main", Group: "dotf", Path: "/foo"}}
+	sessions := Merge(panes, entries)
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 separate sessions, got %d", len(sessions))
+	}
 }

--- a/internal/tmux/launch.go
+++ b/internal/tmux/launch.go
@@ -1,37 +1,37 @@
 package tmux
 
 import (
-    "fmt"
-    "os"
-    "os/exec"
+	"fmt"
+	"os"
+	"os/exec"
 )
 
 // WindowSpec describes a window to create inside a tmux session.
 type WindowSpec struct {
-    Name           string
-    AfterCreateCmd string
+	Name           string
+	AfterCreateCmd string
 }
 
 // NewSession creates a detached tmux session named `name` rooted at `path`,
 // then switches the client to it. Returns an error if name or path is empty,
 // or if the path does not exist on disk.
 func NewSession(name, path string) error {
-    if name == "" {
-        return fmt.Errorf("session name is required")
-    }
-    if path == "" {
-        return fmt.Errorf("session path is required")
-    }
-    if _, err := os.Stat(path); err != nil {
-        return fmt.Errorf("session path %q: %w", path, err)
-    }
-    if err := exec.Command("tmux", "new-session", "-d", "-s", name, "-c", path).Run(); err != nil {
-        return fmt.Errorf("tmux new-session: %w", err)
-    }
-    if err := exec.Command("tmux", "switch-client", "-t", name).Run(); err != nil {
-        return fmt.Errorf("tmux switch-client: %w", err)
-    }
-    return nil
+	if name == "" {
+		return fmt.Errorf("session name is required")
+	}
+	if path == "" {
+		return fmt.Errorf("session path is required")
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("session path %q: %w", path, err)
+	}
+	if err := exec.Command("tmux", "new-session", "-d", "-s", name, "-c", path).Run(); err != nil {
+		return fmt.Errorf("tmux new-session: %w", err)
+	}
+	if err := exec.Command("tmux", "switch-client", "-t", name).Run(); err != nil {
+		return fmt.Errorf("tmux switch-client: %w", err)
+	}
+	return nil
 }
 
 // CreateSessionWindows configures windows for an existing tmux session.
@@ -40,25 +40,25 @@ func NewSession(name, path string) error {
 // windows for windows[1:]. path is the starting directory for new windows;
 // when non-empty it is passed as -c to tmux new-window. A nil or empty list is a no-op.
 func CreateSessionWindows(sessionName, path string, windows []WindowSpec) error {
-    for i, w := range windows {
-        if i == 0 {
-            if err := exec.Command("tmux", "rename-window", "-t", sessionName+":0", w.Name).Run(); err != nil {
-                return fmt.Errorf("tmux rename-window %q: %w", w.Name, err)
-            }
-        } else {
-            if err := exec.Command("tmux", "new-window", "-t", sessionName, "-n", w.Name, "-c", path).Run(); err != nil {
-                return fmt.Errorf("tmux new-window %q: %w", w.Name, err)
-            }
-            if err := exec.Command("tmux", "rename-window", "-t", fmt.Sprintf("%s:%d", sessionName, i), w.Name).Run(); err != nil {
-                return fmt.Errorf("tmux rename-window %q: %w", w.Name, err)
-            }
-        }
-        if w.AfterCreateCmd != "" {
-            target := fmt.Sprintf("%s:%d", sessionName, i)
-            if err := exec.Command("tmux", "send-keys", "-t", target, w.AfterCreateCmd, "Enter").Run(); err != nil {
-                return fmt.Errorf("tmux send-keys %q: %w", w.Name, err)
-            }
-        }
-    }
-    return nil
+	for i, w := range windows {
+		if i == 0 {
+			if err := exec.Command("tmux", "rename-window", "-t", sessionName+":0", w.Name).Run(); err != nil {
+				return fmt.Errorf("tmux rename-window %q: %w", w.Name, err)
+			}
+		} else {
+			if err := exec.Command("tmux", "new-window", "-t", sessionName, "-n", w.Name, "-c", path).Run(); err != nil {
+				return fmt.Errorf("tmux new-window %q: %w", w.Name, err)
+			}
+			if err := exec.Command("tmux", "rename-window", "-t", fmt.Sprintf("%s:%d", sessionName, i), w.Name).Run(); err != nil {
+				return fmt.Errorf("tmux rename-window %q: %w", w.Name, err)
+			}
+		}
+		if w.AfterCreateCmd != "" {
+			target := fmt.Sprintf("%s:%d", sessionName, i)
+			if err := exec.Command("tmux", "send-keys", "-t", target, w.AfterCreateCmd, "Enter").Run(); err != nil {
+				return fmt.Errorf("tmux send-keys %q: %w", w.Name, err)
+			}
+		}
+	}
+	return nil
 }

--- a/internal/tmux/launch_test.go
+++ b/internal/tmux/launch_test.go
@@ -1,26 +1,26 @@
 package tmux
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestNewSession_PathRequired(t *testing.T) {
-    err := NewSession("test-session", "")
-    if err == nil {
-        t.Error("expected error for empty path")
-    }
+	err := NewSession("test-session", "")
+	if err == nil {
+		t.Error("expected error for empty path")
+	}
 }
 
 func TestNewSession_NameRequired(t *testing.T) {
-    err := NewSession("", "/tmp")
-    if err == nil {
-        t.Error("expected error for empty name")
-    }
+	err := NewSession("", "/tmp")
+	if err == nil {
+		t.Error("expected error for empty name")
+	}
 }
 
 func TestNewSession_PathNotExist(t *testing.T) {
-    err := NewSession("test-session", "/tmp/demux-no-such-dir-xyz")
-    if err == nil {
-        t.Error("expected error for nonexistent path")
-    }
+	err := NewSession("test-session", "/tmp/demux-no-such-dir-xyz")
+	if err == nil {
+		t.Error("expected error for nonexistent path")
+	}
 }

--- a/internal/tmux/pane_cwd.go
+++ b/internal/tmux/pane_cwd.go
@@ -3,13 +3,13 @@ package tmux
 // PrimaryPaneCWD returns the CWD of pane index 0, falling back to the first pane.
 // Returns "" if panes is empty.
 func PrimaryPaneCWD(panes []Pane) string {
-    for _, p := range panes {
-        if p.PaneIndex == 0 {
-            return p.CWD
-        }
-    }
-    if len(panes) > 0 {
-        return panes[0].CWD
-    }
-    return ""
+	for _, p := range panes {
+		if p.PaneIndex == 0 {
+			return p.CWD
+		}
+	}
+	if len(panes) > 0 {
+		return panes[0].CWD
+	}
+	return ""
 }

--- a/internal/tmux/pane_cwd_test.go
+++ b/internal/tmux/pane_cwd_test.go
@@ -1,25 +1,25 @@
 package tmux_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func TestPrimaryPaneCWD(t *testing.T) {
-    cases := []struct {
-        name  string
-        panes []tmux.Pane
-        want  string
-    }{
-        {"empty", nil, ""},
-        {"pane 0 first", []tmux.Pane{{PaneIndex: 0, CWD: "/a"}, {PaneIndex: 1, CWD: "/b"}}, "/a"},
-        {"no pane 0 fallback", []tmux.Pane{{PaneIndex: 1, CWD: "/b"}}, "/b"},
-    }
-    for _, c := range cases {
-        got := tmux.PrimaryPaneCWD(c.panes)
-        if got != c.want {
-            t.Errorf("%s: PrimaryPaneCWD = %q, want %q", c.name, got, c.want)
-        }
-    }
+	cases := []struct {
+		name  string
+		panes []tmux.Pane
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"pane 0 first", []tmux.Pane{{PaneIndex: 0, CWD: "/a"}, {PaneIndex: 1, CWD: "/b"}}, "/a"},
+		{"no pane 0 fallback", []tmux.Pane{{PaneIndex: 1, CWD: "/b"}}, "/b"},
+	}
+	for _, c := range cases {
+		got := tmux.PrimaryPaneCWD(c.panes)
+		if got != c.want {
+			t.Errorf("%s: PrimaryPaneCWD = %q, want %q", c.name, got, c.want)
+		}
+	}
 }

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -1,133 +1,133 @@
 package tmux
 
 import (
-    "fmt"
-    "os/exec"
-    "strconv"
-    "strings"
-    "time"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type Pane struct {
-    Session     string
-    WindowIndex int
-    PaneIndex   int
-    CWD         string
-    PaneID      string // e.g. %12
-    WindowName  string
-    PanePID         int32  // PID of the shell process running in this pane
-    SessionActivity int64  // Unix timestamp from #{session_activity}
+	Session         string
+	WindowIndex     int
+	PaneIndex       int
+	CWD             string
+	PaneID          string // e.g. %12
+	WindowName      string
+	PanePID         int32 // PID of the shell process running in this pane
+	SessionActivity int64 // Unix timestamp from #{session_activity}
 }
 
 // ListPanes runs tmux list-panes and returns all panes across all sessions.
 func ListPanes() ([]Pane, error) {
-    out, err := exec.Command("tmux", "list-panes", "-a",
-        "-F", "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_current_path}\t#{pane_id}\t#{window_name}\t#{pane_pid}\t#{session_activity}",
-    ).Output()
-    if err != nil {
-        return nil, fmt.Errorf("tmux list-panes: %w", err)
-    }
-    return ParsePanes(string(out))
+	out, err := exec.Command("tmux", "list-panes", "-a",
+		"-F", "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_current_path}\t#{pane_id}\t#{window_name}\t#{pane_pid}\t#{session_activity}",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("tmux list-panes: %w", err)
+	}
+	return ParsePanes(string(out))
 }
 
 func ParsePanes(raw string) ([]Pane, error) {
-    var panes []Pane
-    for _, line := range strings.Split(raw, "\n") {
-        line = strings.TrimSpace(line)
-        if line == "" {
-            continue
-        }
-        parts := strings.Split(line, "\t")
-        if len(parts) < 4 {
-            continue
-        }
-        wi, _ := strconv.Atoi(parts[1])
-        pi, _ := strconv.Atoi(parts[2])
-        p := Pane{
-            Session:     parts[0],
-            WindowIndex: wi,
-            PaneIndex:   pi,
-            CWD:         parts[3],
-        }
-        if len(parts) >= 5 {
-            p.PaneID = parts[4]
-        }
-        if len(parts) >= 6 {
-            p.WindowName = parts[5]
-        }
-        if len(parts) >= 7 {
-            if pid, err := strconv.ParseInt(strings.TrimSpace(parts[6]), 10, 32); err == nil {
-                p.PanePID = int32(pid)
-            }
-        }
-        if len(parts) >= 8 {
-            if ts, err := strconv.ParseInt(strings.TrimSpace(parts[7]), 10, 64); err == nil {
-                p.SessionActivity = ts
-            }
-        }
-        panes = append(panes, p)
-    }
-    return panes, nil
+	var panes []Pane
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) < 4 {
+			continue
+		}
+		wi, _ := strconv.Atoi(parts[1])
+		pi, _ := strconv.Atoi(parts[2])
+		p := Pane{
+			Session:     parts[0],
+			WindowIndex: wi,
+			PaneIndex:   pi,
+			CWD:         parts[3],
+		}
+		if len(parts) >= 5 {
+			p.PaneID = parts[4]
+		}
+		if len(parts) >= 6 {
+			p.WindowName = parts[5]
+		}
+		if len(parts) >= 7 {
+			if pid, err := strconv.ParseInt(strings.TrimSpace(parts[6]), 10, 32); err == nil {
+				p.PanePID = int32(pid)
+			}
+		}
+		if len(parts) >= 8 {
+			if ts, err := strconv.ParseInt(strings.TrimSpace(parts[7]), 10, 64); err == nil {
+				p.SessionActivity = ts
+			}
+		}
+		panes = append(panes, p)
+	}
+	return panes, nil
 }
 
 // GroupBySessions organises panes into a map[session]map[windowIndex][]Pane.
 func GroupBySessions(panes []Pane) map[string]map[int][]Pane {
-    m := make(map[string]map[int][]Pane)
-    for _, p := range panes {
-        if m[p.Session] == nil {
-            m[p.Session] = make(map[int][]Pane)
-        }
-        m[p.Session][p.WindowIndex] = append(m[p.Session][p.WindowIndex], p)
-    }
-    return m
+	m := make(map[string]map[int][]Pane)
+	for _, p := range panes {
+		if m[p.Session] == nil {
+			m[p.Session] = make(map[int][]Pane)
+		}
+		m[p.Session][p.WindowIndex] = append(m[p.Session][p.WindowIndex], p)
+	}
+	return m
 }
 
 // SessionActivityMap returns the most recent session_activity timestamp per
 // session name, derived from the already-fetched pane list.
 func SessionActivityMap(panes []Pane) map[string]time.Time {
-    m := make(map[string]time.Time, len(panes))
-    for _, p := range panes {
-        if p.SessionActivity <= 0 {
-            continue
-        }
-        t := time.Unix(p.SessionActivity, 0)
-        if existing, ok := m[p.Session]; !ok || t.After(existing) {
-            m[p.Session] = t
-        }
-    }
-    return m
+	m := make(map[string]time.Time, len(panes))
+	for _, p := range panes {
+		if p.SessionActivity <= 0 {
+			continue
+		}
+		t := time.Unix(p.SessionActivity, 0)
+		if existing, ok := m[p.Session]; !ok || t.After(existing) {
+			m[p.Session] = t
+		}
+	}
+	return m
 }
 
 // ParseCurrentTarget parses the output of `tmux display-message -p "#{session_name}\t#{window_index}"`.
 // Empty input is treated as an error because a real tmux invocation only produces empty output
 // in degenerate states; the caller (CurrentTarget) surfaces the exec error before this is reached.
 func ParseCurrentTarget(raw string) (string, int, error) {
-    raw = strings.TrimSpace(raw)
-    if raw == "" {
-        return "", 0, fmt.Errorf("empty output")
-    }
-    parts := strings.SplitN(raw, "\t", 2)
-    if len(parts) < 2 {
-        return "", 0, fmt.Errorf("unexpected format: %q", raw)
-    }
-    wi, err := strconv.Atoi(strings.TrimSpace(parts[1]))
-    if err != nil {
-        return "", 0, fmt.Errorf("invalid window index: %w", err)
-    }
-    return parts[0], wi, nil
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", 0, fmt.Errorf("empty output")
+	}
+	parts := strings.SplitN(raw, "\t", 2)
+	if len(parts) < 2 {
+		return "", 0, fmt.Errorf("unexpected format: %q", raw)
+	}
+	wi, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid window index: %w", err)
+	}
+	return parts[0], wi, nil
 }
 
 // CurrentTarget returns the session name and window index of the tmux client
 // that launched this process. Returns an error if tmux is unavailable.
 func CurrentTarget() (string, int, error) {
-    out, err := exec.Command("tmux", "display-message", "-p", "#{session_name}\t#{window_index}").Output()
-    if err != nil {
-        return "", 0, fmt.Errorf("tmux display-message: %w", err)
-    }
-    return ParseCurrentTarget(string(out))
+	out, err := exec.Command("tmux", "display-message", "-p", "#{session_name}\t#{window_index}").Output()
+	if err != nil {
+		return "", 0, fmt.Errorf("tmux display-message: %w", err)
+	}
+	return ParseCurrentTarget(string(out))
 }
 
 // SwitchClient runs tmux switch-client -t target.
 func SwitchClient(target string) error {
-    return exec.Command("tmux", "switch-client", "-t", target).Run()
+	return exec.Command("tmux", "switch-client", "-t", target).Run()
 }

--- a/internal/tmux/query_test.go
+++ b/internal/tmux/query_test.go
@@ -1,158 +1,158 @@
 package tmux_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func TestParsePanes(t *testing.T) {
-    raw := "mysession\t0\t0\t/home/dev/project\t%1\teditor\n" +
-        "mysession\t0\t1\t/home/dev/project/ui\t%2\teditor\n" +
-        "mysession\t1\t0\t/home/dev/project\t%3\tserver\n"
+	raw := "mysession\t0\t0\t/home/dev/project\t%1\teditor\n" +
+		"mysession\t0\t1\t/home/dev/project/ui\t%2\teditor\n" +
+		"mysession\t1\t0\t/home/dev/project\t%3\tserver\n"
 
-    panes, err := tmux.ParsePanes(raw)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(panes) != 3 {
-        t.Fatalf("expected 3, got %d", len(panes))
-    }
-    if panes[0].Session != "mysession" {
-        t.Errorf("unexpected session: %s", panes[0].Session)
-    }
-    if panes[1].PaneIndex != 1 {
-        t.Errorf("unexpected pane index: %d", panes[1].PaneIndex)
-    }
-    if panes[1].CWD != "/home/dev/project/ui" {
-        t.Errorf("unexpected cwd: %s", panes[1].CWD)
-    }
-    if panes[0].PaneID != "%1" {
-        t.Errorf("unexpected pane id: %s", panes[0].PaneID)
-    }
-    if panes[0].WindowName != "editor" {
-        t.Errorf("unexpected window name: %s", panes[0].WindowName)
-    }
+	panes, err := tmux.ParsePanes(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(panes) != 3 {
+		t.Fatalf("expected 3, got %d", len(panes))
+	}
+	if panes[0].Session != "mysession" {
+		t.Errorf("unexpected session: %s", panes[0].Session)
+	}
+	if panes[1].PaneIndex != 1 {
+		t.Errorf("unexpected pane index: %d", panes[1].PaneIndex)
+	}
+	if panes[1].CWD != "/home/dev/project/ui" {
+		t.Errorf("unexpected cwd: %s", panes[1].CWD)
+	}
+	if panes[0].PaneID != "%1" {
+		t.Errorf("unexpected pane id: %s", panes[0].PaneID)
+	}
+	if panes[0].WindowName != "editor" {
+		t.Errorf("unexpected window name: %s", panes[0].WindowName)
+	}
 }
 
 func TestGroupBySessions(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "s1", WindowIndex: 0, PaneIndex: 0, CWD: "/a"},
-        {Session: "s1", WindowIndex: 0, PaneIndex: 1, CWD: "/b"},
-        {Session: "s1", WindowIndex: 1, PaneIndex: 0, CWD: "/c"},
-        {Session: "s2", WindowIndex: 0, PaneIndex: 0, CWD: "/d"},
-    }
-    grouped := tmux.GroupBySessions(panes)
+	panes := []tmux.Pane{
+		{Session: "s1", WindowIndex: 0, PaneIndex: 0, CWD: "/a"},
+		{Session: "s1", WindowIndex: 0, PaneIndex: 1, CWD: "/b"},
+		{Session: "s1", WindowIndex: 1, PaneIndex: 0, CWD: "/c"},
+		{Session: "s2", WindowIndex: 0, PaneIndex: 0, CWD: "/d"},
+	}
+	grouped := tmux.GroupBySessions(panes)
 
-    if len(grouped) != 2 {
-        t.Fatalf("expected 2 sessions, got %d", len(grouped))
-    }
-    if len(grouped["s1"][0]) != 2 {
-        t.Errorf("expected 2 panes in s1:window0, got %d", len(grouped["s1"][0]))
-    }
-    if len(grouped["s1"][1]) != 1 {
-        t.Errorf("expected 1 pane in s1:window1, got %d", len(grouped["s1"][1]))
-    }
-    if len(grouped["s2"][0]) != 1 {
-        t.Errorf("expected 1 pane in s2:window0, got %d", len(grouped["s2"][0]))
-    }
+	if len(grouped) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(grouped))
+	}
+	if len(grouped["s1"][0]) != 2 {
+		t.Errorf("expected 2 panes in s1:window0, got %d", len(grouped["s1"][0]))
+	}
+	if len(grouped["s1"][1]) != 1 {
+		t.Errorf("expected 1 pane in s1:window1, got %d", len(grouped["s1"][1]))
+	}
+	if len(grouped["s2"][0]) != 1 {
+		t.Errorf("expected 1 pane in s2:window0, got %d", len(grouped["s2"][0]))
+	}
 }
 
 func TestParsePanesEmpty(t *testing.T) {
-    panes, err := tmux.ParsePanes("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(panes) != 0 {
-        t.Errorf("expected 0 panes, got %d", len(panes))
-    }
+	panes, err := tmux.ParsePanes("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(panes) != 0 {
+		t.Errorf("expected 0 panes, got %d", len(panes))
+	}
 }
 
 func TestParsePanes_WithSessionActivity(t *testing.T) {
-    // 8 fields: session, window_index, pane_index, cwd, pane_id, window_name, pane_pid, session_activity
-    raw := "mysession\t0\t0\t/home/dev\t%1\teditor\t1234\t1711652000\n"
-    panes, err := tmux.ParsePanes(raw)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(panes) != 1 {
-        t.Fatalf("expected 1 pane, got %d", len(panes))
-    }
-    if panes[0].SessionActivity != 1711652000 {
-        t.Errorf("expected SessionActivity=1711652000, got %d", panes[0].SessionActivity)
-    }
+	// 8 fields: session, window_index, pane_index, cwd, pane_id, window_name, pane_pid, session_activity
+	raw := "mysession\t0\t0\t/home/dev\t%1\teditor\t1234\t1711652000\n"
+	panes, err := tmux.ParsePanes(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(panes) != 1 {
+		t.Fatalf("expected 1 pane, got %d", len(panes))
+	}
+	if panes[0].SessionActivity != 1711652000 {
+		t.Errorf("expected SessionActivity=1711652000, got %d", panes[0].SessionActivity)
+	}
 }
 
 func TestParsePanes_WithoutSessionActivity_BackwardCompat(t *testing.T) {
-    // Old 7-field format (no session_activity) should still parse with SessionActivity=0
-    raw := "mysession\t0\t0\t/home/dev\t%1\teditor\t1234\n"
-    panes, err := tmux.ParsePanes(raw)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if len(panes) != 1 {
-        t.Fatalf("expected 1 pane, got %d", len(panes))
-    }
-    if panes[0].SessionActivity != 0 {
-        t.Errorf("expected SessionActivity=0 for old format, got %d", panes[0].SessionActivity)
-    }
+	// Old 7-field format (no session_activity) should still parse with SessionActivity=0
+	raw := "mysession\t0\t0\t/home/dev\t%1\teditor\t1234\n"
+	panes, err := tmux.ParsePanes(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(panes) != 1 {
+		t.Fatalf("expected 1 pane, got %d", len(panes))
+	}
+	if panes[0].SessionActivity != 0 {
+		t.Errorf("expected SessionActivity=0 for old format, got %d", panes[0].SessionActivity)
+	}
 }
 
 func TestSessionActivityMap_MaxPerSession(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "s1", SessionActivity: 1000},
-        {Session: "s1", SessionActivity: 3000}, // max for s1
-        {Session: "s2", SessionActivity: 2000},
-    }
-    m := tmux.SessionActivityMap(panes)
-    if m["s1"].Unix() != 3000 {
-        t.Errorf("expected s1=3000, got %d", m["s1"].Unix())
-    }
-    if m["s2"].Unix() != 2000 {
-        t.Errorf("expected s2=2000, got %d", m["s2"].Unix())
-    }
+	panes := []tmux.Pane{
+		{Session: "s1", SessionActivity: 1000},
+		{Session: "s1", SessionActivity: 3000}, // max for s1
+		{Session: "s2", SessionActivity: 2000},
+	}
+	m := tmux.SessionActivityMap(panes)
+	if m["s1"].Unix() != 3000 {
+		t.Errorf("expected s1=3000, got %d", m["s1"].Unix())
+	}
+	if m["s2"].Unix() != 2000 {
+		t.Errorf("expected s2=2000, got %d", m["s2"].Unix())
+	}
 }
 
 func TestSessionActivityMap_Empty(t *testing.T) {
-    m := tmux.SessionActivityMap(nil)
-    if len(m) != 0 {
-        t.Errorf("expected empty map, got %v", m)
-    }
+	m := tmux.SessionActivityMap(nil)
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %v", m)
+	}
 }
 
 func TestSessionActivityMap_ZeroTimestampSkipped(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "s1", SessionActivity: 0},
-    }
-    m := tmux.SessionActivityMap(panes)
-    if _, ok := m["s1"]; ok {
-        t.Error("expected s1 to be absent (zero timestamp skipped)")
-    }
+	panes := []tmux.Pane{
+		{Session: "s1", SessionActivity: 0},
+	}
+	m := tmux.SessionActivityMap(panes)
+	if _, ok := m["s1"]; ok {
+		t.Error("expected s1 to be absent (zero timestamp skipped)")
+	}
 }
 
 func TestParseCurrentTarget(t *testing.T) {
-    session, window, err := tmux.ParseCurrentTarget("myproject\t3\n")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if session != "myproject" {
-        t.Errorf("expected session \"myproject\", got %q", session)
-    }
-    if window != 3 {
-        t.Errorf("expected window 3, got %d", window)
-    }
+	session, window, err := tmux.ParseCurrentTarget("myproject\t3\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session != "myproject" {
+		t.Errorf("expected session \"myproject\", got %q", session)
+	}
+	if window != 3 {
+		t.Errorf("expected window 3, got %d", window)
+	}
 }
 
 func TestParseCurrentTarget_Empty(t *testing.T) {
-    _, _, err := tmux.ParseCurrentTarget("")
-    if err == nil {
-        t.Error("expected error for empty input")
-    }
+	_, _, err := tmux.ParseCurrentTarget("")
+	if err == nil {
+		t.Error("expected error for empty input")
+	}
 }
 
 func TestParseCurrentTarget_NoTab(t *testing.T) {
-    _, _, err := tmux.ParseCurrentTarget("myproject")
-    if err == nil {
-        t.Error("expected error for input with no tab")
-    }
+	_, _, err := tmux.ParseCurrentTarget("myproject")
+	if err == nil {
+		t.Error("expected error for input with no tab")
+	}
 }

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -1,255 +1,254 @@
 package tui
 
 import (
-    "fmt"
-    "path/filepath"
-    "strings"
+	"fmt"
+	"path/filepath"
+	"strings"
 
-    "github.com/charmbracelet/lipgloss"
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/format"
-    "github.com/rtalexk/demux/internal/git"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
 )
-
 
 type DetailSelection int
 
 const (
-    DetailNone DetailSelection = iota
-    DetailSession
-    DetailWindow
-    DetailProc
+	DetailNone DetailSelection = iota
+	DetailSession
+	DetailWindow
+	DetailProc
 )
 
 type DetailModel struct {
-    selType DetailSelection
-    cfg     config.Config
+	selType DetailSelection
+	cfg     config.Config
 
-    // session
-    session        string
-    sessionCWD     string
-    configPath     string // populated for config-only (non-live) sessions
-    configWorktree string // worktree name for config-only sessions with Worktree=true
-    isConfigOnly   bool   // true when session exists in config but is not currently live
-    gitInfo      git.Info
-    prInfo       string
-    winCount     int
-    paneCount    int
-    procCount    int
-    alertCount   int
+	// session
+	session        string
+	sessionCWD     string
+	configPath     string // populated for config-only (non-live) sessions
+	configWorktree string // worktree name for config-only sessions with Worktree=true
+	isConfigOnly   bool   // true when session exists in config but is not currently live
+	gitInfo        git.Info
+	prInfo         string
+	winCount       int
+	paneCount      int
+	procCount      int
+	alertCount     int
 
-    // window
-    windowIndex int
-    windowPanes []tmux.Pane
-    windowGit   git.Info
-    windowAlert *db.Alert
+	// window
+	windowIndex int
+	windowPanes []tmux.Pane
+	windowGit   git.Info
+	windowAlert *db.Alert
 
-    // proc
-    proc     proc.Process
-    procGit  git.Info
-    procPort string
-    procCWD  string
+	// proc
+	proc     proc.Process
+	procGit  git.Info
+	procPort string
+	procCWD  string
 }
 
 // ContentLines returns the number of visual rows the detail content will occupy
 // at the given inner width (panel width minus border). Long values wrap at valueW.
 func (d DetailModel) ContentLines(innerWidth int) int {
-    var lines []string
-    switch d.selType {
-    case DetailSession:
-        lines = d.renderSession()
-    case DetailWindow:
-        lines = d.renderWindow()
-    case DetailProc:
-        lines = d.renderProc(innerWidth)
-    default:
-        return 1
-    }
-    valueW := innerWidth - 10 // label is 10 wide
-    if valueW < 1 {
-        valueW = 1
-    }
-    total := 0
-    for _, l := range lines {
-        if l == "" {
-            total++
-            continue
-        }
-        plain := stripANSI(l)
-        // plain width = label(10) + value; count wrapped rows
-        rows := (len([]rune(plain)) + innerWidth - 1) / innerWidth
-        if rows < 1 {
-            rows = 1
-        }
-        _ = valueW
-        total += rows
-    }
-    return total
+	var lines []string
+	switch d.selType {
+	case DetailSession:
+		lines = d.renderSession()
+	case DetailWindow:
+		lines = d.renderWindow()
+	case DetailProc:
+		lines = d.renderProc(innerWidth)
+	default:
+		return 1
+	}
+	valueW := innerWidth - 10 // label is 10 wide
+	if valueW < 1 {
+		valueW = 1
+	}
+	total := 0
+	for _, l := range lines {
+		if l == "" {
+			total++
+			continue
+		}
+		plain := stripANSI(l)
+		// plain width = label(10) + value; count wrapped rows
+		rows := (len([]rune(plain)) + innerWidth - 1) / innerWidth
+		if rows < 1 {
+			rows = 1
+		}
+		_ = valueW
+		total += rows
+	}
+	return total
 }
 
 func (d DetailModel) Render(width, height int) string {
-    innerW := width - 2
-    var lines []string
-    switch d.selType {
-    case DetailSession:
-        lines = d.renderSession()
-    case DetailWindow:
-        lines = d.renderWindow()
-    case DetailProc:
-        lines = d.renderProc(innerW)
-    default:
-        lines = []string{
-            noSelectionStyle.Render("No selection"),
-        }
-    }
-    maxLines := height - 2
-    if maxLines < 0 {
-        maxLines = 0
-    }
-    if len(lines) > maxLines {
-        lines = lines[:maxLines]
-    }
-    inner := strings.Join(lines, "\n")
-    return detailBorder.Width(innerW).Height(height - 2).Render(inner)
+	innerW := width - 2
+	var lines []string
+	switch d.selType {
+	case DetailSession:
+		lines = d.renderSession()
+	case DetailWindow:
+		lines = d.renderWindow()
+	case DetailProc:
+		lines = d.renderProc(innerW)
+	default:
+		lines = []string{
+			noSelectionStyle.Render("No selection"),
+		}
+	}
+	maxLines := height - 2
+	if maxLines < 0 {
+		maxLines = 0
+	}
+	if len(lines) > maxLines {
+		lines = lines[:maxLines]
+	}
+	inner := strings.Join(lines, "\n")
+	return detailBorder.Width(innerW).Height(height - 2).Render(inner)
 }
 
 func worktreeValue(info git.Info) string {
-    if info.RepoRoot == "" {
-        return info.Worktree
-    }
-    root := info.RepoRoot
-    // Bare-repo worktree convention: demux/.bare + demux/main/ → show parent "demux"
-    if filepath.Base(root) == info.Worktree {
-        root = filepath.Dir(root)
-    }
-    return info.Worktree + " (" + filepath.Base(root) + ")"
+	if info.RepoRoot == "" {
+		return info.Worktree
+	}
+	root := info.RepoRoot
+	// Bare-repo worktree convention: demux/.bare + demux/main/ → show parent "demux"
+	if filepath.Base(root) == info.Worktree {
+		root = filepath.Dir(root)
+	}
+	return info.Worktree + " (" + filepath.Base(root) + ")"
 }
 
 func row(label, value string) string {
-    return detailLabelStyle.Render(label) + detailValueStyle.Render(value)
+	return detailLabelStyle.Render(label) + detailValueStyle.Render(value)
 }
 
 func inlineStat(label, value string) string {
-    return detailLabelStyle.Width(0).Render(label+":") + " " + detailValueStyle.Render(value)
+	return detailLabelStyle.Width(0).Render(label+":") + " " + detailValueStyle.Render(value)
 }
 
 func (d DetailModel) renderSession() []string {
-    if d.isConfigOnly {
-        var lines []string
-        if d.configPath != "" {
-            lines = append(lines, row("path", format.ShortenPath(d.configPath, d.cfg.PathAliases)))
-        }
-        if d.configWorktree != "" {
-            lines = append(lines, row("worktree", d.configWorktree))
-        }
-        return lines
-    }
-    lines := []string{
-        row("path", format.ShortenPath(d.sessionCWD, d.cfg.PathAliases)),
-    }
-    if d.gitInfo.Worktree != "" {
-        lines = append(lines, row("worktree", worktreeValue(d.gitInfo)))
-    } else if d.gitInfo.IsWorktreeRoot {
-        bareStr := lipgloss.NewStyle().Italic(true).Render("_bare_")
-        lines = append(lines, row("worktree", bareStr+" ("+filepath.Base(d.gitInfo.Dir)+")"))
-    }
-    if d.gitInfo.Branch != "" {
-        branch := d.gitInfo.Branch
-        if ind := gitIndicatorsLong(d.gitInfo); ind != "" {
-            branch += "  " + ind
-        }
-        lines = append(lines, row("branch", branch))
-    }
-    if d.prInfo != "" {
-        lines = append(lines, row("pr", d.prInfo))
-    }
-    lines = append(lines,
-        "",
-        inlineStat("windows", fmt.Sprint(d.winCount))+"   "+
-            inlineStat("panes", fmt.Sprint(d.paneCount))+"   "+
-            inlineStat("procs", fmt.Sprint(d.procCount))+"   "+
-            inlineStat("alerts", fmt.Sprint(d.alertCount)),
-    )
-    return lines
+	if d.isConfigOnly {
+		var lines []string
+		if d.configPath != "" {
+			lines = append(lines, row("path", format.ShortenPath(d.configPath, d.cfg.PathAliases)))
+		}
+		if d.configWorktree != "" {
+			lines = append(lines, row("worktree", d.configWorktree))
+		}
+		return lines
+	}
+	lines := []string{
+		row("path", format.ShortenPath(d.sessionCWD, d.cfg.PathAliases)),
+	}
+	if d.gitInfo.Worktree != "" {
+		lines = append(lines, row("worktree", worktreeValue(d.gitInfo)))
+	} else if d.gitInfo.IsWorktreeRoot {
+		bareStr := lipgloss.NewStyle().Italic(true).Render("_bare_")
+		lines = append(lines, row("worktree", bareStr+" ("+filepath.Base(d.gitInfo.Dir)+")"))
+	}
+	if d.gitInfo.Branch != "" {
+		branch := d.gitInfo.Branch
+		if ind := gitIndicatorsLong(d.gitInfo); ind != "" {
+			branch += "  " + ind
+		}
+		lines = append(lines, row("branch", branch))
+	}
+	if d.prInfo != "" {
+		lines = append(lines, row("pr", d.prInfo))
+	}
+	lines = append(lines,
+		"",
+		inlineStat("windows", fmt.Sprint(d.winCount))+"   "+
+			inlineStat("panes", fmt.Sprint(d.paneCount))+"   "+
+			inlineStat("procs", fmt.Sprint(d.procCount))+"   "+
+			inlineStat("alerts", fmt.Sprint(d.alertCount)),
+	)
+	return lines
 }
 
 func (d DetailModel) renderWindow() []string {
-    lines := []string{
-        row("path", format.ShortenPath(d.sessionCWD, d.cfg.PathAliases)),
-    }
-    if d.gitInfo.Worktree != "" {
-        lines = append(lines, row("worktree", worktreeValue(d.gitInfo)))
-    }
-    if d.gitInfo.Branch != "" {
-        branch := d.gitInfo.Branch
-        if ind := gitIndicatorsLong(d.gitInfo); ind != "" {
-            branch += "  " + ind
-        }
-        lines = append(lines, row("branch", branch))
-    }
-    if d.prInfo != "" {
-        lines = append(lines, row("pr", d.prInfo))
-    }
-    lines = append(lines,
-        "",
-        inlineStat("panes", fmt.Sprint(len(d.windowPanes)))+"   "+
-            inlineStat("procs", fmt.Sprint(d.procCount))+"   "+
-            inlineStat("alerts", fmt.Sprint(d.alertCount)),
-    )
-    return lines
+	lines := []string{
+		row("path", format.ShortenPath(d.sessionCWD, d.cfg.PathAliases)),
+	}
+	if d.gitInfo.Worktree != "" {
+		lines = append(lines, row("worktree", worktreeValue(d.gitInfo)))
+	}
+	if d.gitInfo.Branch != "" {
+		branch := d.gitInfo.Branch
+		if ind := gitIndicatorsLong(d.gitInfo); ind != "" {
+			branch += "  " + ind
+		}
+		lines = append(lines, row("branch", branch))
+	}
+	if d.prInfo != "" {
+		lines = append(lines, row("pr", d.prInfo))
+	}
+	lines = append(lines,
+		"",
+		inlineStat("panes", fmt.Sprint(len(d.windowPanes)))+"   "+
+			inlineStat("procs", fmt.Sprint(d.procCount))+"   "+
+			inlineStat("alerts", fmt.Sprint(d.alertCount)),
+	)
+	return lines
 }
 
 func (d DetailModel) renderProc(innerWidth int) []string {
-    valueW := innerWidth - 10 // label column is 10 wide
-    if valueW < 8 {
-        valueW = 8
-    }
-    cmd := d.proc.Cmdline
-    cmdRunes := []rune(cmd)
-    if len(cmdRunes) > valueW {
-        cmdRunes = append(cmdRunes[:valueW-1], '…')
-        cmd = string(cmdRunes)
-    }
-    lines := []string{
-        row("name", d.proc.FriendlyName()),
-        row("pid", fmt.Sprint(d.proc.PID)),
-        row("cmd", cmd),
-        row("uptime", formatProcDuration(d.proc.Uptime)),
-        row("memory", fmt.Sprintf("%.1fMB", float64(d.proc.MemRSS)/1024/1024)),
-    }
-    if d.procPort != "" {
-        lines = append(lines, row("port", d.procPort))
-    }
-    if d.procCWD != "" {
-        lines = append(lines, row("cwd", format.ShortenPath(d.procCWD, d.cfg.PathAliases)))
-    }
-    if d.procGit.Branch != "" {
-        lines = append(lines, "")
-        if d.procGit.Worktree != "" {
-            lines = append(lines, row("worktree", worktreeValue(d.procGit)))
-        }
-        branch := d.procGit.Branch
-        if ind := gitIndicatorsLong(d.procGit); ind != "" {
-            branch += "  " + ind
-        }
-        lines = append(lines, row("branch", branch))
-    }
-    return lines
+	valueW := innerWidth - 10 // label column is 10 wide
+	if valueW < 8 {
+		valueW = 8
+	}
+	cmd := d.proc.Cmdline
+	cmdRunes := []rune(cmd)
+	if len(cmdRunes) > valueW {
+		cmdRunes = append(cmdRunes[:valueW-1], '…')
+		cmd = string(cmdRunes)
+	}
+	lines := []string{
+		row("name", d.proc.FriendlyName()),
+		row("pid", fmt.Sprint(d.proc.PID)),
+		row("cmd", cmd),
+		row("uptime", formatProcDuration(d.proc.Uptime)),
+		row("memory", fmt.Sprintf("%.1fMB", float64(d.proc.MemRSS)/1024/1024)),
+	}
+	if d.procPort != "" {
+		lines = append(lines, row("port", d.procPort))
+	}
+	if d.procCWD != "" {
+		lines = append(lines, row("cwd", format.ShortenPath(d.procCWD, d.cfg.PathAliases)))
+	}
+	if d.procGit.Branch != "" {
+		lines = append(lines, "")
+		if d.procGit.Worktree != "" {
+			lines = append(lines, row("worktree", worktreeValue(d.procGit)))
+		}
+		branch := d.procGit.Branch
+		if ind := gitIndicatorsLong(d.procGit); ind != "" {
+			branch += "  " + ind
+		}
+		lines = append(lines, row("branch", branch))
+	}
+	return lines
 }
 
 func gitIndicatorsLong(info git.Info) string {
-    var parts []string
-    if info.Ahead > 0 {
-        parts = append(parts, gitAheadStyle.Render(fmt.Sprintf("↑%d", info.Ahead)))
-    }
-    if info.Behind > 0 {
-        parts = append(parts, gitBehindStyle.Render(fmt.Sprintf("↓%d", info.Behind)))
-    }
-    if info.Dirty {
-        parts = append(parts, gitDirtyStyle.Render("*"))
-    }
-    return strings.Join(parts, " ")
+	var parts []string
+	if info.Ahead > 0 {
+		parts = append(parts, gitAheadStyle.Render(fmt.Sprintf("↑%d", info.Ahead)))
+	}
+	if info.Behind > 0 {
+		parts = append(parts, gitBehindStyle.Render(fmt.Sprintf("↓%d", info.Behind)))
+	}
+	if info.Dirty {
+		parts = append(parts, gitDirtyStyle.Render("*"))
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -1,77 +1,77 @@
 package tui
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/git"
 )
 
 func TestDetailRender_clipsContentToHeight(t *testing.T) {
-    d := DetailModel{
-        selType:    DetailSession,
-        sessionCWD: "/some/path",
-        winCount:   3,
-        procCount:  6,
-        alertCount: 1,
-    }
-    // height=6 → inner=4, so content must be clipped to 4 lines
-    rendered := d.Render(40, 6)
-    inner := stripANSI(rendered)
-    lines := strings.Split(strings.TrimRight(inner, "\n"), "\n")
-    // subtract 2 border lines
-    contentLines := len(lines) - 2
-    if contentLines > 4 {
-        t.Errorf("expected at most 4 content lines for height=6, got %d", contentLines)
-    }
+	d := DetailModel{
+		selType:    DetailSession,
+		sessionCWD: "/some/path",
+		winCount:   3,
+		procCount:  6,
+		alertCount: 1,
+	}
+	// height=6 → inner=4, so content must be clipped to 4 lines
+	rendered := d.Render(40, 6)
+	inner := stripANSI(rendered)
+	lines := strings.Split(strings.TrimRight(inner, "\n"), "\n")
+	// subtract 2 border lines
+	contentLines := len(lines) - 2
+	if contentLines > 4 {
+		t.Errorf("expected at most 4 content lines for height=6, got %d", contentLines)
+	}
 }
 
 func TestDetailRender_emptyStateWhenNoSelection(t *testing.T) {
-    d := DetailModel{}
-    rendered := d.Render(40, 8)
-    if !strings.Contains(stripANSI(rendered), "No selection") {
-        t.Error("expected 'No selection' for empty DetailModel")
-    }
+	d := DetailModel{}
+	rendered := d.Render(40, 8)
+	if !strings.Contains(stripANSI(rendered), "No selection") {
+		t.Error("expected 'No selection' for empty DetailModel")
+	}
 }
 
 func TestWorktreeValue_bareRepoConvention(t *testing.T) {
-    // demux/.bare + demux/main/ → worktree dir == worktree name → show parent "demux"
-    info := git.Info{Worktree: "main", RepoRoot: "/home/user/demux/main"}
-    got := worktreeValue(info)
-    if got != "main (demux)" {
-        t.Errorf("bare-repo case: got %q, want %q", got, "main (demux)")
-    }
+	// demux/.bare + demux/main/ → worktree dir == worktree name → show parent "demux"
+	info := git.Info{Worktree: "main", RepoRoot: "/home/user/demux/main"}
+	got := worktreeValue(info)
+	if got != "main (demux)" {
+		t.Errorf("bare-repo case: got %q, want %q", got, "main (demux)")
+	}
 }
 
 func TestWorktreeValue_standardLinkedWorktree(t *testing.T) {
-    // Non-bare linked worktree: working dir name differs from worktree name
-    info := git.Info{Worktree: "feature", RepoRoot: "/home/user/myproject-feature"}
-    got := worktreeValue(info)
-    if got != "feature (myproject-feature)" {
-        t.Errorf("standard worktree case: got %q, want %q", got, "feature (myproject-feature)")
-    }
+	// Non-bare linked worktree: working dir name differs from worktree name
+	info := git.Info{Worktree: "feature", RepoRoot: "/home/user/myproject-feature"}
+	got := worktreeValue(info)
+	if got != "feature (myproject-feature)" {
+		t.Errorf("standard worktree case: got %q, want %q", got, "feature (myproject-feature)")
+	}
 }
 
 func TestWorktreeValue_noRepoRoot(t *testing.T) {
-    info := git.Info{Worktree: "main", RepoRoot: ""}
-    got := worktreeValue(info)
-    if got != "main" {
-        t.Errorf("no root case: got %q, want %q", got, "main")
-    }
+	info := git.Info{Worktree: "main", RepoRoot: ""}
+	got := worktreeValue(info)
+	if got != "main" {
+		t.Errorf("no root case: got %q, want %q", got, "main")
+	}
 }
 
 func TestDetailRender_showsSessionFields(t *testing.T) {
-    d := DetailModel{
-        selType:    DetailSession,
-        sessionCWD: "/work/myses",
-        winCount:   2,
-        procCount:  4,
-        alertCount: 0,
-    }
-    rendered := stripANSI(d.Render(60, 14))
-    for _, want := range []string{"/work/myses", "2", "4"} {
-        if !strings.Contains(rendered, want) {
-            t.Errorf("expected %q in session detail, got:\n%s", want, rendered)
-        }
-    }
+	d := DetailModel{
+		selType:    DetailSession,
+		sessionCWD: "/work/myses",
+		winCount:   2,
+		procCount:  4,
+		alertCount: 0,
+	}
+	rendered := stripANSI(d.Render(60, 14))
+	for _, want := range []string{"/work/myses", "2", "4"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("expected %q in session detail, got:\n%s", want, rendered)
+		}
+	}
 }

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -1,118 +1,118 @@
 package tui
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 )
 
 const (
-    helpContentWidth = 44
-    // helpOverhead is the number of rows consumed by the overlay border and padding.
-    helpOverhead = 4 // border top+bottom (2) + padding top+bottom (2)
+	helpContentWidth = 44
+	// helpOverhead is the number of rows consumed by the overlay border and padding.
+	helpOverhead = 4 // border top+bottom (2) + padding top+bottom (2)
 )
 
 type HelpModel struct {
-    scrollOffset int
+	scrollOffset int
 }
 
 func helpSection(name string) string {
-    prefix := paneSepStyle.Render("─── ")
-    label := paneHeaderStyle.Render(name)
-    fillLen := helpContentWidth - 4 - len(name) - 1
-    if fillLen < 0 {
-        fillLen = 0
-    }
-    suffix := paneSepStyle.Render(" " + strings.Repeat("─", fillLen))
-    return prefix + label + suffix
+	prefix := paneSepStyle.Render("─── ")
+	label := paneHeaderStyle.Render(name)
+	fillLen := helpContentWidth - 4 - len(name) - 1
+	if fillLen < 0 {
+		fillLen = 0
+	}
+	suffix := paneSepStyle.Render(" " + strings.Repeat("─", fillLen))
+	return prefix + label + suffix
 }
 
 // helpKV formats a keybinding line: key column padded to keyW, description grayed.
 func helpKV(keyW int, k, description string) string {
-    return fmt.Sprintf("  %-*s", keyW, k) + helpDescStyle.Render(description)
+	return fmt.Sprintf("  %-*s", keyW, k) + helpDescStyle.Render(description)
 }
 
 // helpNavLine builds a Navigation prose line. Even-indexed parts (key tokens) render
 // in normal color; odd-indexed parts (separators / trailing description) are grayed.
 func helpNavLine(parts ...string) string {
-    var b strings.Builder
-    b.WriteString("  ")
-    for i, p := range parts {
-        if i%2 == 0 {
-            b.WriteString(p)
-        } else {
-            b.WriteString(helpDescStyle.Render(p))
-        }
-    }
-    return b.String()
+	var b strings.Builder
+	b.WriteString("  ")
+	for i, p := range parts {
+		if i%2 == 0 {
+			b.WriteString(p)
+		} else {
+			b.WriteString(helpDescStyle.Render(p))
+		}
+	}
+	return b.String()
 }
 
 func (h *HelpModel) ScrollUp() {
-    if h.scrollOffset > 0 {
-        h.scrollOffset--
-    }
+	if h.scrollOffset > 0 {
+		h.scrollOffset--
+	}
 }
 
 func (h *HelpModel) ScrollDown(availH int) {
-    lines := h.buildLines()
-    visible := max(availH-helpOverhead, 1)
-    maxOffset := max(len(lines)-visible, 0)
-    if h.scrollOffset < maxOffset {
-        h.scrollOffset++
-    }
+	lines := h.buildLines()
+	visible := max(availH-helpOverhead, 1)
+	maxOffset := max(len(lines)-visible, 0)
+	if h.scrollOffset < maxOffset {
+		h.scrollOffset++
+	}
 }
 
 func (h HelpModel) buildLines() []string {
-    return []string{
-        helpSection("Global"),
-        helpKV(8, "h / l", "focus sidebar / process list"),
-        helpKV(8, "y", "yank menu"),
-        helpKV(8, "f", "filter"),
-        helpKV(8, "ctrl+u", "clear filter"),
-        helpKV(8, "R", "force refresh"),
-        helpKV(8, "?", "toggle help"),
-        helpKV(8, "q", "quit"),
-        "",
-        helpSection("Navigation"),
-        helpNavLine("j/k", " · ", "ctrl+j/n", " · ", "ctrl+k/p", " navigate."),
-        helpNavLine("Tab/Shift+Tab", " cycles (wraps).  ", "g/G", " jumps."),
-        "",
-        helpSection("Sidebar"),
-        helpKV(7, "Enter", "expand session / select window"),
-        helpKV(7, "o", "attach to session / window"),
-        helpKV(7, "Esc", "back to session level"),
-        helpKV(7, keys.Defer.Help().Key, keys.Defer.Help().Desc),
-        "",
-        helpSection("Filters"),
-        helpKV(3, "t", "tmux sessions only (default)"),
-        helpKV(3, "a", "all sessions (tmux + config)"),
-        helpKV(3, "c", "config sessions only"),
-        helpKV(3, "w", "sessions in current worktree"),
-        helpKV(3, "!", "alert filter"),
-        "",
-        helpSection("Process list"),
-        helpKV(7, "J / K", "jump to next/prev pane"),
-        helpKV(7, "] / [", "expand / collapse group"),
-        helpKV(7, "} / {", "expand / collapse all"),
-        helpKV(7, "Enter", "attach to session:window"),
-        helpKV(7, "o", "attach to pane"),
-        helpKV(7, "x", "kill process"),
-        helpKV(7, "r", "restart process"),
-        helpKV(7, "L", "open log popup"),
-    }
+	return []string{
+		helpSection("Global"),
+		helpKV(8, "h / l", "focus sidebar / process list"),
+		helpKV(8, "y", "yank menu"),
+		helpKV(8, "f", "filter"),
+		helpKV(8, "ctrl+u", "clear filter"),
+		helpKV(8, "R", "force refresh"),
+		helpKV(8, "?", "toggle help"),
+		helpKV(8, "q", "quit"),
+		"",
+		helpSection("Navigation"),
+		helpNavLine("j/k", " · ", "ctrl+j/n", " · ", "ctrl+k/p", " navigate."),
+		helpNavLine("Tab/Shift+Tab", " cycles (wraps).  ", "g/G", " jumps."),
+		"",
+		helpSection("Sidebar"),
+		helpKV(7, "Enter", "expand session / select window"),
+		helpKV(7, "o", "attach to session / window"),
+		helpKV(7, "Esc", "back to session level"),
+		helpKV(7, keys.Defer.Help().Key, keys.Defer.Help().Desc),
+		"",
+		helpSection("Filters"),
+		helpKV(3, "t", "tmux sessions only (default)"),
+		helpKV(3, "a", "all sessions (tmux + config)"),
+		helpKV(3, "c", "config sessions only"),
+		helpKV(3, "w", "sessions in current worktree"),
+		helpKV(3, "!", "alert filter"),
+		"",
+		helpSection("Process list"),
+		helpKV(7, "J / K", "jump to next/prev pane"),
+		helpKV(7, "] / [", "expand / collapse group"),
+		helpKV(7, "} / {", "expand / collapse all"),
+		helpKV(7, "Enter", "attach to session:window"),
+		helpKV(7, "o", "attach to pane"),
+		helpKV(7, "x", "kill process"),
+		helpKV(7, "r", "restart process"),
+		helpKV(7, "L", "open log popup"),
+	}
 }
 
 // Render returns the styled help overlay, clipped to maxH terminal rows.
 // Pass maxH=0 to render without clipping (for tests).
 func (h HelpModel) Render(maxH int) string {
-    lines := h.buildLines()
+	lines := h.buildLines()
 
-    if maxH > 0 {
-        visible := max(maxH-helpOverhead, 1)
-        if len(lines) > visible {
-            start := min(h.scrollOffset, len(lines)-visible)
-            lines = lines[start : start+visible]
-        }
-    }
+	if maxH > 0 {
+		visible := max(maxH-helpOverhead, 1)
+		if len(lines) > visible {
+			start := min(h.scrollOffset, len(lines)-visible)
+			lines = lines[start : start+visible]
+		}
+	}
 
-    return helpStyle.Render(strings.Join(lines, "\n"))
+	return helpStyle.Render(strings.Join(lines, "\n"))
 }

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -1,69 +1,69 @@
 package tui
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 func TestHelpSection_ContainsSectionName(t *testing.T) {
-    initStyles(Theme{}, config.ProcessesConfig{}, nil)
-    out := stripANSI(helpSection("MySection"))
-    if !strings.Contains(out, "MySection") {
-        t.Errorf("expected section name in output, got: %q", out)
-    }
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	out := stripANSI(helpSection("MySection"))
+	if !strings.Contains(out, "MySection") {
+		t.Errorf("expected section name in output, got: %q", out)
+	}
 }
 
 func TestHelpSection_HasSeparatorChars(t *testing.T) {
-    initStyles(Theme{}, config.ProcessesConfig{}, nil)
-    out := stripANSI(helpSection("Test"))
-    if !strings.Contains(out, "─") {
-        t.Errorf("expected separator char ─, got: %q", out)
-    }
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	out := stripANSI(helpSection("Test"))
+	if !strings.Contains(out, "─") {
+		t.Errorf("expected separator char ─, got: %q", out)
+	}
 }
 
 func TestHelpSection_StartsWithSeparatorPrefix(t *testing.T) {
-    initStyles(Theme{}, config.ProcessesConfig{}, nil)
-    out := stripANSI(helpSection("Test"))
-    if !strings.HasPrefix(out, "─── ") {
-        t.Errorf("expected '─── ' prefix, got: %q", out)
-    }
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	out := stripANSI(helpSection("Test"))
+	if !strings.HasPrefix(out, "─── ") {
+		t.Errorf("expected '─── ' prefix, got: %q", out)
+	}
 }
 
 func TestHelpSection_TotalWidth(t *testing.T) {
-    initStyles(Theme{}, config.ProcessesConfig{}, nil)
-    out := stripANSI(helpSection("Global"))
-    runes := []rune(out)
-    if len(runes) != helpContentWidth {
-        t.Errorf("expected width %d, got %d: %q", helpContentWidth, len(runes), out)
-    }
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	out := stripANSI(helpSection("Global"))
+	runes := []rune(out)
+	if len(runes) != helpContentWidth {
+		t.Errorf("expected width %d, got %d: %q", helpContentWidth, len(runes), out)
+	}
 }
 
 func TestHelpRender_AllSectionHeaders(t *testing.T) {
-    initStyles(Theme{}, config.ProcessesConfig{}, nil)
-    out := stripANSI(HelpModel{}.Render(0))
-    for _, section := range []string{"Global", "Navigation", "Sidebar", "Filters", "Process list"} {
-        if !strings.Contains(out, section) {
-            t.Errorf("expected section %q in help output", section)
-        }
-    }
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	out := stripANSI(HelpModel{}.Render(0))
+	for _, section := range []string{"Global", "Navigation", "Sidebar", "Filters", "Process list"} {
+		if !strings.Contains(out, section) {
+			t.Errorf("expected section %q in help output", section)
+		}
+	}
 }
 
 func TestHelpRender_KeyBindings(t *testing.T) {
-    initStyles(Theme{}, config.ProcessesConfig{}, nil)
-    out := stripANSI(HelpModel{}.Render(0))
-    for _, want := range []string{
-        "h / l",   // corrected focus keys (was 1/2)
-        "ctrl+u",  // clear filter
-        "Shift+Tab", // backward navigate
-        "G",       // goto bottom
-        "] / [",   // expand/collapse group
-        "} / {",   // expand/collapse all
-        "L",       // log popup (uppercase, was lowercase l)
-    } {
-        if !strings.Contains(out, want) {
-            t.Errorf("expected %q in help output:\n%s", want, out)
-        }
-    }
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	out := stripANSI(HelpModel{}.Render(0))
+	for _, want := range []string{
+		"h / l",     // corrected focus keys (was 1/2)
+		"ctrl+u",    // clear filter
+		"Shift+Tab", // backward navigate
+		"G",         // goto bottom
+		"] / [",     // expand/collapse group
+		"} / {",     // expand/collapse all
+		"L",         // log popup (uppercase, was lowercase l)
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in help output:\n%s", want, out)
+		}
+	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -3,67 +3,67 @@ package tui
 import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
-    FocusSidebar  key.Binding
-    FocusProcList key.Binding
-    Yank          key.Binding
-    Refresh       key.Binding
-    Help          key.Binding
-    Quit          key.Binding
-    Up            key.Binding
-    Down          key.Binding
-    Enter         key.Binding
-    Esc           key.Binding
-    Kill          key.Binding
-    Restart       key.Binding
-    Log           key.Binding
-    JumpUp        key.Binding
-    JumpDown      key.Binding
-    Tab           key.Binding
-    ShiftTab      key.Binding
-    GotoTop         key.Binding
-    GotoBottom      key.Binding
-    FilterTmux      key.Binding
-    FilterAll       key.Binding
-    FilterConfig    key.Binding
-    FilterWorktree  key.Binding
-    Open          key.Binding
-    AlertFilter   key.Binding
-    Expand        key.Binding
-    Collapse      key.Binding
-    ExpandAll     key.Binding
-    CollapseAll   key.Binding
-    Defer         key.Binding
+	FocusSidebar   key.Binding
+	FocusProcList  key.Binding
+	Yank           key.Binding
+	Refresh        key.Binding
+	Help           key.Binding
+	Quit           key.Binding
+	Up             key.Binding
+	Down           key.Binding
+	Enter          key.Binding
+	Esc            key.Binding
+	Kill           key.Binding
+	Restart        key.Binding
+	Log            key.Binding
+	JumpUp         key.Binding
+	JumpDown       key.Binding
+	Tab            key.Binding
+	ShiftTab       key.Binding
+	GotoTop        key.Binding
+	GotoBottom     key.Binding
+	FilterTmux     key.Binding
+	FilterAll      key.Binding
+	FilterConfig   key.Binding
+	FilterWorktree key.Binding
+	Open           key.Binding
+	AlertFilter    key.Binding
+	Expand         key.Binding
+	Collapse       key.Binding
+	ExpandAll      key.Binding
+	CollapseAll    key.Binding
+	Defer          key.Binding
 }
 
 var keys = keyMap{
-    FocusSidebar:  key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "sidebar")),
-    FocusProcList: key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "procs")),
-    Yank:          key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yank")),
-    Refresh:       key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refresh")),
-    Help:          key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
-    Quit:          key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
-    Up:            key.NewBinding(key.WithKeys("k", "up", "ctrl+k", "ctrl+p")),
-    Down:          key.NewBinding(key.WithKeys("j", "down", "ctrl+j", "ctrl+n")),
-    Enter:         key.NewBinding(key.WithKeys("enter")),
-    Esc:           key.NewBinding(key.WithKeys("esc")),
-    Kill:          key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "kill")),
-    Restart:       key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "restart")),
-    Log:           key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "log")),
-    JumpUp:        key.NewBinding(key.WithKeys("K")),
-    JumpDown:      key.NewBinding(key.WithKeys("J")),
-    Tab:           key.NewBinding(key.WithKeys("tab")),
-    ShiftTab:      key.NewBinding(key.WithKeys("shift+tab")),
-    GotoTop:        key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "top")),
-    GotoBottom:     key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "bottom")),
-    FilterTmux:     key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tmux")),
-    FilterAll:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "all")),
-    FilterConfig:   key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "config")),
-    FilterWorktree: key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "worktree")),
-    Open:          key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "open/attach")),
-    AlertFilter:   key.NewBinding(key.WithKeys("!"), key.WithHelp("!", "alert filter")),
-    Expand:        key.NewBinding(key.WithKeys("]")),
-    Collapse:      key.NewBinding(key.WithKeys("[")),
-    ExpandAll:     key.NewBinding(key.WithKeys("}")),
-    CollapseAll:   key.NewBinding(key.WithKeys("{")),
-    Defer:         key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "defer")),
+	FocusSidebar:   key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "sidebar")),
+	FocusProcList:  key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "procs")),
+	Yank:           key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yank")),
+	Refresh:        key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refresh")),
+	Help:           key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+	Quit:           key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
+	Up:             key.NewBinding(key.WithKeys("k", "up", "ctrl+k", "ctrl+p")),
+	Down:           key.NewBinding(key.WithKeys("j", "down", "ctrl+j", "ctrl+n")),
+	Enter:          key.NewBinding(key.WithKeys("enter")),
+	Esc:            key.NewBinding(key.WithKeys("esc")),
+	Kill:           key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "kill")),
+	Restart:        key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "restart")),
+	Log:            key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "log")),
+	JumpUp:         key.NewBinding(key.WithKeys("K")),
+	JumpDown:       key.NewBinding(key.WithKeys("J")),
+	Tab:            key.NewBinding(key.WithKeys("tab")),
+	ShiftTab:       key.NewBinding(key.WithKeys("shift+tab")),
+	GotoTop:        key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "top")),
+	GotoBottom:     key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "bottom")),
+	FilterTmux:     key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tmux")),
+	FilterAll:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "all")),
+	FilterConfig:   key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "config")),
+	FilterWorktree: key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "worktree")),
+	Open:           key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "open/attach")),
+	AlertFilter:    key.NewBinding(key.WithKeys("!"), key.WithHelp("!", "alert filter")),
+	Expand:         key.NewBinding(key.WithKeys("]")),
+	Collapse:       key.NewBinding(key.WithKeys("[")),
+	ExpandAll:      key.NewBinding(key.WithKeys("}")),
+	CollapseAll:    key.NewBinding(key.WithKeys("{")),
+	Defer:          key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "defer")),
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,31 +1,31 @@
 package tui
 
 import (
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
-    "time"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/lipgloss"
-    xansi "github.com/charmbracelet/x/ansi"
-    runewidth "github.com/mattn/go-runewidth"
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/git"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/query"
-    "github.com/rtalexk/demux/internal/session"
-    "github.com/rtalexk/demux/internal/tmux"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
+	runewidth "github.com/mattn/go-runewidth"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/git"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/query"
+	"github.com/rtalexk/demux/internal/session"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 type panel int
 
 const (
-    panelSidebar panel = iota
-    panelProcList
+	panelSidebar panel = iota
+	panelProcList
 )
 
 const searchBoxH = 3
@@ -35,308 +35,308 @@ var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "�
 // Message types
 type tickMsg time.Time
 type panesMsg struct {
-    panes          []tmux.Pane
-    currentSession string // populated by CurrentTarget(); used for startup focus in Task 4
+	panes          []tmux.Pane
+	currentSession string // populated by CurrentTarget(); used for startup focus in Task 4
 }
 type alertsMsg struct{ alerts []db.Alert }
 type procDataMsg struct {
-    procs  []proc.Process
-    cwdMap map[int32]string
-    gen    int // generation counter — stale results are discarded
+	procs  []proc.Process
+	cwdMap map[int32]string
+	gen    int // generation counter — stale results are discarded
 }
 type gitResultMsg struct {
-    key  string // session name, or "session:window" for deviants
-    info git.Info
+	key  string // session name, or "session:window" for deviants
+	info git.Info
 }
 
 type searchDebounceMsg struct{ gen int }
 type queryResultMsg struct {
-    result query.Result
-    gen    int
+	result query.Result
+	gen    int
 }
 
 type Model struct {
-    cfg    config.Config
-    db     *db.DB
-    focus  panel
-    width  int
-    height int
+	cfg    config.Config
+	db     *db.DB
+	focus  panel
+	width  int
+	height int
 
-    panes   []tmux.Pane
-    alerts  []db.Alert
-    gitInfo map[string]git.Info // keyed by session name
-    procs   []proc.Process
-    cwdMap  map[int32]string // PID -> CWD, pre-fetched async
+	panes   []tmux.Pane
+	alerts  []db.Alert
+	gitInfo map[string]git.Info // keyed by session name
+	procs   []proc.Process
+	cwdMap  map[int32]string // PID -> CWD, pre-fetched async
 
-    sidebar  SidebarModel
-    procList ProcListModel
-    detail   DetailModel
-    yank     YankModel
-    help     HelpModel
+	sidebar  SidebarModel
+	procList ProcListModel
+	detail   DetailModel
+	yank     YankModel
+	help     HelpModel
 
-    showYank bool
-    showHelp bool
+	showYank bool
+	showHelp bool
 
-    pulse        bool
-    spinnerFrame int
-    statusMsg    string
-    statusExp    time.Time
-    ready        bool // true after first panesMsg — gates deferred fetches
-    procGen      int  // incremented on window change; discards in-flight proc fetches for old window
-    popupMode    bool // true when launched with DEMUX_POPUP=1; quits after attach
+	pulse        bool
+	spinnerFrame int
+	statusMsg    string
+	statusExp    time.Time
+	ready        bool // true after first panesMsg — gates deferred fetches
+	procGen      int  // incremented on window change; discards in-flight proc fetches for old window
+	popupMode    bool // true when launched with DEMUX_POPUP=1; quits after attach
 
-    currentSession   string
-    startupFocusDone bool
+	currentSession   string
+	startupFocusDone bool
 
-    searchInput SearchInputModel
-    queryResult query.Result
-    searchGen   int
+	searchInput SearchInputModel
+	queryResult query.Result
+	searchGen   int
 
-    sessionsConfig session.SessionsConfig
-    configDir      string
+	sessionsConfig session.SessionsConfig
+	configDir      string
 }
 
 func New(cfg config.Config, database *db.DB) Model {
-    initStyles(ThemeFromConfig(cfg.Theme), cfg.Theme.Processes, cfg.IgnoredProcesses)
-    m := Model{
-        cfg:       cfg,
-        db:        database,
-        focus:     panelSidebar,
-        gitInfo:   make(map[string]git.Info),
-        popupMode: os.Getenv("DEMUX_POPUP") == "1",
-    }
-    m.searchInput = NewSearchInputModel()
-    cfgPath, _ := config.DefaultPath()
-    m.configDir = filepath.Dir(cfgPath)
-    var loadErr error
-    m.sessionsConfig, loadErr = session.LoadConfigSessions(m.configDir)
-    if loadErr != nil {
-        demuxlog.Error("failed to load config sessions", "dir", m.configDir, "err", loadErr)
-    }
-    if cfg.Sidebar.DefaultFilter != "" {
-        m.sidebar.filter = SidebarFilter(cfg.Sidebar.DefaultFilter)
-    } else {
-        m.sidebar.filter = FilterTmux
-    }
-    return m
+	initStyles(ThemeFromConfig(cfg.Theme), cfg.Theme.Processes, cfg.IgnoredProcesses)
+	m := Model{
+		cfg:       cfg,
+		db:        database,
+		focus:     panelSidebar,
+		gitInfo:   make(map[string]git.Info),
+		popupMode: os.Getenv("DEMUX_POPUP") == "1",
+	}
+	m.searchInput = NewSearchInputModel()
+	cfgPath, _ := config.DefaultPath()
+	m.configDir = filepath.Dir(cfgPath)
+	var loadErr error
+	m.sessionsConfig, loadErr = session.LoadConfigSessions(m.configDir)
+	if loadErr != nil {
+		demuxlog.Error("failed to load config sessions", "dir", m.configDir, "err", loadErr)
+	}
+	if cfg.Sidebar.DefaultFilter != "" {
+		m.sidebar.filter = SidebarFilter(cfg.Sidebar.DefaultFilter)
+	} else {
+		m.sidebar.filter = FilterTmux
+	}
+	return m
 }
 
 func (m Model) Init() tea.Cmd {
-    // Only fetch panes on startup — sidebar renders immediately.
-    // fetchAlerts, fetchProcs, and the tick are deferred until panesMsg arrives.
-    return m.fetchPanes()
+	// Only fetch panes on startup — sidebar renders immediately.
+	// fetchAlerts, fetchProcs, and the tick are deferred until panesMsg arrives.
+	return m.fetchPanes()
 }
 
 func (m Model) View() string {
-    if m.width == 0 {
-        return "loading..."
-    }
+	if m.width == 0 {
+		return "loading..."
+	}
 
-    if m.cfg.Mode == "compact" {
-        return m.compactView()
-    }
+	if m.cfg.Mode == "compact" {
+		return m.compactView()
+	}
 
-    sidebarW := m.cfg.Sidebar.Width
-    if sidebarW <= 0 {
-        sidebarW = 30
-    }
-    procW := m.width - sidebarW
-    if procW < 10 {
-        procW = 10
-    }
+	sidebarW := m.cfg.Sidebar.Width
+	if sidebarW <= 0 {
+		sidebarW = 30
+	}
+	procW := m.width - sidebarW
+	if procW < 10 {
+		procW = 10
+	}
 
-    // sidebar spans full content height; proclist + detail stack on the right
-    contentH := m.height
-    if m.cfg.StatusBar.Show {
-        contentH-- // reserve 1 row for status bar
-    }
-    innerW := procW - 2
-    detailContent := m.detail.ContentLines(innerW)
-    detailH := detailContent + 2 // +2 for border
-    minDetailH := 4
-    maxDetailH := contentH - 4 // leave at least 4 rows for proc list
-    if detailH < minDetailH {
-        detailH = minDetailH
-    }
-    if detailH > maxDetailH {
-        detailH = maxDetailH
-    }
-    procH := contentH - detailH
+	// sidebar spans full content height; proclist + detail stack on the right
+	contentH := m.height
+	if m.cfg.StatusBar.Show {
+		contentH-- // reserve 1 row for status bar
+	}
+	innerW := procW - 2
+	detailContent := m.detail.ContentLines(innerW)
+	detailH := detailContent + 2 // +2 for border
+	minDetailH := 4
+	maxDetailH := contentH - 4 // leave at least 4 rows for proc list
+	if detailH < minDetailH {
+		detailH = minDetailH
+	}
+	if detailH > maxDetailH {
+		detailH = maxDetailH
+	}
+	procH := contentH - detailH
 
-    // build sidebar border title: [h] Sessions (N)
-    sessionCount := m.sidebar.SessionCount()
-    sessionCountStr := statValueStyle.Render(fmt.Sprintf("(%d)", sessionCount))
-    filterMark := ""
-    if f := m.sidebar.ActiveFilter(); f != FilterTmux {
-        filterMark = " [" + string(f) + "]"
-    }
-    sidebarTitle := fmt.Sprintf(" [h] Sessions %s%s ", sessionCountStr, filterMark)
+	// build sidebar border title: [h] Sessions (N)
+	sessionCount := m.sidebar.SessionCount()
+	sessionCountStr := statValueStyle.Render(fmt.Sprintf("(%d)", sessionCount))
+	filterMark := ""
+	if f := m.sidebar.ActiveFilter(); f != FilterTmux {
+		filterMark = " [" + string(f) + "]"
+	}
+	sidebarTitle := fmt.Sprintf(" [h] Sessions %s%s ", sessionCountStr, filterMark)
 
-    // build proc list border title: [l] <session> / <window>
-    bc := m.plainBreadcrumb()
-    procTitleSuffix := " "
-    if runes := []rune(bc); len(runes) > 0 && isIconRune(runes[len(runes)-1]) {
-        procTitleSuffix = "  "
-    }
-    procTitle := " [l] " + bc + procTitleSuffix
+	// build proc list border title: [l] <session> / <window>
+	bc := m.plainBreadcrumb()
+	procTitleSuffix := " "
+	if runes := []rune(bc); len(runes) > 0 && isIconRune(runes[len(runes)-1]) {
+		procTitleSuffix = "  "
+	}
+	procTitle := " [l] " + bc + procTitleSuffix
 
-    sidebarContent := m.sidebar.Render(sidebarW, contentH-searchBoxH, m.focus == panelSidebar, sidebarTitle, "")
-    searchBox := m.searchInput.View(sidebarW)
-    leftCol := lipgloss.JoinVertical(lipgloss.Left, searchBox, sidebarContent)
+	sidebarContent := m.sidebar.Render(sidebarW, contentH-searchBoxH, m.focus == panelSidebar, sidebarTitle, "")
+	searchBox := m.searchInput.View(sidebarW)
+	leftCol := lipgloss.JoinVertical(lipgloss.Left, searchBox, sidebarContent)
 
-    procList := m.procList.Render(procW, procH, m.focus == panelProcList, procTitle)
-    detail := m.detail.Render(procW, detailH)
+	procList := m.procList.Render(procW, procH, m.focus == panelProcList, procTitle)
+	detail := m.detail.Render(procW, detailH)
 
-    right := lipgloss.JoinVertical(lipgloss.Left, procList, detail)
-    content := lipgloss.JoinHorizontal(lipgloss.Top, leftCol, right)
-    body := content
+	right := lipgloss.JoinVertical(lipgloss.Left, procList, detail)
+	content := lipgloss.JoinHorizontal(lipgloss.Top, leftCol, right)
+	body := content
 
-    var full string
-    if m.cfg.StatusBar.Show {
-        statusBar := ""
-        if m.statusMsg != "" && time.Now().Before(m.statusExp) {
-            statusBar = m.statusMsg
-        }
-        if statusBar == "" {
-            if m.focus == panelSidebar {
-                statusBar = "  Tab:cycle  j/k:nav  Enter:select  !:alerts  ?:help  q:quit"
-            } else {
-                statusBar = "  Tab:cycle  j/k:nav  J/K:jump  x:kill  r:restart  l:log  q:quit"
-            }
-        }
-        spinnerStr := ""
-        if m.cfg.Git.ShowSpinner {
-            for _, info := range m.gitInfo {
-                if info.Loading {
-                    frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
-                    spinnerStr = " " + spinnerStyle.Render(frame) + " "
-                    break
-                }
-            }
-        }
-        if spinnerStr != "" {
-            leftWidth := m.width - lipgloss.Width(spinnerStr)
-            statusBar = lipgloss.JoinHorizontal(lipgloss.Top,
-                lipgloss.NewStyle().Width(leftWidth).MaxHeight(1).Render(statusBar),
-                spinnerStr,
-            )
-        } else {
-            statusBar = lipgloss.NewStyle().
-                Width(m.width).
-                MaxHeight(1).
-                Render(statusBar)
-        }
-        full = lipgloss.JoinVertical(lipgloss.Left, body, statusBar)
-    } else {
-        full = body
-    }
+	var full string
+	if m.cfg.StatusBar.Show {
+		statusBar := ""
+		if m.statusMsg != "" && time.Now().Before(m.statusExp) {
+			statusBar = m.statusMsg
+		}
+		if statusBar == "" {
+			if m.focus == panelSidebar {
+				statusBar = "  Tab:cycle  j/k:nav  Enter:select  !:alerts  ?:help  q:quit"
+			} else {
+				statusBar = "  Tab:cycle  j/k:nav  J/K:jump  x:kill  r:restart  l:log  q:quit"
+			}
+		}
+		spinnerStr := ""
+		if m.cfg.Git.ShowSpinner {
+			for _, info := range m.gitInfo {
+				if info.Loading {
+					frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+					spinnerStr = " " + spinnerStyle.Render(frame) + " "
+					break
+				}
+			}
+		}
+		if spinnerStr != "" {
+			leftWidth := m.width - lipgloss.Width(spinnerStr)
+			statusBar = lipgloss.JoinHorizontal(lipgloss.Top,
+				lipgloss.NewStyle().Width(leftWidth).MaxHeight(1).Render(statusBar),
+				spinnerStr,
+			)
+		} else {
+			statusBar = lipgloss.NewStyle().
+				Width(m.width).
+				MaxHeight(1).
+				Render(statusBar)
+		}
+		full = lipgloss.JoinVertical(lipgloss.Left, body, statusBar)
+	} else {
+		full = body
+	}
 
-    if m.showHelp {
-        return overlayCenter(m.help.Render(m.height), full, m.width, m.height)
-    }
-    if m.showYank {
-        return overlayCenter(m.yank.Render(), full, m.width, m.height)
-    }
+	if m.showHelp {
+		return overlayCenter(m.help.Render(m.height), full, m.width, m.height)
+	}
+	if m.showYank {
+		return overlayCenter(m.yank.Render(), full, m.width, m.height)
+	}
 
-    return full
+	return full
 }
 
 func (m Model) compactView() string {
-    contentH := m.height
-    if m.cfg.StatusBar.Show {
-        contentH-- // reserve 1 row for status bar
-    }
+	contentH := m.height
+	if m.cfg.StatusBar.Show {
+		contentH-- // reserve 1 row for status bar
+	}
 
-    sessionCount := m.sidebar.SessionCount()
-    sessionCountStr := statValueStyle.Render(fmt.Sprintf("(%d)", sessionCount))
-    filterMark := ""
-    if f := m.sidebar.ActiveFilter(); f != FilterTmux {
-        filterMark = " [" + string(f) + "]"
-    }
-    sidebarTitle := fmt.Sprintf(" [h] Sessions %s%s ", sessionCountStr, filterMark)
+	sessionCount := m.sidebar.SessionCount()
+	sessionCountStr := statValueStyle.Render(fmt.Sprintf("(%d)", sessionCount))
+	filterMark := ""
+	if f := m.sidebar.ActiveFilter(); f != FilterTmux {
+		filterMark = " [" + string(f) + "]"
+	}
+	sidebarTitle := fmt.Sprintf(" [h] Sessions %s%s ", sessionCountStr, filterMark)
 
-    // compact mode: sidebar is the only panel and always has focus
-    sidebarContent := m.sidebar.Render(m.width, contentH-searchBoxH, true, sidebarTitle, "")
-    searchBox := m.searchInput.View(m.width)
-    leftCol := lipgloss.JoinVertical(lipgloss.Left, searchBox, sidebarContent)
+	// compact mode: sidebar is the only panel and always has focus
+	sidebarContent := m.sidebar.Render(m.width, contentH-searchBoxH, true, sidebarTitle, "")
+	searchBox := m.searchInput.View(m.width)
+	leftCol := lipgloss.JoinVertical(lipgloss.Left, searchBox, sidebarContent)
 
-    var full string
-    if m.cfg.StatusBar.Show {
-        statusBar := "  j/k:nav  Enter:open  !:alerts  ?:help  q:quit"
-        if m.statusMsg != "" && time.Now().Before(m.statusExp) {
-            statusBar = m.statusMsg
-        }
-        spinnerStr := ""
-        if m.cfg.Git.ShowSpinner {
-            for _, info := range m.gitInfo {
-                if info.Loading {
-                    frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
-                    spinnerStr = " " + spinnerStyle.Render(frame) + " "
-                    break
-                }
-            }
-        }
-        if spinnerStr != "" {
-            leftWidth := m.width - lipgloss.Width(spinnerStr)
-            statusBar = lipgloss.JoinHorizontal(lipgloss.Top,
-                lipgloss.NewStyle().Width(leftWidth).MaxHeight(1).Render(statusBar),
-                spinnerStr,
-            )
-        } else {
-            statusBar = lipgloss.NewStyle().
-                Width(m.width).
-                MaxHeight(1).
-                Render(statusBar)
-        }
-        full = lipgloss.JoinVertical(lipgloss.Left, leftCol, statusBar)
-    } else {
-        full = leftCol
-    }
+	var full string
+	if m.cfg.StatusBar.Show {
+		statusBar := "  j/k:nav  Enter:open  !:alerts  ?:help  q:quit"
+		if m.statusMsg != "" && time.Now().Before(m.statusExp) {
+			statusBar = m.statusMsg
+		}
+		spinnerStr := ""
+		if m.cfg.Git.ShowSpinner {
+			for _, info := range m.gitInfo {
+				if info.Loading {
+					frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+					spinnerStr = " " + spinnerStyle.Render(frame) + " "
+					break
+				}
+			}
+		}
+		if spinnerStr != "" {
+			leftWidth := m.width - lipgloss.Width(spinnerStr)
+			statusBar = lipgloss.JoinHorizontal(lipgloss.Top,
+				lipgloss.NewStyle().Width(leftWidth).MaxHeight(1).Render(statusBar),
+				spinnerStr,
+			)
+		} else {
+			statusBar = lipgloss.NewStyle().
+				Width(m.width).
+				MaxHeight(1).
+				Render(statusBar)
+		}
+		full = lipgloss.JoinVertical(lipgloss.Left, leftCol, statusBar)
+	} else {
+		full = leftCol
+	}
 
-    if m.showHelp {
-        return overlayCenter(m.help.Render(m.height), full, m.width, m.height)
-    }
-    if m.showYank {
-        return overlayCenter(m.yank.Render(), full, m.width, m.height)
-    }
-    return full
+	if m.showHelp {
+		return overlayCenter(m.help.Render(m.height), full, m.width, m.height)
+	}
+	if m.showYank {
+		return overlayCenter(m.yank.Render(), full, m.width, m.height)
+	}
+	return full
 }
 
 // overlayCenter places fg centered on top of bg (bgW×bgH visible columns).
 // Uses ANSI-aware slicing so the background content remains visible.
 func overlayCenter(fg, bg string, bgW, bgH int) string {
-    fgLines := strings.Split(fg, "\n")
-    bgLines := strings.Split(bg, "\n")
+	fgLines := strings.Split(fg, "\n")
+	bgLines := strings.Split(bg, "\n")
 
-    fgH := len(fgLines)
-    fgW := 0
-    for _, l := range fgLines {
-        if w := lipgloss.Width(l); w > fgW {
-            fgW = w
-        }
-    }
+	fgH := len(fgLines)
+	fgW := 0
+	for _, l := range fgLines {
+		if w := lipgloss.Width(l); w > fgW {
+			fgW = w
+		}
+	}
 
-    startY := (bgH - fgH) / 2
-    startX := (bgW - fgW) / 2
-    if startX < 0 {
-        startX = 0
-    }
-    if startY < 0 {
-        startY = 0
-    }
+	startY := (bgH - fgH) / 2
+	startX := (bgW - fgW) / 2
+	if startX < 0 {
+		startX = 0
+	}
+	if startY < 0 {
+		startY = 0
+	}
 
-    result := make([]string, len(bgLines))
-    for i, bgLine := range bgLines {
-        fgIdx := i - startY
-        if fgIdx < 0 || fgIdx >= fgH {
-            result[i] = bgLine
-            continue
-        }
-        left := xansi.Truncate(bgLine, startX, "")
-        right := xansi.TruncateLeft(bgLine, startX+fgW, "")
-        result[i] = left + fgLines[fgIdx] + right
-    }
-    return strings.Join(result, "\n")
+	result := make([]string, len(bgLines))
+	for i, bgLine := range bgLines {
+		fgIdx := i - startY
+		if fgIdx < 0 || fgIdx >= fgH {
+			result[i] = bgLine
+			continue
+		}
+		left := xansi.Truncate(bgLine, startX, "")
+		right := xansi.TruncateLeft(bgLine, startX+fgW, "")
+		result[i] = left + fgLines[fgIdx] + right
+	}
+	return strings.Join(result, "\n")
 }
 
 // isIconRune reports whether r is likely a terminal icon that renders as 2
@@ -344,32 +344,32 @@ func overlayCenter(fg, bg string, bgW, bgH int) string {
 // (U+E000–U+F8FF, U+F0000+), and common symbol blocks that many terminals
 // render wide.
 func isIconRune(r rune) bool {
-    if runewidth.RuneWidth(r) > 1 {
-        return true
-    }
-    // Private Use Area — Nerd Font icons live here and render as 2-wide
-    // in terminals even though Unicode assigns them width 1.
-    if r >= 0xE000 && r <= 0xF8FF {
-        return true
-    }
-    if r >= 0xF0000 {
-        return true
-    }
-    return false
+	if runewidth.RuneWidth(r) > 1 {
+		return true
+	}
+	// Private Use Area — Nerd Font icons live here and render as 2-wide
+	// in terminals even though Unicode assigns them width 1.
+	if r >= 0xE000 && r <= 0xF8FF {
+		return true
+	}
+	if r >= 0xF0000 {
+		return true
+	}
+	return false
 }
 
 func (m Model) plainBreadcrumb() string {
-    node := m.sidebar.Selected()
-    if node == nil {
-        return ""
-    }
-    return node.Session
+	node := m.sidebar.Selected()
+	if node == nil {
+		return ""
+	}
+	return node.Session
 }
 
 // Run launches the Bubbletea program.
 func Run(cfg config.Config, database *db.DB) error {
-    m := New(cfg, database)
-    p := tea.NewProgram(m, tea.WithAltScreen())
-    _, err := p.Run()
-    return err
+	m := New(cfg, database)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	_, err := p.Run()
+	return err
 }

--- a/internal/tui/model_compact_test.go
+++ b/internal/tui/model_compact_test.go
@@ -1,129 +1,129 @@
 package tui
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/rtalexk/demux/internal/config"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 func TestCompactView_OmitsProcList(t *testing.T) {
-    cfg := config.Default()
-    cfg.Mode = "compact"
-    m := New(cfg, nil)
-    m.width = 40
-    m.height = 20
+	cfg := config.Default()
+	cfg.Mode = "compact"
+	m := New(cfg, nil)
+	m.width = 40
+	m.height = 20
 
-    view := m.View()
+	view := m.View()
 
-    // proclist border title always contains "[l]"
-    if strings.Contains(view, "[l]") {
-        t.Error("compact View() must not render the proc list panel")
-    }
+	// proclist border title always contains "[l]"
+	if strings.Contains(view, "[l]") {
+		t.Error("compact View() must not render the proc list panel")
+	}
 }
 
 func TestCompactView_ContainsSidebar(t *testing.T) {
-    cfg := config.Default()
-    cfg.Mode = "compact"
-    m := New(cfg, nil)
-    m.width = 40
-    m.height = 20
+	cfg := config.Default()
+	cfg.Mode = "compact"
+	m := New(cfg, nil)
+	m.width = 40
+	m.height = 20
 
-    view := m.View()
+	view := m.View()
 
-    // sidebar border title always contains "[h]"
-    if !strings.Contains(view, "[h]") {
-        t.Error("compact View() must render the sidebar panel")
-    }
+	// sidebar border title always contains "[h]"
+	if !strings.Contains(view, "[h]") {
+		t.Error("compact View() must render the sidebar panel")
+	}
 }
 
 func TestFullView_ContainsProcList(t *testing.T) {
-    cfg := config.Default()
-    // cfg.Mode defaults to "full"
-    m := New(cfg, nil)
-    m.width = 80
-    m.height = 24
+	cfg := config.Default()
+	// cfg.Mode defaults to "full"
+	m := New(cfg, nil)
+	m.width = 80
+	m.height = 24
 
-    view := m.View()
+	view := m.View()
 
-    if !strings.Contains(view, "[l]") {
-        t.Error("full View() must render the proc list panel")
-    }
+	if !strings.Contains(view, "[l]") {
+		t.Error("full View() must render the proc list panel")
+	}
 }
 
 func TestFullView_StatusBarHidden(t *testing.T) {
-    cfg := config.Default()
-    cfg.StatusBar.Show = false
-    m := New(cfg, nil)
-    m.width = 80
-    m.height = 24
+	cfg := config.Default()
+	cfg.StatusBar.Show = false
+	m := New(cfg, nil)
+	m.width = 80
+	m.height = 24
 
-    view := m.View()
+	view := m.View()
 
-    // status bar contains "q:quit" — must be absent when hidden
-    if strings.Contains(view, "q:quit") {
-        t.Error("full View() must not render status bar when StatusBar.Show = false")
-    }
+	// status bar contains "q:quit" — must be absent when hidden
+	if strings.Contains(view, "q:quit") {
+		t.Error("full View() must not render status bar when StatusBar.Show = false")
+	}
 }
 
 func TestFullView_StatusBarVisible(t *testing.T) {
-    cfg := config.Default()
-    // cfg.StatusBar.Show defaults to true
-    m := New(cfg, nil)
-    m.width = 80
-    m.height = 24
+	cfg := config.Default()
+	// cfg.StatusBar.Show defaults to true
+	m := New(cfg, nil)
+	m.width = 80
+	m.height = 24
 
-    view := m.View()
+	view := m.View()
 
-    if !strings.Contains(view, "q:quit") {
-        t.Error("full View() must render status bar when StatusBar.Show = true")
-    }
+	if !strings.Contains(view, "q:quit") {
+		t.Error("full View() must render status bar when StatusBar.Show = true")
+	}
 }
 
 func TestCompactView_StatusBarHidden(t *testing.T) {
-    cfg := config.Default()
-    cfg.Mode = "compact"
-    cfg.StatusBar.Show = false
-    m := New(cfg, nil)
-    m.width = 60 // wide enough that "q:quit" would appear if status bar rendered
-    m.height = 20
+	cfg := config.Default()
+	cfg.Mode = "compact"
+	cfg.StatusBar.Show = false
+	m := New(cfg, nil)
+	m.width = 60 // wide enough that "q:quit" would appear if status bar rendered
+	m.height = 20
 
-    view := m.View()
+	view := m.View()
 
-    if strings.Contains(view, "q:quit") {
-        t.Error("compact View() must not render status bar when StatusBar.Show = false")
-    }
+	if strings.Contains(view, "q:quit") {
+		t.Error("compact View() must not render status bar when StatusBar.Show = false")
+	}
 }
 
 func TestCompactView_StatusBarVisible(t *testing.T) {
-    cfg := config.Default()
-    cfg.Mode = "compact"
-    // cfg.StatusBar.Show defaults to true
-    m := New(cfg, nil)
-    m.width = 60 // wide enough that "q:quit" fits without lipgloss truncation
-    m.height = 20
+	cfg := config.Default()
+	cfg.Mode = "compact"
+	// cfg.StatusBar.Show defaults to true
+	m := New(cfg, nil)
+	m.width = 60 // wide enough that "q:quit" fits without lipgloss truncation
+	m.height = 20
 
-    view := m.View()
+	view := m.View()
 
-    if !strings.Contains(view, "q:quit") {
-        t.Error("compact View() must render status bar when StatusBar.Show = true")
-    }
+	if !strings.Contains(view, "q:quit") {
+		t.Error("compact View() must render status bar when StatusBar.Show = true")
+	}
 }
 
 func TestCompactUpdate_FocusProcListIsNoop(t *testing.T) {
-    cfg := config.Default()
-    cfg.Mode = "compact"
-    m := New(cfg, nil)
-    m.width = 40
-    m.height = 20
+	cfg := config.Default()
+	cfg.Mode = "compact"
+	m := New(cfg, nil)
+	m.width = 40
+	m.height = 20
 
-    // simulate pressing 'l' (FocusProcList)
-    msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")}
-    newModel, _ := m.Update(msg)
-    updated := newModel.(Model)
+	// simulate pressing 'l' (FocusProcList)
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")}
+	newModel, _ := m.Update(msg)
+	updated := newModel.(Model)
 
-    if updated.focus != panelSidebar {
-        t.Errorf("compact mode: pressing 'l' should not move focus off panelSidebar, got %v", updated.focus)
-    }
+	if updated.focus != panelSidebar {
+		t.Errorf("compact mode: pressing 'l' should not move focus off panelSidebar, got %v", updated.focus)
+	}
 }

--- a/internal/tui/model_fetch.go
+++ b/internal/tui/model_fetch.go
@@ -1,104 +1,104 @@
 package tui
 
 import (
-    "time"
+	"time"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/rtalexk/demux/internal/git"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/session"
-    "github.com/rtalexk/demux/internal/tmux"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rtalexk/demux/internal/git"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/session"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func tick(interval time.Duration) tea.Cmd {
-    return tea.Tick(interval, func(t time.Time) tea.Msg {
-        return tickMsg(t)
-    })
+	return tea.Tick(interval, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
 }
 
 func resolveWindowSpecs(ids []string, templates map[string]session.WindowTemplate) []tmux.WindowSpec {
-    specs, unknown := session.ResolveWindowSpecs(ids, templates)
-    for _, id := range unknown {
-        demuxlog.Warn("session references unknown window_template id", "id", id)
-    }
-    return specs
+	specs, unknown := session.ResolveWindowSpecs(ids, templates)
+	for _, id := range unknown {
+		demuxlog.Warn("session references unknown window_template id", "id", id)
+	}
+	return specs
 }
 
 func (m Model) fetchPanes() tea.Cmd {
-    return func() tea.Msg {
-        panes, err := tmux.ListPanes()
-        if err != nil {
-            return panesMsg{}
-        }
-        session, _, _ := tmux.CurrentTarget()
-        return panesMsg{panes: panes, currentSession: session}
-    }
+	return func() tea.Msg {
+		panes, err := tmux.ListPanes()
+		if err != nil {
+			return panesMsg{}
+		}
+		session, _, _ := tmux.CurrentTarget()
+		return panesMsg{panes: panes, currentSession: session}
+	}
 }
 
 func (m Model) fetchAlerts() tea.Cmd {
-    return func() tea.Msg {
-        alerts, err := m.db.AlertList()
-        if err != nil {
-            demuxlog.Warn("fetch alerts failed", "err", err)
-        }
-        return alertsMsg{alerts: alerts}
-    }
+	return func() tea.Msg {
+		alerts, err := m.db.AlertList()
+		if err != nil {
+			demuxlog.Warn("fetch alerts failed", "err", err)
+		}
+		return alertsMsg{alerts: alerts}
+	}
 }
 
 // scheduleProcFetch fires an immediate proc snapshot tagged with the current generation.
 // Stale results (gen mismatch) are discarded in the procDataMsg handler.
 func (m Model) scheduleProcFetch() tea.Cmd {
-    gen := m.procGen
-    return func() tea.Msg {
-        procs, err := proc.Snapshot()
-        if err != nil {
-            return procDataMsg{gen: gen}
-        }
-        cwdMap, err := proc.CWDAll()
-        if err != nil {
-            demuxlog.Warn("cwd fetch failed", "err", err)
-        }
-        if cwdMap == nil {
-            cwdMap = make(map[int32]string)
-        }
-        return procDataMsg{procs: procs, cwdMap: cwdMap, gen: gen}
-    }
+	gen := m.procGen
+	return func() tea.Msg {
+		procs, err := proc.Snapshot()
+		if err != nil {
+			return procDataMsg{gen: gen}
+		}
+		cwdMap, err := proc.CWDAll()
+		if err != nil {
+			demuxlog.Warn("cwd fetch failed", "err", err)
+		}
+		if cwdMap == nil {
+			cwdMap = make(map[int32]string)
+		}
+		return procDataMsg{procs: procs, cwdMap: cwdMap, gen: gen}
+	}
 }
 
 // scheduleDelayedProcFetch schedules a proc snapshot after 2s, tagged with the current generation.
 func (m Model) scheduleDelayedProcFetch() tea.Cmd {
-    gen := m.procGen
-    return tea.Tick(2*time.Second, func(_ time.Time) tea.Msg {
-        procs, err := proc.Snapshot()
-        if err != nil {
-            return procDataMsg{gen: gen}
-        }
-        cwdMap, err := proc.CWDAll()
-        if err != nil {
-            demuxlog.Warn("cwd fetch failed", "err", err)
-        }
-        if cwdMap == nil {
-            cwdMap = make(map[int32]string)
-        }
-        return procDataMsg{procs: procs, cwdMap: cwdMap, gen: gen}
-    })
+	gen := m.procGen
+	return tea.Tick(2*time.Second, func(_ time.Time) tea.Msg {
+		procs, err := proc.Snapshot()
+		if err != nil {
+			return procDataMsg{gen: gen}
+		}
+		cwdMap, err := proc.CWDAll()
+		if err != nil {
+			demuxlog.Warn("cwd fetch failed", "err", err)
+		}
+		if cwdMap == nil {
+			cwdMap = make(map[int32]string)
+		}
+		return procDataMsg{procs: procs, cwdMap: cwdMap, gen: gen}
+	})
 }
 
 func fetchGit(k, dir string, timeoutMs int) tea.Cmd {
-    return func() tea.Msg {
-        info, err := git.Fetch(dir, timeoutMs)
-        if err != nil {
-            // Preserve Dir and IsWorktreeRoot even when git is unavailable.
-            return gitResultMsg{key: k, info: git.Info{Dir: info.Dir, IsWorktreeRoot: info.IsWorktreeRoot}}
-        }
-        return gitResultMsg{key: k, info: info}
-    }
+	return func() tea.Msg {
+		info, err := git.Fetch(dir, timeoutMs)
+		if err != nil {
+			// Preserve Dir and IsWorktreeRoot even when git is unavailable.
+			return gitResultMsg{key: k, info: git.Info{Dir: info.Dir, IsWorktreeRoot: info.IsWorktreeRoot}}
+		}
+		return gitResultMsg{key: k, info: info}
+	}
 }
 
 func debounceSearch(gen int) tea.Cmd {
-    return func() tea.Msg {
-        time.Sleep(150 * time.Millisecond)
-        return searchDebounceMsg{gen: gen}
-    }
+	return func() tea.Msg {
+		time.Sleep(150 * time.Millisecond)
+		return searchDebounceMsg{gen: gen}
+	}
 }

--- a/internal/tui/model_focus_test.go
+++ b/internal/tui/model_focus_test.go
@@ -1,94 +1,94 @@
 package tui
 
 import (
-    "testing"
-    "time"
+	"testing"
+	"time"
 
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/tmux"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func focusTestModel(focusOnOpen string) Model {
-    cfg := config.Default()
-    cfg.Sidebar.FocusOnOpen = focusOnOpen
-    database, _ := db.Open(":memory:")
-    return New(cfg, database)
+	cfg := config.Default()
+	cfg.Sidebar.FocusOnOpen = focusOnOpen
+	database, _ := db.Open(":memory:")
+	return New(cfg, database)
 }
 
 func applyPanesMsg(m Model, currentSession string) (Model, tea.Cmd) {
-    panes := []tmux.Pane{
-        {Session: "alpha", WindowIndex: 0},
-        {Session: "alpha", WindowIndex: 1},
-        {Session: "beta", WindowIndex: 0},
-    }
-    msg := panesMsg{panes: panes, currentSession: currentSession}
-    updated, cmd := m.Update(msg)
-    return updated.(Model), cmd
+	panes := []tmux.Pane{
+		{Session: "alpha", WindowIndex: 0},
+		{Session: "alpha", WindowIndex: 1},
+		{Session: "beta", WindowIndex: 0},
+	}
+	msg := panesMsg{panes: panes, currentSession: currentSession}
+	updated, cmd := m.Update(msg)
+	return updated.(Model), cmd
 }
 
 func applyAlertsMsg(m Model, alerts []db.Alert) (Model, tea.Cmd) {
-    updated, cmd := m.Update(alertsMsg{alerts: alerts})
-    return updated.(Model), cmd
+	updated, cmd := m.Update(alertsMsg{alerts: alerts})
+	return updated.(Model), cmd
 }
 
 func TestFocusOnOpen_CurrentSession(t *testing.T) {
-    m := focusTestModel("current_session")
-    m.height = 40
-    m, _ = applyPanesMsg(m, "beta")
-    node := m.sidebar.Selected()
-    if node == nil || node.Session != "beta" {
-        t.Errorf("expected session node beta, got %+v", node)
-    }
+	m := focusTestModel("current_session")
+	m.height = 40
+	m, _ = applyPanesMsg(m, "beta")
+	node := m.sidebar.Selected()
+	if node == nil || node.Session != "beta" {
+		t.Errorf("expected session node beta, got %+v", node)
+	}
 }
 
 func TestFocusOnOpen_AlertSession(t *testing.T) {
-    m := focusTestModel("alert_session")
-    m.height = 40
-    m, _ = applyPanesMsg(m, "alpha")
-    alerts := []db.Alert{
-        {Target: "beta:0", Level: "warn", CreatedAt: time.Now()},
-    }
-    m, _ = applyAlertsMsg(m, alerts)
-    node := m.sidebar.Selected()
-    if node == nil || node.Session != "beta" {
-        t.Errorf("expected session node beta, got %+v", node)
-    }
+	m := focusTestModel("alert_session")
+	m.height = 40
+	m, _ = applyPanesMsg(m, "alpha")
+	alerts := []db.Alert{
+		{Target: "beta:0", Level: "warn", CreatedAt: time.Now()},
+	}
+	m, _ = applyAlertsMsg(m, alerts)
+	node := m.sidebar.Selected()
+	if node == nil || node.Session != "beta" {
+		t.Errorf("expected session node beta, got %+v", node)
+	}
 }
 
 func TestFocusOnOpen_FirstSession(t *testing.T) {
-    m := focusTestModel("first_session")
-    m.height = 40
-    m, _ = applyPanesMsg(m, "alpha")
-    node := m.sidebar.Selected()
-    if node == nil {
-        t.Errorf("expected a session node, got nil")
-    }
+	m := focusTestModel("first_session")
+	m.height = 40
+	m, _ = applyPanesMsg(m, "alpha")
+	node := m.sidebar.Selected()
+	if node == nil {
+		t.Errorf("expected a session node, got nil")
+	}
 }
 
 func TestFocusSearchOnOpen_true(t *testing.T) {
-    cfg := config.Default()
-    cfg.Sidebar.FocusSearchOnOpen = true
-    database, _ := db.Open(":memory:")
-    m := New(cfg, database)
-    m.height = 40
-    m, _ = applyPanesMsg(m, "alpha")
-    m, _ = applyAlertsMsg(m, nil)
-    if !m.searchInput.IsInsert() {
-        t.Errorf("expected searchInput to be in insert mode when FocusSearchOnOpen = true")
-    }
+	cfg := config.Default()
+	cfg.Sidebar.FocusSearchOnOpen = true
+	database, _ := db.Open(":memory:")
+	m := New(cfg, database)
+	m.height = 40
+	m, _ = applyPanesMsg(m, "alpha")
+	m, _ = applyAlertsMsg(m, nil)
+	if !m.searchInput.IsInsert() {
+		t.Errorf("expected searchInput to be in insert mode when FocusSearchOnOpen = true")
+	}
 }
 
 func TestFocusSearchOnOpen_false(t *testing.T) {
-    cfg := config.Default()
-    cfg.Sidebar.FocusSearchOnOpen = false
-    database, _ := db.Open(":memory:")
-    m := New(cfg, database)
-    m.height = 40
-    m, _ = applyPanesMsg(m, "alpha")
-    m, _ = applyAlertsMsg(m, nil)
-    if m.searchInput.IsInsert() {
-        t.Errorf("expected searchInput to not be in insert mode when FocusSearchOnOpen = false")
-    }
+	cfg := config.Default()
+	cfg.Sidebar.FocusSearchOnOpen = false
+	database, _ := db.Open(":memory:")
+	m := New(cfg, database)
+	m.height = 40
+	m, _ = applyPanesMsg(m, "alpha")
+	m, _ = applyAlertsMsg(m, nil)
+	if m.searchInput.IsInsert() {
+		t.Errorf("expected searchInput to not be in insert mode when FocusSearchOnOpen = false")
+	}
 }

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -1,374 +1,374 @@
 package tui
 
 import (
-    "fmt"
-    "time"
+	"fmt"
+	"time"
 
-    "github.com/charmbracelet/bubbles/key"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/rtalexk/demux/internal/db"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/query"
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rtalexk/demux/internal/db"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/query"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-    if m.searchInput.IsInsert() {
-        sidebarVisibleRows := m.height - 1 - 2 - searchBoxH
-        if sidebarVisibleRows < 1 {
-            sidebarVisibleRows = 1
-        }
-        m.sidebar.visibleRows = sidebarVisibleRows
-        switch msg.String() {
-        case "esc", "enter":
-            if msg.String() == "enter" {
-                if node := m.sidebar.Selected(); node != nil {
-                    sess := m.sidebar.FindSession(node.Session)
-                    if sess != nil && !sess.IsLive && sess.IsConfig && sess.Config != nil {
-                        if err := tmux.NewSession(sess.DisplayName, sess.Config.Path); err != nil {
-                            m.statusMsg = "launch failed: " + err.Error()
-                            m.statusExp = time.Now().Add(5 * time.Second)
-                            m.sidebar.SetLaunchErr(err.Error())
-                            m.searchInput.ExitInsertMode()
-                            return m, nil
-                        }
-                        if specs := resolveWindowSpecs(sess.Config.Windows, m.sessionsConfig.WindowTemplates); len(specs) > 0 {
-                            if err := tmux.CreateSessionWindows(sess.DisplayName, sess.Config.Path, specs); err != nil {
-                                m.statusMsg = "window setup failed: " + err.Error()
-                                m.statusExp = time.Now().Add(5 * time.Second)
-                            }
-                        }
-                        m.sidebar.ClearLaunchErr()
-                        m.searchInput.ExitInsertMode()
-                        if m.popupMode {
-                            return m, tea.Quit
-                        }
-                        return m, m.fetchPanes()
-                    }
-                    if err := tmux.SwitchClient(node.Session); err == nil {
-                        if m.popupMode {
-                            return m, tea.Quit
-                        }
-                    }
-                }
-            }
-            m.searchInput.ExitInsertMode()
-            return m, nil
-        case "ctrl+j", "ctrl+n":
-            m.sidebar.CursorDown()
-            if node := m.sidebar.Selected(); node != nil {
-                m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-                m.procGen++
-                m.updateDetailFromSelection()
-                return m, m.scheduleProcFetch()
-            }
-            return m, nil
-        case "ctrl+k", "ctrl+p":
-            m.sidebar.CursorUp()
-            if node := m.sidebar.Selected(); node != nil {
-                m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-                m.procGen++
-                m.updateDetailFromSelection()
-                return m, m.scheduleProcFetch()
-            }
-            return m, nil
-        default:
-            var cmd tea.Cmd
-            prevVal := m.searchInput.Value()
-            m.searchInput, cmd = m.searchInput.Update(msg)
-            if m.searchInput.Value() != prevVal {
-                if m.searchInput.Value() == "" {
-                    // Input cleared: reset immediately without waiting for debounce.
-                    m.queryResult = query.Result{}
-                    m.sidebar.SetSearchResult(query.Result{})
-                    m.procList.SetSearchQuery(query.ParsedQuery{}, query.Result{})
-                    m.searchGen++ // cancel any in-flight query
-                    return m, cmd
-                }
-                m.searchGen++
-                return m, tea.Batch(cmd, debounceSearch(m.searchGen))
-            }
-            return m, cmd
-        }
-    }
+	if m.searchInput.IsInsert() {
+		sidebarVisibleRows := m.height - 1 - 2 - searchBoxH
+		if sidebarVisibleRows < 1 {
+			sidebarVisibleRows = 1
+		}
+		m.sidebar.visibleRows = sidebarVisibleRows
+		switch msg.String() {
+		case "esc", "enter":
+			if msg.String() == "enter" {
+				if node := m.sidebar.Selected(); node != nil {
+					sess := m.sidebar.FindSession(node.Session)
+					if sess != nil && !sess.IsLive && sess.IsConfig && sess.Config != nil {
+						if err := tmux.NewSession(sess.DisplayName, sess.Config.Path); err != nil {
+							m.statusMsg = "launch failed: " + err.Error()
+							m.statusExp = time.Now().Add(5 * time.Second)
+							m.sidebar.SetLaunchErr(err.Error())
+							m.searchInput.ExitInsertMode()
+							return m, nil
+						}
+						if specs := resolveWindowSpecs(sess.Config.Windows, m.sessionsConfig.WindowTemplates); len(specs) > 0 {
+							if err := tmux.CreateSessionWindows(sess.DisplayName, sess.Config.Path, specs); err != nil {
+								m.statusMsg = "window setup failed: " + err.Error()
+								m.statusExp = time.Now().Add(5 * time.Second)
+							}
+						}
+						m.sidebar.ClearLaunchErr()
+						m.searchInput.ExitInsertMode()
+						if m.popupMode {
+							return m, tea.Quit
+						}
+						return m, m.fetchPanes()
+					}
+					if err := tmux.SwitchClient(node.Session); err == nil {
+						if m.popupMode {
+							return m, tea.Quit
+						}
+					}
+				}
+			}
+			m.searchInput.ExitInsertMode()
+			return m, nil
+		case "ctrl+j", "ctrl+n":
+			m.sidebar.CursorDown()
+			if node := m.sidebar.Selected(); node != nil {
+				m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+				m.procGen++
+				m.updateDetailFromSelection()
+				return m, m.scheduleProcFetch()
+			}
+			return m, nil
+		case "ctrl+k", "ctrl+p":
+			m.sidebar.CursorUp()
+			if node := m.sidebar.Selected(); node != nil {
+				m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+				m.procGen++
+				m.updateDetailFromSelection()
+				return m, m.scheduleProcFetch()
+			}
+			return m, nil
+		default:
+			var cmd tea.Cmd
+			prevVal := m.searchInput.Value()
+			m.searchInput, cmd = m.searchInput.Update(msg)
+			if m.searchInput.Value() != prevVal {
+				if m.searchInput.Value() == "" {
+					// Input cleared: reset immediately without waiting for debounce.
+					m.queryResult = query.Result{}
+					m.sidebar.SetSearchResult(query.Result{})
+					m.procList.SetSearchQuery(query.ParsedQuery{}, query.Result{})
+					m.searchGen++ // cancel any in-flight query
+					return m, cmd
+				}
+				m.searchGen++
+				return m, tea.Batch(cmd, debounceSearch(m.searchGen))
+			}
+			return m, cmd
+		}
+	}
 
-    switch {
-    case key.Matches(msg, keys.Quit):
-        return m, tea.Quit
-    case key.Matches(msg, keys.FocusSidebar):
-        m.focus = panelSidebar
-        m.updateDetailFromSelection()
-    case key.Matches(msg, keys.FocusProcList):
-        // compact mode: FocusProcList is a no-op; panelSidebar is the only panel
-        if m.cfg.Mode != "compact" {
-            m.focus = panelProcList
-        }
-        // updateDetailFromSelection gates on m.focus, so safe to call unconditionally
-        m.updateDetailFromSelection()
-    case key.Matches(msg, keys.Help):
-        m.showHelp = !m.showHelp
-    case key.Matches(msg, keys.Yank):
-        m.populateYankFields()
-        m.showYank = true
-    case key.Matches(msg, keys.Refresh):
-        m.procGen++
-        return m, tea.Batch(m.fetchPanes(), m.fetchAlerts(), m.scheduleProcFetch())
-    case key.Matches(msg, keys.AlertFilter),
-        key.Matches(msg, keys.FilterTmux),
-        key.Matches(msg, keys.FilterAll),
-        key.Matches(msg, keys.FilterConfig),
-        key.Matches(msg, keys.FilterWorktree):
+	switch {
+	case key.Matches(msg, keys.Quit):
+		return m, tea.Quit
+	case key.Matches(msg, keys.FocusSidebar):
+		m.focus = panelSidebar
+		m.updateDetailFromSelection()
+	case key.Matches(msg, keys.FocusProcList):
+		// compact mode: FocusProcList is a no-op; panelSidebar is the only panel
+		if m.cfg.Mode != "compact" {
+			m.focus = panelProcList
+		}
+		// updateDetailFromSelection gates on m.focus, so safe to call unconditionally
+		m.updateDetailFromSelection()
+	case key.Matches(msg, keys.Help):
+		m.showHelp = !m.showHelp
+	case key.Matches(msg, keys.Yank):
+		m.populateYankFields()
+		m.showYank = true
+	case key.Matches(msg, keys.Refresh):
+		m.procGen++
+		return m, tea.Batch(m.fetchPanes(), m.fetchAlerts(), m.scheduleProcFetch())
+	case key.Matches(msg, keys.AlertFilter),
+		key.Matches(msg, keys.FilterTmux),
+		key.Matches(msg, keys.FilterAll),
+		key.Matches(msg, keys.FilterConfig),
+		key.Matches(msg, keys.FilterWorktree):
 
-        sidebarVisibleRows := m.height - 1 - 2 - searchBoxH
-        if sidebarVisibleRows < 1 {
-            sidebarVisibleRows = 1
-        }
-        var newFilter SidebarFilter
-        switch {
-        case key.Matches(msg, keys.AlertFilter):
-            newFilter = FilterPriority
-        case key.Matches(msg, keys.FilterTmux):
-            newFilter = FilterTmux
-        case key.Matches(msg, keys.FilterAll):
-            newFilter = FilterAll
-        case key.Matches(msg, keys.FilterConfig):
-            newFilter = FilterConfig
-        case key.Matches(msg, keys.FilterWorktree):
-            newFilter = FilterWorktree
-        }
-        m.sidebar.SetFilter(newFilter, sidebarVisibleRows)
-        if node := m.sidebar.Selected(); node != nil {
-            m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-            m.updateDetailFromSelection()
-        }
-    default:
-        if msg.String() == "f" {
-            m.searchInput.EnterInsertMode()
-            return m, nil
-        }
-        if msg.String() == "ctrl+u" && m.searchInput.IsActive() {
-            m.searchInput.Clear()
-            m.queryResult = query.Result{}
-            m.sidebar.SetSearchResult(query.Result{})
-            m.procList.SetSearchQuery(query.ParsedQuery{}, query.Result{})
-            m.searchGen++
-            return m, nil
-        }
-        if m.focus == panelSidebar {
-            return m.handleSidebarKey(msg)
-        }
-        return m.handleProcListKey(msg)
-    }
-    return m, nil
+		sidebarVisibleRows := m.height - 1 - 2 - searchBoxH
+		if sidebarVisibleRows < 1 {
+			sidebarVisibleRows = 1
+		}
+		var newFilter SidebarFilter
+		switch {
+		case key.Matches(msg, keys.AlertFilter):
+			newFilter = FilterPriority
+		case key.Matches(msg, keys.FilterTmux):
+			newFilter = FilterTmux
+		case key.Matches(msg, keys.FilterAll):
+			newFilter = FilterAll
+		case key.Matches(msg, keys.FilterConfig):
+			newFilter = FilterConfig
+		case key.Matches(msg, keys.FilterWorktree):
+			newFilter = FilterWorktree
+		}
+		m.sidebar.SetFilter(newFilter, sidebarVisibleRows)
+		if node := m.sidebar.Selected(); node != nil {
+			m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+			m.updateDetailFromSelection()
+		}
+	default:
+		if msg.String() == "f" {
+			m.searchInput.EnterInsertMode()
+			return m, nil
+		}
+		if msg.String() == "ctrl+u" && m.searchInput.IsActive() {
+			m.searchInput.Clear()
+			m.queryResult = query.Result{}
+			m.sidebar.SetSearchResult(query.Result{})
+			m.procList.SetSearchQuery(query.ParsedQuery{}, query.Result{})
+			m.searchGen++
+			return m, nil
+		}
+		if m.focus == panelSidebar {
+			return m.handleSidebarKey(msg)
+		}
+		return m.handleProcListKey(msg)
+	}
+	return m, nil
 }
 
 func (m Model) handleSidebarKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-    sidebarVisibleRows := m.height - 1 - 2 - searchBoxH // contentH (height-1) minus border (2) minus searchBoxH
-    if sidebarVisibleRows < 1 {
-        sidebarVisibleRows = 1
-    }
-    m.sidebar.visibleRows = sidebarVisibleRows
+	sidebarVisibleRows := m.height - 1 - 2 - searchBoxH // contentH (height-1) minus border (2) minus searchBoxH
+	if sidebarVisibleRows < 1 {
+		sidebarVisibleRows = 1
+	}
+	m.sidebar.visibleRows = sidebarVisibleRows
 
-    switch {
-    case key.Matches(msg, keys.Up):
-        m.sidebar.MoveUp(sidebarVisibleRows)
-    case key.Matches(msg, keys.Down):
-        m.sidebar.MoveDown(sidebarVisibleRows)
-    case key.Matches(msg, keys.Tab):
-        m.sidebar.TabNextSession(sidebarVisibleRows)
-    case key.Matches(msg, keys.ShiftTab):
-        m.sidebar.TabPrevSession(sidebarVisibleRows)
-    case key.Matches(msg, keys.GotoTop):
-        m.sidebar.GotoTop(sidebarVisibleRows)
-    case key.Matches(msg, keys.GotoBottom):
-        m.sidebar.GotoBottom(sidebarVisibleRows)
-    case key.Matches(msg, keys.Enter), key.Matches(msg, keys.Open):
-        if node := m.sidebar.Selected(); node != nil {
-            sess := m.sidebar.FindSession(node.Session)
-            if sess != nil && !sess.IsLive && sess.IsConfig && sess.Config != nil {
-                if err := tmux.NewSession(sess.DisplayName, sess.Config.Path); err != nil {
-                    m.statusMsg = "launch failed: " + err.Error()
-                    m.statusExp = time.Now().Add(5 * time.Second)
-                    m.sidebar.SetLaunchErr(err.Error())
-                    return m, nil
-                }
-                if specs := resolveWindowSpecs(sess.Config.Windows, m.sessionsConfig.WindowTemplates); len(specs) > 0 {
-                    if err := tmux.CreateSessionWindows(sess.DisplayName, sess.Config.Path, specs); err != nil {
-                        m.statusMsg = "window setup failed: " + err.Error()
-                        m.statusExp = time.Now().Add(5 * time.Second)
-                    }
-                }
-                m.sidebar.ClearLaunchErr()
-                if m.popupMode {
-                    return m, tea.Quit
-                }
-                return m, m.fetchPanes()
-            }
-            target := m.sidebar.BestAlertTargetInSession(node.Session, m.cfg.Sidebar.SwitchFocus)
-            if target == "" {
-                target = node.Session
-            }
-            err := tmux.SwitchClient(target)
-            if err != nil && target != node.Session {
-                err = tmux.SwitchClient(node.Session)
-            }
-            if err == nil && m.popupMode {
-                return m, tea.Quit
-            }
-        }
-    case key.Matches(msg, keys.Esc):
-        m.sidebar.MoveToSessionLevel()
-    case key.Matches(msg, keys.Defer):
-        if node := m.sidebar.Selected(); node != nil {
-            return m, m.toggleDeferAlert(node.Session)
-        }
-    }
-    // Populate proc list: session overview for all nodes.
-    var cmd tea.Cmd
-    if node := m.sidebar.Selected(); node != nil {
-        m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-        m.procGen++
-        cmd = m.scheduleProcFetch()
-    }
-    m.updateDetailFromSelection()
-    return m, cmd
+	switch {
+	case key.Matches(msg, keys.Up):
+		m.sidebar.MoveUp(sidebarVisibleRows)
+	case key.Matches(msg, keys.Down):
+		m.sidebar.MoveDown(sidebarVisibleRows)
+	case key.Matches(msg, keys.Tab):
+		m.sidebar.TabNextSession(sidebarVisibleRows)
+	case key.Matches(msg, keys.ShiftTab):
+		m.sidebar.TabPrevSession(sidebarVisibleRows)
+	case key.Matches(msg, keys.GotoTop):
+		m.sidebar.GotoTop(sidebarVisibleRows)
+	case key.Matches(msg, keys.GotoBottom):
+		m.sidebar.GotoBottom(sidebarVisibleRows)
+	case key.Matches(msg, keys.Enter), key.Matches(msg, keys.Open):
+		if node := m.sidebar.Selected(); node != nil {
+			sess := m.sidebar.FindSession(node.Session)
+			if sess != nil && !sess.IsLive && sess.IsConfig && sess.Config != nil {
+				if err := tmux.NewSession(sess.DisplayName, sess.Config.Path); err != nil {
+					m.statusMsg = "launch failed: " + err.Error()
+					m.statusExp = time.Now().Add(5 * time.Second)
+					m.sidebar.SetLaunchErr(err.Error())
+					return m, nil
+				}
+				if specs := resolveWindowSpecs(sess.Config.Windows, m.sessionsConfig.WindowTemplates); len(specs) > 0 {
+					if err := tmux.CreateSessionWindows(sess.DisplayName, sess.Config.Path, specs); err != nil {
+						m.statusMsg = "window setup failed: " + err.Error()
+						m.statusExp = time.Now().Add(5 * time.Second)
+					}
+				}
+				m.sidebar.ClearLaunchErr()
+				if m.popupMode {
+					return m, tea.Quit
+				}
+				return m, m.fetchPanes()
+			}
+			target := m.sidebar.BestAlertTargetInSession(node.Session, m.cfg.Sidebar.SwitchFocus)
+			if target == "" {
+				target = node.Session
+			}
+			err := tmux.SwitchClient(target)
+			if err != nil && target != node.Session {
+				err = tmux.SwitchClient(node.Session)
+			}
+			if err == nil && m.popupMode {
+				return m, tea.Quit
+			}
+		}
+	case key.Matches(msg, keys.Esc):
+		m.sidebar.MoveToSessionLevel()
+	case key.Matches(msg, keys.Defer):
+		if node := m.sidebar.Selected(); node != nil {
+			return m, m.toggleDeferAlert(node.Session)
+		}
+	}
+	// Populate proc list: session overview for all nodes.
+	var cmd tea.Cmd
+	if node := m.sidebar.Selected(); node != nil {
+		m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+		m.procGen++
+		cmd = m.scheduleProcFetch()
+	}
+	m.updateDetailFromSelection()
+	return m, cmd
 }
 
 func (m Model) handleProcListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-    contentH := m.height - 1
-    innerW := m.width - m.cfg.Sidebar.Width - 2
-    if innerW < 1 {
-        innerW = 1
-    }
-    detailContent := m.detail.ContentLines(innerW)
-    detailH := detailContent + 2
-    if detailH < 4 {
-        detailH = 4
-    }
-    maxDetailH := contentH - 4
-    if detailH > maxDetailH {
-        detailH = maxDetailH
-    }
-    procH := contentH - detailH
+	contentH := m.height - 1
+	innerW := m.width - m.cfg.Sidebar.Width - 2
+	if innerW < 1 {
+		innerW = 1
+	}
+	detailContent := m.detail.ContentLines(innerW)
+	detailH := detailContent + 2
+	if detailH < 4 {
+		detailH = 4
+	}
+	maxDetailH := contentH - 4
+	if detailH > maxDetailH {
+		detailH = maxDetailH
+	}
+	procH := contentH - detailH
 
-    switch {
-    case key.Matches(msg, keys.Up):
-        m.procList.MoveUp()
-    case key.Matches(msg, keys.Down):
-        m.procList.MoveDown()
-    case key.Matches(msg, keys.Tab):
-        m.procList.TabNext()
-    case key.Matches(msg, keys.JumpUp):
-        m.procList.JumpToPrevPane()
-    case key.Matches(msg, keys.JumpDown):
-        m.procList.JumpToNextPane()
-    case key.Matches(msg, keys.GotoTop):
-        m.procList.GotoTop()
-    case key.Matches(msg, keys.GotoBottom):
-        m.procList.GotoBottom()
-    case key.Matches(msg, keys.Enter):
-        if m.procList.ToggleCollapse() {
-            // Rebuild immediately with current data. The nil guard is defensive: if the
-            // sidebar selection is lost between refreshes, the next poll cycle rebuilds instead.
-            if node := m.sidebar.Selected(); node != nil {
-                m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-            }
-            m.procGen++
-            m.procList.clampOffset(procH - 2)
-            m.updateDetailFromSelection()
-            return m, m.scheduleDelayedProcFetch()
-        }
-    case key.Matches(msg, keys.Expand):
-        if m.procList.Expand() {
-            if node := m.sidebar.Selected(); node != nil {
-                m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-            }
-            m.procGen++
-            m.procList.clampOffset(procH - 2)
-            m.updateDetailFromSelection()
-            return m, m.scheduleDelayedProcFetch()
-        }
-    case key.Matches(msg, keys.Collapse):
-        if m.procList.Collapse() {
-            if node := m.sidebar.Selected(); node != nil {
-                m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-            }
-            m.procGen++
-            m.procList.clampOffset(procH - 2)
-            m.updateDetailFromSelection()
-            return m, m.scheduleDelayedProcFetch()
-        }
-    case key.Matches(msg, keys.ExpandAll):
-        if m.procList.ExpandAll() {
-            if node := m.sidebar.Selected(); node != nil {
-                m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-            }
-            m.procGen++
-            m.procList.clampOffset(procH - 2)
-            m.updateDetailFromSelection()
-            return m, m.scheduleDelayedProcFetch()
-        }
-    case key.Matches(msg, keys.CollapseAll):
-        if m.procList.CollapseAll() {
-            if node := m.sidebar.Selected(); node != nil {
-                m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-            }
-            m.procGen++
-            m.procList.clampOffset(procH - 2)
-            m.updateDetailFromSelection()
-            return m, m.scheduleDelayedProcFetch()
-        }
-    case key.Matches(msg, keys.Open):
-        var target string
-        if pane := m.procList.SelectedPane(); pane != nil {
-            target = fmt.Sprintf("%s:%d.%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
-        } else if node := m.sidebar.Selected(); node != nil {
-            target = node.Session
-        }
-        if target != "" {
-            tmux.SwitchClient(target)
-            if m.popupMode {
-                return m, tea.Quit
-            }
-        }
-    case key.Matches(msg, keys.Esc):
-        m.focus = panelSidebar
-    case key.Matches(msg, keys.Kill):
-        // TODO: confirmation prompt
-    case key.Matches(msg, keys.Restart):
-        // TODO: restart via tmux send-keys Up Enter
-    case key.Matches(msg, keys.Log):
-        // TODO: tmux popup with scrollback
-    }
-    m.procList.clampOffset(procH - 2) // procH includes border; pass inner content height
-    m.updateDetailFromSelection()
-    return m, nil
+	switch {
+	case key.Matches(msg, keys.Up):
+		m.procList.MoveUp()
+	case key.Matches(msg, keys.Down):
+		m.procList.MoveDown()
+	case key.Matches(msg, keys.Tab):
+		m.procList.TabNext()
+	case key.Matches(msg, keys.JumpUp):
+		m.procList.JumpToPrevPane()
+	case key.Matches(msg, keys.JumpDown):
+		m.procList.JumpToNextPane()
+	case key.Matches(msg, keys.GotoTop):
+		m.procList.GotoTop()
+	case key.Matches(msg, keys.GotoBottom):
+		m.procList.GotoBottom()
+	case key.Matches(msg, keys.Enter):
+		if m.procList.ToggleCollapse() {
+			// Rebuild immediately with current data. The nil guard is defensive: if the
+			// sidebar selection is lost between refreshes, the next poll cycle rebuilds instead.
+			if node := m.sidebar.Selected(); node != nil {
+				m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+			}
+			m.procGen++
+			m.procList.clampOffset(procH - 2)
+			m.updateDetailFromSelection()
+			return m, m.scheduleDelayedProcFetch()
+		}
+	case key.Matches(msg, keys.Expand):
+		if m.procList.Expand() {
+			if node := m.sidebar.Selected(); node != nil {
+				m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+			}
+			m.procGen++
+			m.procList.clampOffset(procH - 2)
+			m.updateDetailFromSelection()
+			return m, m.scheduleDelayedProcFetch()
+		}
+	case key.Matches(msg, keys.Collapse):
+		if m.procList.Collapse() {
+			if node := m.sidebar.Selected(); node != nil {
+				m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+			}
+			m.procGen++
+			m.procList.clampOffset(procH - 2)
+			m.updateDetailFromSelection()
+			return m, m.scheduleDelayedProcFetch()
+		}
+	case key.Matches(msg, keys.ExpandAll):
+		if m.procList.ExpandAll() {
+			if node := m.sidebar.Selected(); node != nil {
+				m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+			}
+			m.procGen++
+			m.procList.clampOffset(procH - 2)
+			m.updateDetailFromSelection()
+			return m, m.scheduleDelayedProcFetch()
+		}
+	case key.Matches(msg, keys.CollapseAll):
+		if m.procList.CollapseAll() {
+			if node := m.sidebar.Selected(); node != nil {
+				m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+			}
+			m.procGen++
+			m.procList.clampOffset(procH - 2)
+			m.updateDetailFromSelection()
+			return m, m.scheduleDelayedProcFetch()
+		}
+	case key.Matches(msg, keys.Open):
+		var target string
+		if pane := m.procList.SelectedPane(); pane != nil {
+			target = fmt.Sprintf("%s:%d.%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
+		} else if node := m.sidebar.Selected(); node != nil {
+			target = node.Session
+		}
+		if target != "" {
+			tmux.SwitchClient(target)
+			if m.popupMode {
+				return m, tea.Quit
+			}
+		}
+	case key.Matches(msg, keys.Esc):
+		m.focus = panelSidebar
+	case key.Matches(msg, keys.Kill):
+		// TODO: confirmation prompt
+	case key.Matches(msg, keys.Restart):
+		// TODO: restart via tmux send-keys Up Enter
+	case key.Matches(msg, keys.Log):
+		// TODO: tmux popup with scrollback
+	}
+	m.procList.clampOffset(procH - 2) // procH includes border; pass inner content height
+	m.updateDetailFromSelection()
+	return m, nil
 }
 
 func (m Model) toggleDeferAlert(target string) tea.Cmd {
-    var hasDefer bool
-    for _, a := range m.alerts {
-        if a.Target == target && a.Level == db.LevelDefer {
-            hasDefer = true
-            break
-        }
-    }
-    reason := m.cfg.Alerts.DeferDefaultReason
-    d := m.db
-    return func() tea.Msg {
-        if hasDefer {
-            if err := d.AlertRemove(target); err != nil {
-                demuxlog.Warn("defer remove failed", "err", err)
-            }
-        } else {
-            if err := d.AlertSet(target, reason, db.LevelDefer); err != nil {
-                demuxlog.Warn("defer set failed", "err", err)
-            }
-        }
-        alerts, err := d.AlertList()
-        if err != nil {
-            demuxlog.Warn("fetch alerts after defer toggle failed", "err", err)
-        }
-        return alertsMsg{alerts: alerts}
-    }
+	var hasDefer bool
+	for _, a := range m.alerts {
+		if a.Target == target && a.Level == db.LevelDefer {
+			hasDefer = true
+			break
+		}
+	}
+	reason := m.cfg.Alerts.DeferDefaultReason
+	d := m.db
+	return func() tea.Msg {
+		if hasDefer {
+			if err := d.AlertRemove(target); err != nil {
+				demuxlog.Warn("defer remove failed", "err", err)
+			}
+		} else {
+			if err := d.AlertSet(target, reason, db.LevelDefer); err != nil {
+				demuxlog.Warn("defer set failed", "err", err)
+			}
+		}
+		alerts, err := d.AlertList()
+		if err != nil {
+			demuxlog.Warn("fetch alerts after defer toggle failed", "err", err)
+		}
+		return alertsMsg{alerts: alerts}
+	}
 }

--- a/internal/tui/model_popup_test.go
+++ b/internal/tui/model_popup_test.go
@@ -1,27 +1,27 @@
 package tui
 
 import (
-    "os"
-    "testing"
+	"os"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 func TestNew_PopupMode_Enabled(t *testing.T) {
-    os.Setenv("DEMUX_POPUP", "1")
-    defer os.Unsetenv("DEMUX_POPUP")
+	os.Setenv("DEMUX_POPUP", "1")
+	defer os.Unsetenv("DEMUX_POPUP")
 
-    m := New(config.Config{}, nil)
-    if !m.popupMode {
-        t.Error("expected popupMode=true when DEMUX_POPUP=1")
-    }
+	m := New(config.Config{}, nil)
+	if !m.popupMode {
+		t.Error("expected popupMode=true when DEMUX_POPUP=1")
+	}
 }
 
 func TestNew_PopupMode_Disabled(t *testing.T) {
-    os.Unsetenv("DEMUX_POPUP")
+	os.Unsetenv("DEMUX_POPUP")
 
-    m := New(config.Config{}, nil)
-    if m.popupMode {
-        t.Error("expected popupMode=false when DEMUX_POPUP is unset")
-    }
+	m := New(config.Config{}, nil)
+	if m.popupMode {
+		t.Error("expected popupMode=false when DEMUX_POPUP is unset")
+	}
 }

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -1,429 +1,429 @@
 package tui
 
 import (
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
-    "time"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
-    "github.com/charmbracelet/bubbles/key"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/lipgloss"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/git"
-    demuxlog "github.com/rtalexk/demux/internal/log"
-    "github.com/rtalexk/demux/internal/query"
-    "github.com/rtalexk/demux/internal/session"
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/git"
+	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/query"
+	"github.com/rtalexk/demux/internal/session"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-    // Delegate to overlay handlers first
-    if m.showHelp {
-        if msg, ok := msg.(tea.KeyMsg); ok {
-            switch {
-            case key.Matches(msg, keys.Esc), key.Matches(msg, keys.Help), msg.String() == "q":
-                m.showHelp = false
-            case key.Matches(msg, keys.Up):
-                m.help.ScrollUp()
-            case key.Matches(msg, keys.Down):
-                m.help.ScrollDown(m.height)
-            }
-        }
-        return m, nil
-    }
-    if m.showYank {
-        return m.updateYank(msg)
-    }
+	// Delegate to overlay handlers first
+	if m.showHelp {
+		if msg, ok := msg.(tea.KeyMsg); ok {
+			switch {
+			case key.Matches(msg, keys.Esc), key.Matches(msg, keys.Help), msg.String() == "q":
+				m.showHelp = false
+			case key.Matches(msg, keys.Up):
+				m.help.ScrollUp()
+			case key.Matches(msg, keys.Down):
+				m.help.ScrollDown(m.height)
+			}
+		}
+		return m, nil
+	}
+	if m.showYank {
+		return m.updateYank(msg)
+	}
 
-    switch msg := msg.(type) {
-    case tea.KeyMsg:
-        return m.handleKey(msg)
-    case tea.WindowSizeMsg:
-        m.width = msg.Width
-        m.height = msg.Height
-        return m, nil
-    case tickMsg:
-        m.pulse = !m.pulse
-        m.spinnerFrame++
-        if time.Now().After(m.statusExp) {
-            m.statusMsg = ""
-        }
-        return m, tea.Batch(tick(time.Duration(m.cfg.RefreshIntervalMs)*time.Millisecond), m.fetchPanes(), m.fetchAlerts())
-    case panesMsg:
-        m.panes = msg.panes
-        grouped := tmux.GroupBySessions(msg.panes)
-        merged := session.Merge(msg.panes, m.sessionsConfig.Entries)
-        m.sidebar.SetData(merged, m.alerts, m.gitInfo, m.cfg)
-        m.updateDetailFromSelection()
-        var cmds []tea.Cmd
-        if !m.ready {
-            // First load: sidebar is visible — kick off tick and alerts; procs are fetched on-demand
-            m.currentSession = msg.currentSession
-            switch m.cfg.Sidebar.FocusOnOpen {
-            case "current_session", "first_session":
-                visibleRows := max(1, m.height-1-2-searchBoxH)
-                m.applyNonAlertFocusMode(m.cfg.Sidebar.FocusOnOpen, visibleRows)
-            }
-            m.ready = true
-            cmds = append(cmds, tick(time.Duration(m.cfg.RefreshIntervalMs)*time.Millisecond), m.fetchAlerts())
-            // If startup focus landed on a window node, kick off an initial proc fetch.
-            if node := m.sidebar.Selected(); node != nil {
-                m.procGen++
-                cmds = append(cmds, m.scheduleProcFetch())
-            }
-        }
-        if m.cfg.Git.Enabled {
-            for sessionName, windows := range grouped {
-                info := m.gitInfo[sessionName]
-                info.Loading = true
-                m.gitInfo[sessionName] = info
-                primaryCWD := tmux.PrimaryPaneCWD(windows[0])
-                if primaryCWD != "" {
-                    cmds = append(cmds, fetchGit(sessionName, primaryCWD, m.cfg.Git.TimeoutMs))
-                }
-            }
-        }
-        return m, tea.Batch(cmds...)
-    case procDataMsg:
-        if msg.gen != m.procGen {
-            // Stale result from a previously selected window — discard.
-            return m, nil
-        }
-        m.procs = msg.procs
-        m.cwdMap = msg.cwdMap
-        if node := m.sidebar.Selected(); node != nil {
-            m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-        }
-        m.updateDetailFromSelection()
-        // Self-schedule next poll in 2s for the selected window.
-        return m, m.scheduleDelayedProcFetch()
-    case alertsMsg:
-        m.alerts = msg.alerts
-        merged := session.Merge(m.panes, m.sessionsConfig.Entries)
-        m.sidebar.SetData(merged, msg.alerts, m.gitInfo, m.cfg)
-        if !m.startupFocusDone {
-            m.startupFocusDone = true
-            visibleRows := max(1, m.height-1-2-searchBoxH)
-            if m.cfg.Sidebar.FocusOnOpen == "alert_session" {
-                m.sidebar.FocusFirstAlertSession(visibleRows)
-            }
-            if m.cfg.Sidebar.FocusSearchOnOpen {
-                m.searchInput.EnterInsertMode()
-            }
-        }
-        m.updateDetailFromSelection()
-        // If startup focus landed on a window node, kick off an initial proc fetch.
-        var cmds []tea.Cmd
-        if node := m.sidebar.Selected(); node != nil {
-            m.procGen++
-            cmds = append(cmds, m.scheduleProcFetch())
-        }
-        if pruneCmd := m.pruneStaleAlerts(); pruneCmd != nil {
-            cmds = append(cmds, pruneCmd)
-        }
-        return m, tea.Batch(cmds...)
-    case gitResultMsg:
-        m.gitInfo[msg.key] = msg.info
-        merged := session.Merge(m.panes, m.sessionsConfig.Entries)
-        m.sidebar.SetData(merged, m.alerts, m.gitInfo, m.cfg)
-        m.updateDetailFromSelection()
-        return m, nil
-    case queryResultMsg:
-        if msg.gen == m.searchGen {
-            m.queryResult = msg.result
-            m.sidebar.SetSearchResult(msg.result)
-            m.procList.SetSearchQuery(query.Parse(m.searchInput.Value()), msg.result)
-            if node := m.sidebar.Selected(); node != nil {
-                m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
-                m.procGen++
-                m.updateDetailFromSelection()
-                return m, m.scheduleProcFetch()
-            } else {
-                m.procList.Reset()
-            }
-        }
-        return m, nil
-    case searchDebounceMsg:
-        if msg.gen != m.searchGen {
-            return m, nil
-        }
-        pq := query.Parse(m.searchInput.Value())
-        for _, sess := range m.sidebar.sessions {
-            if !sess.IsLive {
-                pq.ExtraSessions = append(pq.ExtraSessions, sess.DisplayName)
-            }
-        }
-        gen := m.searchGen
-        return m, func() tea.Msg {
-            result, err := query.Run(pq)
-            if err != nil {
-                return queryResultMsg{gen: gen}
-            }
-            return queryResultMsg{result: result, gen: gen}
-        }
-    }
-    return m, nil
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case tickMsg:
+		m.pulse = !m.pulse
+		m.spinnerFrame++
+		if time.Now().After(m.statusExp) {
+			m.statusMsg = ""
+		}
+		return m, tea.Batch(tick(time.Duration(m.cfg.RefreshIntervalMs)*time.Millisecond), m.fetchPanes(), m.fetchAlerts())
+	case panesMsg:
+		m.panes = msg.panes
+		grouped := tmux.GroupBySessions(msg.panes)
+		merged := session.Merge(msg.panes, m.sessionsConfig.Entries)
+		m.sidebar.SetData(merged, m.alerts, m.gitInfo, m.cfg)
+		m.updateDetailFromSelection()
+		var cmds []tea.Cmd
+		if !m.ready {
+			// First load: sidebar is visible — kick off tick and alerts; procs are fetched on-demand
+			m.currentSession = msg.currentSession
+			switch m.cfg.Sidebar.FocusOnOpen {
+			case "current_session", "first_session":
+				visibleRows := max(1, m.height-1-2-searchBoxH)
+				m.applyNonAlertFocusMode(m.cfg.Sidebar.FocusOnOpen, visibleRows)
+			}
+			m.ready = true
+			cmds = append(cmds, tick(time.Duration(m.cfg.RefreshIntervalMs)*time.Millisecond), m.fetchAlerts())
+			// If startup focus landed on a window node, kick off an initial proc fetch.
+			if node := m.sidebar.Selected(); node != nil {
+				m.procGen++
+				cmds = append(cmds, m.scheduleProcFetch())
+			}
+		}
+		if m.cfg.Git.Enabled {
+			for sessionName, windows := range grouped {
+				info := m.gitInfo[sessionName]
+				info.Loading = true
+				m.gitInfo[sessionName] = info
+				primaryCWD := tmux.PrimaryPaneCWD(windows[0])
+				if primaryCWD != "" {
+					cmds = append(cmds, fetchGit(sessionName, primaryCWD, m.cfg.Git.TimeoutMs))
+				}
+			}
+		}
+		return m, tea.Batch(cmds...)
+	case procDataMsg:
+		if msg.gen != m.procGen {
+			// Stale result from a previously selected window — discard.
+			return m, nil
+		}
+		m.procs = msg.procs
+		m.cwdMap = msg.cwdMap
+		if node := m.sidebar.Selected(); node != nil {
+			m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+		}
+		m.updateDetailFromSelection()
+		// Self-schedule next poll in 2s for the selected window.
+		return m, m.scheduleDelayedProcFetch()
+	case alertsMsg:
+		m.alerts = msg.alerts
+		merged := session.Merge(m.panes, m.sessionsConfig.Entries)
+		m.sidebar.SetData(merged, msg.alerts, m.gitInfo, m.cfg)
+		if !m.startupFocusDone {
+			m.startupFocusDone = true
+			visibleRows := max(1, m.height-1-2-searchBoxH)
+			if m.cfg.Sidebar.FocusOnOpen == "alert_session" {
+				m.sidebar.FocusFirstAlertSession(visibleRows)
+			}
+			if m.cfg.Sidebar.FocusSearchOnOpen {
+				m.searchInput.EnterInsertMode()
+			}
+		}
+		m.updateDetailFromSelection()
+		// If startup focus landed on a window node, kick off an initial proc fetch.
+		var cmds []tea.Cmd
+		if node := m.sidebar.Selected(); node != nil {
+			m.procGen++
+			cmds = append(cmds, m.scheduleProcFetch())
+		}
+		if pruneCmd := m.pruneStaleAlerts(); pruneCmd != nil {
+			cmds = append(cmds, pruneCmd)
+		}
+		return m, tea.Batch(cmds...)
+	case gitResultMsg:
+		m.gitInfo[msg.key] = msg.info
+		merged := session.Merge(m.panes, m.sessionsConfig.Entries)
+		m.sidebar.SetData(merged, m.alerts, m.gitInfo, m.cfg)
+		m.updateDetailFromSelection()
+		return m, nil
+	case queryResultMsg:
+		if msg.gen == m.searchGen {
+			m.queryResult = msg.result
+			m.sidebar.SetSearchResult(msg.result)
+			m.procList.SetSearchQuery(query.Parse(m.searchInput.Value()), msg.result)
+			if node := m.sidebar.Selected(); node != nil {
+				m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.alertMap(), m.cfg)
+				m.procGen++
+				m.updateDetailFromSelection()
+				return m, m.scheduleProcFetch()
+			} else {
+				m.procList.Reset()
+			}
+		}
+		return m, nil
+	case searchDebounceMsg:
+		if msg.gen != m.searchGen {
+			return m, nil
+		}
+		pq := query.Parse(m.searchInput.Value())
+		for _, sess := range m.sidebar.sessions {
+			if !sess.IsLive {
+				pq.ExtraSessions = append(pq.ExtraSessions, sess.DisplayName)
+			}
+		}
+		gen := m.searchGen
+		return m, func() tea.Msg {
+			result, err := query.Run(pq)
+			if err != nil {
+				return queryResultMsg{gen: gen}
+			}
+			return queryResultMsg{result: result, gen: gen}
+		}
+	}
+	return m, nil
 }
 
 func (m *Model) populateYankFields() {
-    if m.focus == panelProcList {
-        selNode := m.procList.SelectedNode()
-        if selNode != nil && !selNode.IsPaneHeader && !selNode.IsWindowHeader {
-            pr := selNode.Proc
-            cwd := m.cwdMap[pr.PID]
-            portStr := ""
-            if selNode.Port > 0 {
-                portStr = fmt.Sprintf("%d", selNode.Port)
-            }
-            m.yank.SetFields([]YankField{
-                {Key: "p", Label: "PID", Value: fmt.Sprint(pr.PID)},
-                {Key: "n", Label: "name", Value: pr.Name},
-                {Key: "c", Label: "cmdline", Value: pr.Cmdline},
-                {Key: "d", Label: "CWD", Value: cwd},
-                {Key: "o", Label: "port", Value: portStr},
-            })
-            return
-        }
-    }
-    // session node from sidebar
-    if node := m.sidebar.Selected(); node != nil {
-        m.yank.SetFields([]YankField{
-            {Key: "n", Label: "session", Value: node.Session},
-            {Key: "t", Label: "target", Value: node.Session},
-        })
-    }
+	if m.focus == panelProcList {
+		selNode := m.procList.SelectedNode()
+		if selNode != nil && !selNode.IsPaneHeader && !selNode.IsWindowHeader {
+			pr := selNode.Proc
+			cwd := m.cwdMap[pr.PID]
+			portStr := ""
+			if selNode.Port > 0 {
+				portStr = fmt.Sprintf("%d", selNode.Port)
+			}
+			m.yank.SetFields([]YankField{
+				{Key: "p", Label: "PID", Value: fmt.Sprint(pr.PID)},
+				{Key: "n", Label: "name", Value: pr.Name},
+				{Key: "c", Label: "cmdline", Value: pr.Cmdline},
+				{Key: "d", Label: "CWD", Value: cwd},
+				{Key: "o", Label: "port", Value: portStr},
+			})
+			return
+		}
+	}
+	// session node from sidebar
+	if node := m.sidebar.Selected(); node != nil {
+		m.yank.SetFields([]YankField{
+			{Key: "n", Label: "session", Value: node.Session},
+			{Key: "t", Label: "target", Value: node.Session},
+		})
+	}
 }
 
 // applyNonAlertFocusMode applies a non-alert focus mode to the sidebar.
 // Valid modes: current_session, first_session.
 // No-ops on empty or unrecognised mode.
 func (m *Model) applyNonAlertFocusMode(mode string, visibleRows int) {
-    switch mode {
-    case "current_session":
-        m.sidebar.FocusNode(m.currentSession, visibleRows)
-    case "first_session":
-        // cursor is already 0, which is always the first session — no-op
-    }
+	switch mode {
+	case "current_session":
+		m.sidebar.FocusNode(m.currentSession, visibleRows)
+	case "first_session":
+		// cursor is already 0, which is always the first session — no-op
+	}
 }
 
 // pruneStaleAlerts removes non-sticky alerts whose pane/window/session target no
 // longer appears in the current pane list. Returns a cmd that removes the stale
 // entries from the DB and re-fetches the alert list, or nil if nothing to prune.
 func (m *Model) pruneStaleAlerts() tea.Cmd {
-    if len(m.panes) == 0 {
-        return nil
-    }
-    // Build lookup sets for every live target granularity.
-    paneTargets := make(map[string]bool, len(m.panes))
-    winTargets := make(map[string]bool)
-    sesTargets := make(map[string]bool)
-    for _, p := range m.panes {
-        paneTargets[fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)] = true
-        winTargets[fmt.Sprintf("%s:%d", p.Session, p.WindowIndex)] = true
-        sesTargets[p.Session] = true
-    }
+	if len(m.panes) == 0 {
+		return nil
+	}
+	// Build lookup sets for every live target granularity.
+	paneTargets := make(map[string]bool, len(m.panes))
+	winTargets := make(map[string]bool)
+	sesTargets := make(map[string]bool)
+	for _, p := range m.panes {
+		paneTargets[fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)] = true
+		winTargets[fmt.Sprintf("%s:%d", p.Session, p.WindowIndex)] = true
+		sesTargets[p.Session] = true
+	}
 
-    var stale []string
-    for _, a := range m.alerts {
-        switch {
-        case strings.Contains(a.Target, "."):
-            if !paneTargets[a.Target] {
-                stale = append(stale, a.Target)
-            }
-        case strings.Contains(a.Target, ":"):
-            if !winTargets[a.Target] {
-                stale = append(stale, a.Target)
-            }
-        default:
-            if !sesTargets[a.Target] {
-                stale = append(stale, a.Target)
-            }
-        }
-    }
-    if len(stale) == 0 {
-        return nil
-    }
-    d := m.db
-    return func() tea.Msg {
-        for _, t := range stale {
-            d.AlertRemove(t)
-        }
-        alerts, err := d.AlertList()
-        if err != nil {
-            demuxlog.Warn("fetch alerts failed", "err", err)
-        }
-        return alertsMsg{alerts: alerts}
-    }
+	var stale []string
+	for _, a := range m.alerts {
+		switch {
+		case strings.Contains(a.Target, "."):
+			if !paneTargets[a.Target] {
+				stale = append(stale, a.Target)
+			}
+		case strings.Contains(a.Target, ":"):
+			if !winTargets[a.Target] {
+				stale = append(stale, a.Target)
+			}
+		default:
+			if !sesTargets[a.Target] {
+				stale = append(stale, a.Target)
+			}
+		}
+	}
+	if len(stale) == 0 {
+		return nil
+	}
+	d := m.db
+	return func() tea.Msg {
+		for _, t := range stale {
+			d.AlertRemove(t)
+		}
+		alerts, err := d.AlertList()
+		if err != nil {
+			demuxlog.Warn("fetch alerts failed", "err", err)
+		}
+		return alertsMsg{alerts: alerts}
+	}
 }
 
 func (m *Model) alertMap() map[string]db.Alert {
-    am := make(map[string]db.Alert, len(m.alerts))
-    for _, a := range m.alerts {
-        am[a.Target] = a
-    }
-    return am
+	am := make(map[string]db.Alert, len(m.alerts))
+	for _, a := range m.alerts {
+		am[a.Target] = a
+	}
+	return am
 }
 
 func (m *Model) updateDetailFromSelection() {
-    if m.focus == panelSidebar {
-        node := m.sidebar.Selected()
-        if node == nil {
-            m.detail = DetailModel{}
-            return
-        }
-        grouped := tmux.GroupBySessions(m.panes)
-        windows := grouped[node.Session]
-        alertCount := 0
-        for _, a := range m.alerts {
-            if strings.HasPrefix(a.Target, node.Session+":") {
-                alertCount++
-            }
-        }
-        sessionCWD := tmux.PrimaryPaneCWD(windows[0])
-        // count processes whose CWD is under the session's primary CWD
-        procCount := 0
-        if sessionCWD != "" {
-            for _, pr := range m.procs {
-                cwd := m.cwdMap[pr.PID]
-                if cwd == "" {
-                    continue
-                }
-                if cwd == sessionCWD || git.IsDescendant(cwd, sessionCWD) {
-                    procCount++
-                }
-            }
-        }
-        paneCount := 0
-        for _, wp := range windows {
-            paneCount += len(wp)
-        }
-        sess := m.sidebar.FindSession(node.Session)
-        isConfigOnly := sess != nil && !sess.IsLive && sess.IsConfig
-        configPath := ""
-        configWorktree := ""
-        if isConfigOnly && sess.Config != nil {
-            configPath = sess.Config.Path
-            if sess.Config.Worktree && configPath != "" {
-                // If configPath itself is the worktree root container (.bare/ lives here),
-                // show just the repo name. Otherwise show "worktree (repo)".
-                if fi, err := os.Stat(filepath.Join(configPath, ".bare")); err == nil && fi.IsDir() {
-                    bareStr := lipgloss.NewStyle().Italic(true).Render("_bare_")
-                    configWorktree = bareStr + " (" + filepath.Base(configPath) + ")"
-                } else {
-                    configWorktree = filepath.Base(configPath) + " (" + filepath.Base(filepath.Dir(configPath)) + ")"
-                }
-            }
-        }
-        m.detail = DetailModel{
-            cfg:            m.cfg,
-            selType:        DetailSession,
-            session:        node.Session,
-            sessionCWD:     sessionCWD,
-            isConfigOnly:   isConfigOnly,
-            configPath:     configPath,
-            configWorktree: configWorktree,
-            gitInfo:        m.gitInfo[node.Session],
-            winCount:     len(windows),
-            paneCount:    paneCount,
-            procCount:    procCount,
-            alertCount:   alertCount,
-        }
-        return
-    }
-    // panelProcList focus
-    if m.focus == panelProcList {
-        selNode := m.procList.SelectedNode()
-        if selNode == nil || selNode.IsPaneHeader {
-            m.detail = DetailModel{}
-            return
-        }
-        if selNode.IsWindowHeader {
-            sess := selNode.Pane.Session
-            winIdx := selNode.Pane.WindowIndex
-            grouped := tmux.GroupBySessions(m.panes)
-            windows := grouped[sess]
-            wPanes := windows[winIdx]
-            gitKey := fmt.Sprintf("%s:%d", sess, winIdx)
-            var windowAlert *db.Alert
-            target := fmt.Sprintf("%s:%d", sess, winIdx)
-            if a, err := m.db.AlertByTarget(target); err == nil && a != nil {
-                windowAlert = a
-            }
-            sessionCWD := tmux.PrimaryPaneCWD(windows[0])
-            alertCount := 0
-            for _, a := range m.alerts {
-                if strings.HasPrefix(a.Target, sess+":") {
-                    alertCount++
-                }
-            }
-            procCount := 0
-            if sessionCWD != "" {
-                for _, pr := range m.procs {
-                    cwd := m.cwdMap[pr.PID]
-                    if cwd == "" {
-                        continue
-                    }
-                    if cwd == sessionCWD || git.IsDescendant(cwd, sessionCWD) {
-                        procCount++
-                    }
-                }
-            }
-            m.detail = DetailModel{
-                cfg:         m.cfg,
-                selType:     DetailWindow,
-                session:     sess,
-                sessionCWD:  sessionCWD,
-                gitInfo:     m.gitInfo[sess],
-                winCount:    len(windows),
-                procCount:   procCount,
-                alertCount:  alertCount,
-                windowIndex: winIdx,
-                windowPanes: wPanes,
-                windowGit:   m.gitInfo[gitKey],
-                windowAlert: windowAlert,
-            }
-            return
-        }
-        pr := selNode.Proc
-        cwd := m.cwdMap[pr.PID]
-        portStr := ""
-        if selNode.Port > 0 {
-            portStr = fmt.Sprintf("%d", selNode.Port)
-        }
-        m.detail = DetailModel{
-            cfg:      m.cfg,
-            selType:  DetailProc,
-            proc:     pr,
-            procGit:  m.gitInfo[cwd],
-            procPort: portStr,
-            procCWD:  cwd,
-        }
-    }
+	if m.focus == panelSidebar {
+		node := m.sidebar.Selected()
+		if node == nil {
+			m.detail = DetailModel{}
+			return
+		}
+		grouped := tmux.GroupBySessions(m.panes)
+		windows := grouped[node.Session]
+		alertCount := 0
+		for _, a := range m.alerts {
+			if strings.HasPrefix(a.Target, node.Session+":") {
+				alertCount++
+			}
+		}
+		sessionCWD := tmux.PrimaryPaneCWD(windows[0])
+		// count processes whose CWD is under the session's primary CWD
+		procCount := 0
+		if sessionCWD != "" {
+			for _, pr := range m.procs {
+				cwd := m.cwdMap[pr.PID]
+				if cwd == "" {
+					continue
+				}
+				if cwd == sessionCWD || git.IsDescendant(cwd, sessionCWD) {
+					procCount++
+				}
+			}
+		}
+		paneCount := 0
+		for _, wp := range windows {
+			paneCount += len(wp)
+		}
+		sess := m.sidebar.FindSession(node.Session)
+		isConfigOnly := sess != nil && !sess.IsLive && sess.IsConfig
+		configPath := ""
+		configWorktree := ""
+		if isConfigOnly && sess.Config != nil {
+			configPath = sess.Config.Path
+			if sess.Config.Worktree && configPath != "" {
+				// If configPath itself is the worktree root container (.bare/ lives here),
+				// show just the repo name. Otherwise show "worktree (repo)".
+				if fi, err := os.Stat(filepath.Join(configPath, ".bare")); err == nil && fi.IsDir() {
+					bareStr := lipgloss.NewStyle().Italic(true).Render("_bare_")
+					configWorktree = bareStr + " (" + filepath.Base(configPath) + ")"
+				} else {
+					configWorktree = filepath.Base(configPath) + " (" + filepath.Base(filepath.Dir(configPath)) + ")"
+				}
+			}
+		}
+		m.detail = DetailModel{
+			cfg:            m.cfg,
+			selType:        DetailSession,
+			session:        node.Session,
+			sessionCWD:     sessionCWD,
+			isConfigOnly:   isConfigOnly,
+			configPath:     configPath,
+			configWorktree: configWorktree,
+			gitInfo:        m.gitInfo[node.Session],
+			winCount:       len(windows),
+			paneCount:      paneCount,
+			procCount:      procCount,
+			alertCount:     alertCount,
+		}
+		return
+	}
+	// panelProcList focus
+	if m.focus == panelProcList {
+		selNode := m.procList.SelectedNode()
+		if selNode == nil || selNode.IsPaneHeader {
+			m.detail = DetailModel{}
+			return
+		}
+		if selNode.IsWindowHeader {
+			sess := selNode.Pane.Session
+			winIdx := selNode.Pane.WindowIndex
+			grouped := tmux.GroupBySessions(m.panes)
+			windows := grouped[sess]
+			wPanes := windows[winIdx]
+			gitKey := fmt.Sprintf("%s:%d", sess, winIdx)
+			var windowAlert *db.Alert
+			target := fmt.Sprintf("%s:%d", sess, winIdx)
+			if a, err := m.db.AlertByTarget(target); err == nil && a != nil {
+				windowAlert = a
+			}
+			sessionCWD := tmux.PrimaryPaneCWD(windows[0])
+			alertCount := 0
+			for _, a := range m.alerts {
+				if strings.HasPrefix(a.Target, sess+":") {
+					alertCount++
+				}
+			}
+			procCount := 0
+			if sessionCWD != "" {
+				for _, pr := range m.procs {
+					cwd := m.cwdMap[pr.PID]
+					if cwd == "" {
+						continue
+					}
+					if cwd == sessionCWD || git.IsDescendant(cwd, sessionCWD) {
+						procCount++
+					}
+				}
+			}
+			m.detail = DetailModel{
+				cfg:         m.cfg,
+				selType:     DetailWindow,
+				session:     sess,
+				sessionCWD:  sessionCWD,
+				gitInfo:     m.gitInfo[sess],
+				winCount:    len(windows),
+				procCount:   procCount,
+				alertCount:  alertCount,
+				windowIndex: winIdx,
+				windowPanes: wPanes,
+				windowGit:   m.gitInfo[gitKey],
+				windowAlert: windowAlert,
+			}
+			return
+		}
+		pr := selNode.Proc
+		cwd := m.cwdMap[pr.PID]
+		portStr := ""
+		if selNode.Port > 0 {
+			portStr = fmt.Sprintf("%d", selNode.Port)
+		}
+		m.detail = DetailModel{
+			cfg:      m.cfg,
+			selType:  DetailProc,
+			proc:     pr,
+			procGit:  m.gitInfo[cwd],
+			procPort: portStr,
+			procCWD:  cwd,
+		}
+	}
 }
 
 func (m Model) updateYank(msg tea.Msg) (tea.Model, tea.Cmd) {
-    switch msg := msg.(type) {
-    case tea.KeyMsg:
-        if key.Matches(msg, keys.Esc) || msg.String() == "q" {
-            m.showYank = false
-            return m, nil
-        }
-        if key.Matches(msg, keys.Enter) {
-            val := m.yank.SelectedValue()
-            CopyToClipboard(val)
-            m.showYank = false
-            m.statusMsg = "yanked: " + val
-            m.statusExp = time.Now().Add(2 * time.Second)
-            return m, nil
-        }
-        switch msg.String() {
-        case "j", "down":
-            m.yank.MoveDown()
-        case "k", "up":
-            m.yank.MoveUp()
-        }
-    }
-    return m, nil
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if key.Matches(msg, keys.Esc) || msg.String() == "q" {
+			m.showYank = false
+			return m, nil
+		}
+		if key.Matches(msg, keys.Enter) {
+			val := m.yank.SelectedValue()
+			CopyToClipboard(val)
+			m.showYank = false
+			m.statusMsg = "yanked: " + val
+			m.statusExp = time.Now().Add(2 * time.Second)
+			return m, nil
+		}
+		switch msg.String() {
+		case "j", "down":
+			m.yank.MoveDown()
+		case "k", "up":
+			m.yank.MoveUp()
+		}
+	}
+	return m, nil
 }

--- a/internal/tui/overlay_test.go
+++ b/internal/tui/overlay_test.go
@@ -1,187 +1,187 @@
 package tui
 
 import (
-    "strings"
-    "testing"
-    "time"
+	"strings"
+	"testing"
+	"time"
 
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 // ── overlayCenter ─────────────────────────────────────────────────────────────
 
 func TestOverlayCenter_FgPlacedAtCenter(t *testing.T) {
-    // bg: 10 cols × 5 rows, fg: 3 cols × 1 row
-    // startX=(10-3)/2=3, startY=(5-1)/2=2 → overlay lands on line 2
-    bg := "1234567890\nabcdefghij\nABCDEFGHIJ\n0987654321\nzyxwvutsrq"
-    result := overlayCenter("XXX", bg, 10, 5)
-    lines := strings.Split(result, "\n")
-    if lines[2] != "ABCXXXGHIJ" {
-        t.Errorf("line 2: expected ABCXXXGHIJ, got %q", lines[2])
-    }
+	// bg: 10 cols × 5 rows, fg: 3 cols × 1 row
+	// startX=(10-3)/2=3, startY=(5-1)/2=2 → overlay lands on line 2
+	bg := "1234567890\nabcdefghij\nABCDEFGHIJ\n0987654321\nzyxwvutsrq"
+	result := overlayCenter("XXX", bg, 10, 5)
+	lines := strings.Split(result, "\n")
+	if lines[2] != "ABCXXXGHIJ" {
+		t.Errorf("line 2: expected ABCXXXGHIJ, got %q", lines[2])
+	}
 }
 
 func TestOverlayCenter_BackgroundLinesOutsideRangeUnchanged(t *testing.T) {
-    bg := "1234567890\nabcdefghij\nABCDEFGHIJ\n0987654321\nzyxwvutsrq"
-    result := overlayCenter("XXX", bg, 10, 5)
-    lines := strings.Split(result, "\n")
-    if lines[0] != "1234567890" {
-        t.Errorf("line 0 should be unchanged: %q", lines[0])
-    }
-    if lines[4] != "zyxwvutsrq" {
-        t.Errorf("line 4 should be unchanged: %q", lines[4])
-    }
+	bg := "1234567890\nabcdefghij\nABCDEFGHIJ\n0987654321\nzyxwvutsrq"
+	result := overlayCenter("XXX", bg, 10, 5)
+	lines := strings.Split(result, "\n")
+	if lines[0] != "1234567890" {
+		t.Errorf("line 0 should be unchanged: %q", lines[0])
+	}
+	if lines[4] != "zyxwvutsrq" {
+		t.Errorf("line 4 should be unchanged: %q", lines[4])
+	}
 }
 
 func TestOverlayCenter_MultiLineFg(t *testing.T) {
-    // bg: 10 cols × 3 rows, fg: 3 cols × 2 rows
-    // startX=(10-3)/2=3, startY=(3-2)/2=0 → lines 0 and 1 get overlaid
-    bg := "1234567890\nabcdefghij\nABCDEFGHIJ"
-    result := overlayCenter("XXX\nYYY", bg, 10, 3)
-    lines := strings.Split(result, "\n")
-    if lines[0] != "123XXX7890" {
-        t.Errorf("line 0: expected 123XXX7890, got %q", lines[0])
-    }
-    if lines[1] != "abcYYYghij" {
-        t.Errorf("line 1: expected abcYYYghij, got %q", lines[1])
-    }
-    if lines[2] != "ABCDEFGHIJ" {
-        t.Errorf("line 2 should be unchanged: %q", lines[2])
-    }
+	// bg: 10 cols × 3 rows, fg: 3 cols × 2 rows
+	// startX=(10-3)/2=3, startY=(3-2)/2=0 → lines 0 and 1 get overlaid
+	bg := "1234567890\nabcdefghij\nABCDEFGHIJ"
+	result := overlayCenter("XXX\nYYY", bg, 10, 3)
+	lines := strings.Split(result, "\n")
+	if lines[0] != "123XXX7890" {
+		t.Errorf("line 0: expected 123XXX7890, got %q", lines[0])
+	}
+	if lines[1] != "abcYYYghij" {
+		t.Errorf("line 1: expected abcYYYghij, got %q", lines[1])
+	}
+	if lines[2] != "ABCDEFGHIJ" {
+		t.Errorf("line 2 should be unchanged: %q", lines[2])
+	}
 }
 
 func TestOverlayCenter_FgWiderThanBgClampsStartXToZero(t *testing.T) {
-    // fg (12 cols) wider than bg (5 cols): startX clamped to 0, not negative
-    bg := "abcde\nfghij"
-    result := overlayCenter("XXXXXXXXXXXX", bg, 5, 2)
-    lines := strings.Split(result, "\n")
-    // line 0 (startY=0): fg replaces the entire line content
-    if !strings.Contains(lines[0], "XXX") {
-        t.Errorf("expected fg content at line 0 when fg wider than bg, got: %q", lines[0])
-    }
-    if lines[1] != "fghij" {
-        t.Errorf("line 1 should be unchanged: %q", lines[1])
-    }
+	// fg (12 cols) wider than bg (5 cols): startX clamped to 0, not negative
+	bg := "abcde\nfghij"
+	result := overlayCenter("XXXXXXXXXXXX", bg, 5, 2)
+	lines := strings.Split(result, "\n")
+	// line 0 (startY=0): fg replaces the entire line content
+	if !strings.Contains(lines[0], "XXX") {
+		t.Errorf("expected fg content at line 0 when fg wider than bg, got: %q", lines[0])
+	}
+	if lines[1] != "fghij" {
+		t.Errorf("line 1 should be unchanged: %q", lines[1])
+	}
 }
 
 func TestOverlayCenter_FgTallerThanBgClampsStartYToZero(t *testing.T) {
-    // fg (3 rows) taller than bg (1 row): startY clamped to 0
-    // Only fgLines[0] overlaid on the single bg line
-    // startX=(10-1)/2=4; "background"[0:4]+"X"+"background"[5:]="backXround"
-    result := overlayCenter("X\nY\nZ", "background", 10, 1)
-    lines := strings.Split(result, "\n")
-    if len(lines) != 1 {
-        t.Fatalf("expected 1 output line, got %d", len(lines))
-    }
-    if lines[0] != "backXround" {
-        t.Errorf("expected backXround, got %q", lines[0])
-    }
+	// fg (3 rows) taller than bg (1 row): startY clamped to 0
+	// Only fgLines[0] overlaid on the single bg line
+	// startX=(10-1)/2=4; "background"[0:4]+"X"+"background"[5:]="backXround"
+	result := overlayCenter("X\nY\nZ", "background", 10, 1)
+	lines := strings.Split(result, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 output line, got %d", len(lines))
+	}
+	if lines[0] != "backXround" {
+		t.Errorf("expected backXround, got %q", lines[0])
+	}
 }
 
 // ── pruneStaleAlerts ──────────────────────────────────────────────────────────
 
 func newPruneTestModel(t *testing.T) Model {
-    t.Helper()
-    d, err := db.Open(":memory:")
-    if err != nil {
-        t.Fatal(err)
-    }
-    t.Cleanup(func() { d.Close() })
-    return New(config.Default(), d)
+	t.Helper()
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return New(config.Default(), d)
 }
 
 func TestPruneStaleAlerts_NilWhenNoPanes(t *testing.T) {
-    m := newPruneTestModel(t)
-    m.panes = nil
-    m.alerts = []db.Alert{{Target: "work:0.0", CreatedAt: time.Now()}}
-    if cmd := m.pruneStaleAlerts(); cmd != nil {
-        t.Error("expected nil when panes list is empty")
-    }
+	m := newPruneTestModel(t)
+	m.panes = nil
+	m.alerts = []db.Alert{{Target: "work:0.0", CreatedAt: time.Now()}}
+	if cmd := m.pruneStaleAlerts(); cmd != nil {
+		t.Error("expected nil when panes list is empty")
+	}
 }
 
 func TestPruneStaleAlerts_NilWhenAllAlertsAreLive(t *testing.T) {
-    m := newPruneTestModel(t)
-    m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
-    m.alerts = []db.Alert{
-        {Target: "work:0.0", CreatedAt: time.Now()}, // live pane
-        {Target: "work:0", CreatedAt: time.Now()},   // live window
-        {Target: "work", CreatedAt: time.Now()},     // live session
-    }
-    if cmd := m.pruneStaleAlerts(); cmd != nil {
-        t.Error("expected nil when all alerts reference live targets")
-    }
+	m := newPruneTestModel(t)
+	m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
+	m.alerts = []db.Alert{
+		{Target: "work:0.0", CreatedAt: time.Now()}, // live pane
+		{Target: "work:0", CreatedAt: time.Now()},   // live window
+		{Target: "work", CreatedAt: time.Now()},     // live session
+	}
+	if cmd := m.pruneStaleAlerts(); cmd != nil {
+		t.Error("expected nil when all alerts reference live targets")
+	}
 }
 
 func TestPruneStaleAlerts_PrunesStalePaneTarget(t *testing.T) {
-    m := newPruneTestModel(t)
-    m.db.AlertSet("gone:9.9", "r", "warn")
-    m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
-    alerts, _ := m.db.AlertList()
-    m.alerts = alerts
+	m := newPruneTestModel(t)
+	m.db.AlertSet("gone:9.9", "r", "warn")
+	m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
+	alerts, _ := m.db.AlertList()
+	m.alerts = alerts
 
-    cmd := m.pruneStaleAlerts()
-    if cmd == nil {
-        t.Fatal("expected non-nil cmd for stale pane-level alert")
-    }
-    msg := cmd().(alertsMsg)
-    if len(msg.alerts) != 0 {
-        t.Errorf("expected stale pane alert removed; %d remain", len(msg.alerts))
-    }
+	cmd := m.pruneStaleAlerts()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for stale pane-level alert")
+	}
+	msg := cmd().(alertsMsg)
+	if len(msg.alerts) != 0 {
+		t.Errorf("expected stale pane alert removed; %d remain", len(msg.alerts))
+	}
 }
 
 func TestPruneStaleAlerts_PrunesStaleWindowTarget(t *testing.T) {
-    m := newPruneTestModel(t)
-    m.db.AlertSet("gone:9", "r", "warn")
-    m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
-    alerts, _ := m.db.AlertList()
-    m.alerts = alerts
+	m := newPruneTestModel(t)
+	m.db.AlertSet("gone:9", "r", "warn")
+	m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
+	alerts, _ := m.db.AlertList()
+	m.alerts = alerts
 
-    cmd := m.pruneStaleAlerts()
-    if cmd == nil {
-        t.Fatal("expected non-nil cmd for stale window-level alert")
-    }
-    msg := cmd().(alertsMsg)
-    if len(msg.alerts) != 0 {
-        t.Errorf("expected stale window alert removed; %d remain", len(msg.alerts))
-    }
+	cmd := m.pruneStaleAlerts()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for stale window-level alert")
+	}
+	msg := cmd().(alertsMsg)
+	if len(msg.alerts) != 0 {
+		t.Errorf("expected stale window alert removed; %d remain", len(msg.alerts))
+	}
 }
 
 func TestPruneStaleAlerts_PrunesStaleSessionTarget(t *testing.T) {
-    m := newPruneTestModel(t)
-    m.db.AlertSet("gone-session", "r", "warn")
-    m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
-    alerts, _ := m.db.AlertList()
-    m.alerts = alerts
+	m := newPruneTestModel(t)
+	m.db.AlertSet("gone-session", "r", "warn")
+	m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
+	alerts, _ := m.db.AlertList()
+	m.alerts = alerts
 
-    cmd := m.pruneStaleAlerts()
-    if cmd == nil {
-        t.Fatal("expected non-nil cmd for stale session-level alert")
-    }
-    msg := cmd().(alertsMsg)
-    if len(msg.alerts) != 0 {
-        t.Errorf("expected stale session alert removed; %d remain", len(msg.alerts))
-    }
+	cmd := m.pruneStaleAlerts()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for stale session-level alert")
+	}
+	msg := cmd().(alertsMsg)
+	if len(msg.alerts) != 0 {
+		t.Errorf("expected stale session alert removed; %d remain", len(msg.alerts))
+	}
 }
 
 func TestPruneStaleAlerts_PreservesLiveAlerts(t *testing.T) {
-    m := newPruneTestModel(t)
-    m.db.AlertSet("work:0.0", "live pane", "info")
-    m.db.AlertSet("gone:9.9", "stale pane", "warn")
-    m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
-    alerts, _ := m.db.AlertList()
-    m.alerts = alerts
+	m := newPruneTestModel(t)
+	m.db.AlertSet("work:0.0", "live pane", "info")
+	m.db.AlertSet("gone:9.9", "stale pane", "warn")
+	m.panes = []tmux.Pane{{Session: "work", WindowIndex: 0, PaneIndex: 0}}
+	alerts, _ := m.db.AlertList()
+	m.alerts = alerts
 
-    cmd := m.pruneStaleAlerts()
-    if cmd == nil {
-        t.Fatal("expected non-nil cmd (one stale alert present)")
-    }
-    msg := cmd().(alertsMsg)
-    if len(msg.alerts) != 1 {
-        t.Fatalf("expected 1 alert to survive, got %d", len(msg.alerts))
-    }
-    if msg.alerts[0].Target != "work:0.0" {
-        t.Errorf("expected live alert work:0.0 to survive, got: %q", msg.alerts[0].Target)
-    }
+	cmd := m.pruneStaleAlerts()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd (one stale alert present)")
+	}
+	msg := cmd().(alertsMsg)
+	if len(msg.alerts) != 1 {
+		t.Fatalf("expected 1 alert to survive, got %d", len(msg.alerts))
+	}
+	if msg.alerts[0].Target != "work:0.0" {
+		t.Errorf("expected live alert work:0.0 to survive, got: %q", msg.alerts[0].Target)
+	}
 }

--- a/internal/tui/proclist.go
+++ b/internal/tui/proclist.go
@@ -1,53 +1,53 @@
 package tui
 
 import (
-    "fmt"
-    "sort"
-    "strings"
+	"fmt"
+	"sort"
+	"strings"
 
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/git"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/query"
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/query"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 type ProcListNode struct {
-    IsPaneHeader bool
-    IsIdle         bool // placeholder row shown when a pane has no processes
-    IsWindowHeader bool // true for window-level header rows in session mode
-    Pane         tmux.Pane
-    GitDeviant   bool
-    GitInfo      git.Info
-    Alert        *db.Alert
-    Proc         proc.Process
-    Port         int
-    Depth        int // 0=pane header, 1=process, 2=subprocess
-    // collapse support (depth-1 nodes only)
-    HasChildren bool    // true if this depth-1 node has at least one non-ignored child
-    Collapsed   bool    // true when children are hidden
-    AggCPU      float64 // CPU% summed across parent + all descendants
-    AggMemRSS   uint64  // MemRSS summed across parent + all descendants
-    // tree drawing (set by assignTreePrefixes after SetWindowData)
-    TreePrefix string // line-1 prefix, e.g. "  ├─ " or "  └─ "
-    StatPrefix string // line-2 (stats) prefix, e.g. "  │  " or "     "
+	IsPaneHeader   bool
+	IsIdle         bool // placeholder row shown when a pane has no processes
+	IsWindowHeader bool // true for window-level header rows in session mode
+	Pane           tmux.Pane
+	GitDeviant     bool
+	GitInfo        git.Info
+	Alert          *db.Alert
+	Proc           proc.Process
+	Port           int
+	Depth          int // 0=pane header, 1=process, 2=subprocess
+	// collapse support (depth-1 nodes only)
+	HasChildren bool    // true if this depth-1 node has at least one non-ignored child
+	Collapsed   bool    // true when children are hidden
+	AggCPU      float64 // CPU% summed across parent + all descendants
+	AggMemRSS   uint64  // MemRSS summed across parent + all descendants
+	// tree drawing (set by assignTreePrefixes after SetWindowData)
+	TreePrefix string // line-1 prefix, e.g. "  ├─ " or "  └─ "
+	StatPrefix string // line-2 (stats) prefix, e.g. "  │  " or "     "
 }
 
 type ProcListModel struct {
-    nodes         []ProcListNode
-    cursor        int
-    offset        int // viewport scroll offset (by node index)
-    primaryCWD    string
-    curSession    string
-    curWindow     int
-    collapsedPIDs   map[int32]bool // persists collapse state across SetWindowData calls
-    pendingSeekKey  string         // node identity to restore cursor after next rebuild
-    inSessionMode   bool           // true when displaying all windows of a session
-    sessionAlert    *db.Alert
-    cfg             config.Config
-    searchQuery     query.ParsedQuery
-    queryResult     query.Result
+	nodes          []ProcListNode
+	cursor         int
+	offset         int // viewport scroll offset (by node index)
+	primaryCWD     string
+	curSession     string
+	curWindow      int
+	collapsedPIDs  map[int32]bool // persists collapse state across SetWindowData calls
+	pendingSeekKey string         // node identity to restore cursor after next rebuild
+	inSessionMode  bool           // true when displaying all windows of a session
+	sessionAlert   *db.Alert
+	cfg            config.Config
+	searchQuery    query.ParsedQuery
+	queryResult    query.Result
 }
 
 // TODO: single-window mode (SetWindowData) must be removed — selecting individual
@@ -58,128 +58,128 @@ type ProcListModel struct {
 // gitInfo is keyed by "session:windowIndex:paneIndex" for deviant panes, and
 // alertMap is keyed by "session:windowIndex.paneIndex" for pane-level alerts.
 func (p *ProcListModel) SetWindowData(panes []tmux.Pane, session string, windowIndex int, procs []proc.Process, cwdMap map[int32]string, gitInfo map[string]git.Info, alertMap map[string]db.Alert, cfg config.Config) {
-    p.cfg = cfg
-    p.inSessionMode = false
-    p.sessionAlert = nil
-    grouped := tmux.GroupBySessions(panes)
-    windows := grouped[session]
-    p.primaryCWD = tmux.PrimaryPaneCWD(windows[0])
-    wPanes := windows[windowIndex]
+	p.cfg = cfg
+	p.inSessionMode = false
+	p.sessionAlert = nil
+	grouped := tmux.GroupBySessions(panes)
+	windows := grouped[session]
+	p.primaryCWD = tmux.PrimaryPaneCWD(windows[0])
+	wPanes := windows[windowIndex]
 
-    tree := proc.BuildTree(procs)
+	tree := proc.BuildTree(procs)
 
-    if p.collapsedPIDs == nil {
-        p.collapsedPIDs = make(map[int32]bool)
-    }
+	if p.collapsedPIDs == nil {
+		p.collapsedPIDs = make(map[int32]bool)
+	}
 
-    windowChanged := session != p.curSession || windowIndex != p.curWindow
-    p.curSession = session
-    p.curWindow = windowIndex
-    p.nodes = nil
-    if windowChanged {
-        p.cursor = 0
-        p.offset = 0
-        p.collapsedPIDs = make(map[int32]bool) // reset so new window's PIDs default to collapsed
-    }
+	windowChanged := session != p.curSession || windowIndex != p.curWindow
+	p.curSession = session
+	p.curWindow = windowIndex
+	p.nodes = nil
+	if windowChanged {
+		p.cursor = 0
+		p.offset = 0
+		p.collapsedPIDs = make(map[int32]bool) // reset so new window's PIDs default to collapsed
+	}
 
-    for _, pane := range sortPanes(wPanes) {
-        paneCWD := pane.CWD
-        gitKey := fmt.Sprintf("%s:%d:%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
-        info := gitInfo[gitKey]
-        deviant := p.primaryCWD != "" && !git.IsDescendant(paneCWD, p.primaryCWD) && paneCWD != p.primaryCWD
+	for _, pane := range sortPanes(wPanes) {
+		paneCWD := pane.CWD
+		gitKey := fmt.Sprintf("%s:%d:%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
+		info := gitInfo[gitKey]
+		deviant := p.primaryCWD != "" && !git.IsDescendant(paneCWD, p.primaryCWD) && paneCWD != p.primaryCWD
 
-        headerIdx := len(p.nodes)
-        var paneAlert *db.Alert
-        if alertMap != nil {
-            paneKey := fmt.Sprintf("%s:%d.%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
-            if a, ok := alertMap[paneKey]; ok {
-                paneAlert = &a
-            }
-        }
-        p.nodes = append(p.nodes, ProcListNode{
-            IsPaneHeader: true,
-            Pane:         pane,
-            GitDeviant:   deviant,
-            GitInfo:      info,
-            Alert:        paneAlert,
-        })
+		headerIdx := len(p.nodes)
+		var paneAlert *db.Alert
+		if alertMap != nil {
+			paneKey := fmt.Sprintf("%s:%d.%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
+			if a, ok := alertMap[paneKey]; ok {
+				paneAlert = &a
+			}
+		}
+		p.nodes = append(p.nodes, ProcListNode{
+			IsPaneHeader: true,
+			Pane:         pane,
+			GitDeviant:   deviant,
+			GitInfo:      info,
+			Alert:        paneAlert,
+		})
 
-        // collect depth-1 children of the pane's shell process
-        seen := make(map[int32]bool)
-        var children []proc.Process
-        if pane.PanePID != 0 {
-            // PID-based: direct children of the shell
-            children = tree[pane.PanePID]
-        } else {
-            // fallback: CWD-based match for panes without a known PID
-            for _, pr := range procs {
-                cwd, ok := cwdMap[pr.PID]
-                if !ok || (cwd != paneCWD && !git.IsDescendant(cwd, paneCWD)) {
-                    continue
-                }
-                children = append(children, pr)
-            }
-        }
-        var addProc func(pr proc.Process, depth int)
-        addProc = func(pr proc.Process, depth int) {
-            if seen[pr.PID] {
-                return
-            }
-            seen[pr.PID] = true
-            if containsStr(activeIgnoredProcs, strings.ToLower(pr.FriendlyName())) {
-                // skip shell — promote its children to the same depth
-                for _, child := range tree[pr.PID] {
-                    addProc(child, depth)
-                }
-                return
-            }
+		// collect depth-1 children of the pane's shell process
+		seen := make(map[int32]bool)
+		var children []proc.Process
+		if pane.PanePID != 0 {
+			// PID-based: direct children of the shell
+			children = tree[pane.PanePID]
+		} else {
+			// fallback: CWD-based match for panes without a known PID
+			for _, pr := range procs {
+				cwd, ok := cwdMap[pr.PID]
+				if !ok || (cwd != paneCWD && !git.IsDescendant(cwd, paneCWD)) {
+					continue
+				}
+				children = append(children, pr)
+			}
+		}
+		var addProc func(pr proc.Process, depth int)
+		addProc = func(pr proc.Process, depth int) {
+			if seen[pr.PID] {
+				return
+			}
+			seen[pr.PID] = true
+			if containsStr(activeIgnoredProcs, strings.ToLower(pr.FriendlyName())) {
+				// skip shell — promote its children to the same depth
+				for _, child := range tree[pr.PID] {
+					addProc(child, depth)
+				}
+				return
+			}
 
-            // For depth-1 nodes: compute collapse metadata
-            var hasChildren bool
-            var aggCPU float64
-            var aggMem uint64
-            var collapsed bool
-            if depth == 1 {
-                for _, child := range tree[pr.PID] {
-                    if !containsStr(activeIgnoredProcs, strings.ToLower(child.FriendlyName())) {
-                        hasChildren = true
-                        break
-                    }
-                }
-                aggCPU, aggMem = aggStats(pr, tree)
-                if _, ok := p.collapsedPIDs[pr.PID]; !ok {
-                    p.collapsedPIDs[pr.PID] = true
-                }
-                collapsed = p.collapsedPIDs[pr.PID]
-            }
+			// For depth-1 nodes: compute collapse metadata
+			var hasChildren bool
+			var aggCPU float64
+			var aggMem uint64
+			var collapsed bool
+			if depth == 1 {
+				for _, child := range tree[pr.PID] {
+					if !containsStr(activeIgnoredProcs, strings.ToLower(child.FriendlyName())) {
+						hasChildren = true
+						break
+					}
+				}
+				aggCPU, aggMem = aggStats(pr, tree)
+				if _, ok := p.collapsedPIDs[pr.PID]; !ok {
+					p.collapsedPIDs[pr.PID] = true
+				}
+				collapsed = p.collapsedPIDs[pr.PID]
+			}
 
-            p.nodes = append(p.nodes, ProcListNode{
-                Proc:        pr,
-                Pane:        pane,
-                Depth:       depth,
-                HasChildren: hasChildren,
-                Collapsed:   collapsed,
-                AggCPU:      aggCPU,
-                AggMemRSS:   aggMem,
-            })
+			p.nodes = append(p.nodes, ProcListNode{
+				Proc:        pr,
+				Pane:        pane,
+				Depth:       depth,
+				HasChildren: hasChildren,
+				Collapsed:   collapsed,
+				AggCPU:      aggCPU,
+				AggMemRSS:   aggMem,
+			})
 
-            if depth == 1 && collapsed {
-                return
-            }
-            for _, child := range tree[pr.PID] {
-                addProc(child, depth+1)
-            }
-        }
-        for _, pr := range children {
-            addProc(pr, 1)
-        }
-        if len(p.nodes) == headerIdx+1 {
-            // no children were added — insert an idle placeholder at process depth
-            p.nodes = append(p.nodes, ProcListNode{IsIdle: true, Depth: 1})
-        }
-    }
-    assignTreePrefixes(p.nodes)
-    p.applyPendingSeek()
+			if depth == 1 && collapsed {
+				return
+			}
+			for _, child := range tree[pr.PID] {
+				addProc(child, depth+1)
+			}
+		}
+		for _, pr := range children {
+			addProc(pr, 1)
+		}
+		if len(p.nodes) == headerIdx+1 {
+			// no children were added — insert an idle placeholder at process depth
+			p.nodes = append(p.nodes, ProcListNode{IsIdle: true, Depth: 1})
+		}
+	}
+	assignTreePrefixes(p.nodes)
+	p.applyPendingSeek()
 }
 
 // SetSessionData rebuilds the node list for all windows of a session.
@@ -187,181 +187,181 @@ func (p *ProcListModel) SetWindowData(panes []tmux.Pane, session string, windowI
 // pane and process nodes. Window CWD is taken as the CWD of the lowest-indexed pane;
 // pane CWD is suppressed when it matches that value.
 func (p *ProcListModel) SetSessionData(panes []tmux.Pane, session string, procs []proc.Process, cwdMap map[int32]string, gitInfo map[string]git.Info, alertMap map[string]db.Alert, cfg config.Config) {
-    p.cfg = cfg
-    p.inSessionMode = true
+	p.cfg = cfg
+	p.inSessionMode = true
 
-    grouped := tmux.GroupBySessions(panes)
-    windows := grouped[session]
-    tree := proc.BuildTree(procs)
+	grouped := tmux.GroupBySessions(panes)
+	windows := grouped[session]
+	tree := proc.BuildTree(procs)
 
-    if p.collapsedPIDs == nil {
-        p.collapsedPIDs = make(map[int32]bool)
-    }
+	if p.collapsedPIDs == nil {
+		p.collapsedPIDs = make(map[int32]bool)
+	}
 
-    sessionChanged := session != p.curSession || p.curWindow != -1
-    p.curSession = session
-    p.curWindow = -1
-    p.sessionAlert = nil
-    if alertMap != nil {
-        if a, ok := alertMap[session]; ok {
-            p.sessionAlert = &a
-        }
-    }
-    p.nodes = nil
-    if sessionChanged {
-        p.cursor = 0
-        p.offset = 0
-        p.collapsedPIDs = make(map[int32]bool)
-    }
+	sessionChanged := session != p.curSession || p.curWindow != -1
+	p.curSession = session
+	p.curWindow = -1
+	p.sessionAlert = nil
+	if alertMap != nil {
+		if a, ok := alertMap[session]; ok {
+			p.sessionAlert = &a
+		}
+	}
+	p.nodes = nil
+	if sessionChanged {
+		p.cursor = 0
+		p.offset = 0
+		p.collapsedPIDs = make(map[int32]bool)
+	}
 
-    winIdxs := make([]int, 0, len(windows))
-    for wi := range windows {
-        winIdxs = append(winIdxs, wi)
-    }
-    sort.Ints(winIdxs)
+	winIdxs := make([]int, 0, len(windows))
+	for wi := range windows {
+		winIdxs = append(winIdxs, wi)
+	}
+	sort.Ints(winIdxs)
 
-    // Compute session-level primary CWD from the first window's first pane.
-    p.primaryCWD = ""
-    for _, wi := range winIdxs {
-        ps := sortPanes(windows[wi])
-        if len(ps) > 0 {
-            p.primaryCWD = ps[0].CWD
-            break
-        }
-    }
+	// Compute session-level primary CWD from the first window's first pane.
+	p.primaryCWD = ""
+	for _, wi := range winIdxs {
+		ps := sortPanes(windows[wi])
+		if len(ps) > 0 {
+			p.primaryCWD = ps[0].CWD
+			break
+		}
+	}
 
-    for _, wi := range winIdxs {
-        wPanes := sortPanes(windows[wi])
-        if len(wPanes) == 0 {
-            continue
-        }
-        winCWD := wPanes[0].CWD
+	for _, wi := range winIdxs {
+		wPanes := sortPanes(windows[wi])
+		if len(wPanes) == 0 {
+			continue
+		}
+		winCWD := wPanes[0].CWD
 
-        p.nodes = append(p.nodes, ProcListNode{
-            IsWindowHeader: true,
-            Pane:           wPanes[0],
-            Alert:          windowAlertFromMap(alertMap, session, wi),
-        })
+		p.nodes = append(p.nodes, ProcListNode{
+			IsWindowHeader: true,
+			Pane:           wPanes[0],
+			Alert:          windowAlertFromMap(alertMap, session, wi),
+		})
 
-        for _, pane := range wPanes {
-            paneCWD := pane.CWD
-            gitKey := fmt.Sprintf("%s:%d:%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
-            info := gitInfo[gitKey]
-            deviant := winCWD != "" && !git.IsDescendant(paneCWD, winCWD) && paneCWD != winCWD
+		for _, pane := range wPanes {
+			paneCWD := pane.CWD
+			gitKey := fmt.Sprintf("%s:%d:%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
+			info := gitInfo[gitKey]
+			deviant := winCWD != "" && !git.IsDescendant(paneCWD, winCWD) && paneCWD != winCWD
 
-            displayPane := pane
-            if paneCWD == winCWD {
-                displayPane.CWD = ""
-            }
+			displayPane := pane
+			if paneCWD == winCWD {
+				displayPane.CWD = ""
+			}
 
-            headerIdx := len(p.nodes)
-            var paneAlert *db.Alert
-            if alertMap != nil {
-                paneKey := fmt.Sprintf("%s:%d.%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
-                if a, ok := alertMap[paneKey]; ok {
-                    paneAlert = &a
-                }
-            }
-            p.nodes = append(p.nodes, ProcListNode{
-                IsPaneHeader: true,
-                Pane:         displayPane,
-                GitDeviant:   deviant,
-                GitInfo:      info,
-                Alert:        paneAlert,
-            })
+			headerIdx := len(p.nodes)
+			var paneAlert *db.Alert
+			if alertMap != nil {
+				paneKey := fmt.Sprintf("%s:%d.%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
+				if a, ok := alertMap[paneKey]; ok {
+					paneAlert = &a
+				}
+			}
+			p.nodes = append(p.nodes, ProcListNode{
+				IsPaneHeader: true,
+				Pane:         displayPane,
+				GitDeviant:   deviant,
+				GitInfo:      info,
+				Alert:        paneAlert,
+			})
 
-            seen := make(map[int32]bool)
-            var children []proc.Process
-            if pane.PanePID != 0 {
-                children = tree[pane.PanePID]
-            } else {
-                for _, pr := range procs {
-                    cwd, ok := cwdMap[pr.PID]
-                    if !ok || (cwd != paneCWD && !git.IsDescendant(cwd, paneCWD)) {
-                        continue
-                    }
-                    children = append(children, pr)
-                }
-            }
-            var addProc func(pr proc.Process, depth int)
-            addProc = func(pr proc.Process, depth int) {
-                if seen[pr.PID] {
-                    return
-                }
-                seen[pr.PID] = true
-                if containsStr(activeIgnoredProcs, strings.ToLower(pr.FriendlyName())) {
-                    for _, child := range tree[pr.PID] {
-                        addProc(child, depth)
-                    }
-                    return
-                }
-                var hasChildren bool
-                var aggCPU float64
-                var aggMem uint64
-                var collapsed bool
-                if depth == 1 {
-                    for _, child := range tree[pr.PID] {
-                        if !containsStr(activeIgnoredProcs, strings.ToLower(child.FriendlyName())) {
-                            hasChildren = true
-                            break
-                        }
-                    }
-                    aggCPU, aggMem = aggStats(pr, tree)
-                    if _, ok := p.collapsedPIDs[pr.PID]; !ok {
-                        p.collapsedPIDs[pr.PID] = true
-                    }
-                    collapsed = p.collapsedPIDs[pr.PID]
-                }
-                p.nodes = append(p.nodes, ProcListNode{
-                    Proc:        pr,
-                    Pane:        pane,
-                    Depth:       depth,
-                    HasChildren: hasChildren,
-                    Collapsed:   collapsed,
-                    AggCPU:      aggCPU,
-                    AggMemRSS:   aggMem,
-                })
-                if depth == 1 && collapsed {
-                    return
-                }
-                for _, child := range tree[pr.PID] {
-                    addProc(child, depth+1)
-                }
-            }
-            for _, pr := range children {
-                addProc(pr, 1)
-            }
-            if len(p.nodes) == headerIdx+1 {
-                p.nodes = append(p.nodes, ProcListNode{IsIdle: true, Depth: 1})
-            }
-        }
-    }
-    assignTreePrefixes(p.nodes)
-    p.applyPendingSeek()
+			seen := make(map[int32]bool)
+			var children []proc.Process
+			if pane.PanePID != 0 {
+				children = tree[pane.PanePID]
+			} else {
+				for _, pr := range procs {
+					cwd, ok := cwdMap[pr.PID]
+					if !ok || (cwd != paneCWD && !git.IsDescendant(cwd, paneCWD)) {
+						continue
+					}
+					children = append(children, pr)
+				}
+			}
+			var addProc func(pr proc.Process, depth int)
+			addProc = func(pr proc.Process, depth int) {
+				if seen[pr.PID] {
+					return
+				}
+				seen[pr.PID] = true
+				if containsStr(activeIgnoredProcs, strings.ToLower(pr.FriendlyName())) {
+					for _, child := range tree[pr.PID] {
+						addProc(child, depth)
+					}
+					return
+				}
+				var hasChildren bool
+				var aggCPU float64
+				var aggMem uint64
+				var collapsed bool
+				if depth == 1 {
+					for _, child := range tree[pr.PID] {
+						if !containsStr(activeIgnoredProcs, strings.ToLower(child.FriendlyName())) {
+							hasChildren = true
+							break
+						}
+					}
+					aggCPU, aggMem = aggStats(pr, tree)
+					if _, ok := p.collapsedPIDs[pr.PID]; !ok {
+						p.collapsedPIDs[pr.PID] = true
+					}
+					collapsed = p.collapsedPIDs[pr.PID]
+				}
+				p.nodes = append(p.nodes, ProcListNode{
+					Proc:        pr,
+					Pane:        pane,
+					Depth:       depth,
+					HasChildren: hasChildren,
+					Collapsed:   collapsed,
+					AggCPU:      aggCPU,
+					AggMemRSS:   aggMem,
+				})
+				if depth == 1 && collapsed {
+					return
+				}
+				for _, child := range tree[pr.PID] {
+					addProc(child, depth+1)
+				}
+			}
+			for _, pr := range children {
+				addProc(pr, 1)
+			}
+			if len(p.nodes) == headerIdx+1 {
+				p.nodes = append(p.nodes, ProcListNode{IsIdle: true, Depth: 1})
+			}
+		}
+	}
+	assignTreePrefixes(p.nodes)
+	p.applyPendingSeek()
 }
 
 // CurrentWindow returns the session name and window index currently displayed.
 func (p ProcListModel) CurrentWindow() (string, int) {
-    return p.curSession, p.curWindow
+	return p.curSession, p.curWindow
 }
 
 func (p *ProcListModel) Reset() {
-    p.nodes = nil
-    p.cursor = 0
-    p.offset = 0
-    p.curSession = ""
-    p.curWindow = -1
+	p.nodes = nil
+	p.cursor = 0
+	p.offset = 0
+	p.curSession = ""
+	p.curWindow = -1
 }
 
 func (p ProcListModel) SelectedNode() *ProcListNode {
-    if p.cursor < 0 || p.cursor >= len(p.nodes) {
-        return nil
-    }
-    n := p.nodes[p.cursor]
-    if !isSelectable(n) {
-        return nil
-    }
-    return &n
+	if p.cursor < 0 || p.cursor >= len(p.nodes) {
+		return nil
+	}
+	n := p.nodes[p.cursor]
+	if !isSelectable(n) {
+		return nil
+	}
+	return &n
 }
 
 // SelectedPane returns the tmux.Pane containing the cursor node.
@@ -370,26 +370,26 @@ func (p ProcListModel) SelectedNode() *ProcListNode {
 // backwards to find the nearest enclosing pane header.
 // Returns nil if the node list is empty or no pane header is found.
 func (p ProcListModel) SelectedPane() *tmux.Pane {
-    n := len(p.nodes)
-    if n == 0 {
-        return nil
-    }
-    start := p.cursor
-    if start >= n {
-        start = n - 1
-    }
-    for i := start; i >= 0; i-- {
-        if p.nodes[i].IsPaneHeader || p.nodes[i].IsWindowHeader {
-            pane := p.nodes[i].Pane
-            return &pane
-        }
-    }
-    return nil
+	n := len(p.nodes)
+	if n == 0 {
+		return nil
+	}
+	start := p.cursor
+	if start >= n {
+		start = n - 1
+	}
+	for i := start; i >= 0; i-- {
+		if p.nodes[i].IsPaneHeader || p.nodes[i].IsWindowHeader {
+			pane := p.nodes[i].Pane
+			return &pane
+		}
+	}
+	return nil
 }
 
 // SetSearchQuery stores the current search query and its results so that
 // Render can dim non-matching nodes and highlight matching characters.
 func (p *ProcListModel) SetSearchQuery(pq query.ParsedQuery, r query.Result) {
-    p.searchQuery = pq
-    p.queryResult = r
+	p.searchQuery = pq
+	p.queryResult = r
 }

--- a/internal/tui/proclist_nav.go
+++ b/internal/tui/proclist_nav.go
@@ -11,92 +11,92 @@ import "fmt"
 //   - idle marker   → "idle:<windowIndex>:<paneIndex>"  (uses containing pane)
 //   - process       → "pid:<PID>"  (for depth>1 uses the depth-1 ancestor's PID)
 func (p *ProcListModel) cursorNodeKey() string {
-    if p.cursor < 0 || p.cursor >= len(p.nodes) {
-        return ""
-    }
-    n := p.nodes[p.cursor]
-    switch {
-    case n.IsWindowHeader:
-        return fmt.Sprintf("win:%d", n.Pane.WindowIndex)
-    case n.IsPaneHeader:
-        return fmt.Sprintf("pane:%d:%d", n.Pane.WindowIndex, n.Pane.PaneIndex)
-    case n.IsIdle:
-        for i := p.cursor - 1; i >= 0; i-- {
-            if p.nodes[i].IsPaneHeader {
-                ph := p.nodes[i]
-                return fmt.Sprintf("idle:%d:%d", ph.Pane.WindowIndex, ph.Pane.PaneIndex)
-            }
-        }
-        return ""
-    case n.Depth > 1:
-        for i := p.cursor - 1; i >= 0; i-- {
-            if p.nodes[i].Depth == 1 {
-                return fmt.Sprintf("pid:%d", p.nodes[i].Proc.PID)
-            }
-        }
-        return ""
-    default:
-        return fmt.Sprintf("pid:%d", n.Proc.PID)
-    }
+	if p.cursor < 0 || p.cursor >= len(p.nodes) {
+		return ""
+	}
+	n := p.nodes[p.cursor]
+	switch {
+	case n.IsWindowHeader:
+		return fmt.Sprintf("win:%d", n.Pane.WindowIndex)
+	case n.IsPaneHeader:
+		return fmt.Sprintf("pane:%d:%d", n.Pane.WindowIndex, n.Pane.PaneIndex)
+	case n.IsIdle:
+		for i := p.cursor - 1; i >= 0; i-- {
+			if p.nodes[i].IsPaneHeader {
+				ph := p.nodes[i]
+				return fmt.Sprintf("idle:%d:%d", ph.Pane.WindowIndex, ph.Pane.PaneIndex)
+			}
+		}
+		return ""
+	case n.Depth > 1:
+		for i := p.cursor - 1; i >= 0; i-- {
+			if p.nodes[i].Depth == 1 {
+				return fmt.Sprintf("pid:%d", p.nodes[i].Proc.PID)
+			}
+		}
+		return ""
+	default:
+		return fmt.Sprintf("pid:%d", n.Proc.PID)
+	}
 }
 
 // applyPendingSeek moves the cursor to the node matching pendingSeekKey, then
 // clears the field. Called at the end of each SetWindowData / SetSessionData.
 func (p *ProcListModel) applyPendingSeek() {
-    if p.pendingSeekKey == "" {
-        return
-    }
-    key := p.pendingSeekKey
-    p.pendingSeekKey = ""
-    // Track the most recent pane header for idle-node matching.
-    var curPaneWin, curPanePane int
-    for i, n := range p.nodes {
-        if n.IsPaneHeader {
-            curPaneWin = n.Pane.WindowIndex
-            curPanePane = n.Pane.PaneIndex
-        }
-        var nkey string
-        switch {
-        case n.IsWindowHeader:
-            nkey = fmt.Sprintf("win:%d", n.Pane.WindowIndex)
-        case n.IsPaneHeader:
-            nkey = fmt.Sprintf("pane:%d:%d", n.Pane.WindowIndex, n.Pane.PaneIndex)
-        case n.IsIdle:
-            nkey = fmt.Sprintf("idle:%d:%d", curPaneWin, curPanePane)
-        case n.Proc.PID != 0:
-            nkey = fmt.Sprintf("pid:%d", n.Proc.PID)
-        }
-        if nkey != "" && nkey == key {
-            p.cursor = i
-            return
-        }
-    }
+	if p.pendingSeekKey == "" {
+		return
+	}
+	key := p.pendingSeekKey
+	p.pendingSeekKey = ""
+	// Track the most recent pane header for idle-node matching.
+	var curPaneWin, curPanePane int
+	for i, n := range p.nodes {
+		if n.IsPaneHeader {
+			curPaneWin = n.Pane.WindowIndex
+			curPanePane = n.Pane.PaneIndex
+		}
+		var nkey string
+		switch {
+		case n.IsWindowHeader:
+			nkey = fmt.Sprintf("win:%d", n.Pane.WindowIndex)
+		case n.IsPaneHeader:
+			nkey = fmt.Sprintf("pane:%d:%d", n.Pane.WindowIndex, n.Pane.PaneIndex)
+		case n.IsIdle:
+			nkey = fmt.Sprintf("idle:%d:%d", curPaneWin, curPanePane)
+		case n.Proc.PID != 0:
+			nkey = fmt.Sprintf("pid:%d", n.Proc.PID)
+		}
+		if nkey != "" && nkey == key {
+			p.cursor = i
+			return
+		}
+	}
 }
 
 // clampOffset adjusts p.offset so the cursor node is always within the
 // visible row window. maxRows is the total inner height of the proc panel
 // (border already subtracted).
 func (p *ProcListModel) clampOffset(maxRows int) {
-    if len(p.nodes) == 0 {
-        p.offset = 0
-        p.cursor = 0
-        return
-    }
-    if p.cursor >= len(p.nodes) {
-        p.cursor = len(p.nodes) - 1
-    }
-    if p.cursor < p.offset {
-        p.offset = p.cursor
-    }
-    for p.offset < p.cursor {
-        if procCursorVisible(p.nodes, p.cursor, p.offset, maxRows) {
-            break
-        }
-        p.offset++
-    }
-    if p.offset < 0 {
-        p.offset = 0
-    }
+	if len(p.nodes) == 0 {
+		p.offset = 0
+		p.cursor = 0
+		return
+	}
+	if p.cursor >= len(p.nodes) {
+		p.cursor = len(p.nodes) - 1
+	}
+	if p.cursor < p.offset {
+		p.offset = p.cursor
+	}
+	for p.offset < p.cursor {
+		if procCursorVisible(p.nodes, p.cursor, p.offset, maxRows) {
+			break
+		}
+		p.offset++
+	}
+	if p.offset < 0 {
+		p.offset = 0
+	}
 }
 
 // procCursorVisible mirrors the Render hint logic to determine whether the
@@ -104,258 +104,258 @@ func (p *ProcListModel) clampOffset(maxRows int) {
 //   - ▲ hint is shown when offset > 0 (costs 1 row)
 //   - ▼ hint is shown when content overflows after accounting for ▲ (costs 1 row)
 func procCursorVisible(nodes []ProcListNode, cursor, offset, maxRows int) bool {
-    hasAbove := offset > 0
-    contentRows := maxRows
-    if hasAbove {
-        contentRows--
-    }
+	hasAbove := offset > 0
+	contentRows := maxRows
+	if hasAbove {
+		contentRows--
+	}
 
-    // First pass: scan ALL nodes from offset (not stopping at cursor) so we
-    // can detect whether nodes after the cursor would cause ▼ to appear.
-    rows := 0
-    cursorRows := -1 // rows consumed up to and including the cursor node
-    hasBelow := false
-    for i := offset; i < len(nodes); i++ {
-        nr := nodeRows(nodes[i])
-        if rows+nr > contentRows {
-            hasBelow = true
-            break
-        }
-        rows += nr
-        if i == cursor {
-            cursorRows = rows
-        }
-    }
-    if cursorRows < 0 {
-        return false // cursor not reached within contentRows
-    }
-    if !hasBelow {
-        return true // no ▼ hint; cursor fits
-    }
-    // ▼ hint will be shown — re-check with one fewer row.
-    rows = 0
-    for i := offset; i < len(nodes); i++ {
-        nr := nodeRows(nodes[i])
-        if rows+nr > contentRows-1 {
-            return false
-        }
-        rows += nr
-        if i == cursor {
-            return true
-        }
-    }
-    return false
+	// First pass: scan ALL nodes from offset (not stopping at cursor) so we
+	// can detect whether nodes after the cursor would cause ▼ to appear.
+	rows := 0
+	cursorRows := -1 // rows consumed up to and including the cursor node
+	hasBelow := false
+	for i := offset; i < len(nodes); i++ {
+		nr := nodeRows(nodes[i])
+		if rows+nr > contentRows {
+			hasBelow = true
+			break
+		}
+		rows += nr
+		if i == cursor {
+			cursorRows = rows
+		}
+	}
+	if cursorRows < 0 {
+		return false // cursor not reached within contentRows
+	}
+	if !hasBelow {
+		return true // no ▼ hint; cursor fits
+	}
+	// ▼ hint will be shown — re-check with one fewer row.
+	rows = 0
+	for i := offset; i < len(nodes); i++ {
+		nr := nodeRows(nodes[i])
+		if rows+nr > contentRows-1 {
+			return false
+		}
+		rows += nr
+		if i == cursor {
+			return true
+		}
+	}
+	return false
 }
 
 // MoveUp moves the cursor one item up, skipping idle placeholders.
 func (p *ProcListModel) MoveUp() {
-    for i := p.cursor - 1; i >= 0; i-- {
-        if isSelectable(p.nodes[i]) {
-            p.cursor = i
-            return
-        }
-    }
+	for i := p.cursor - 1; i >= 0; i-- {
+		if isSelectable(p.nodes[i]) {
+			p.cursor = i
+			return
+		}
+	}
 }
 
 // MoveDown moves the cursor one item down, skipping idle placeholders.
 func (p *ProcListModel) MoveDown() {
-    for i := p.cursor + 1; i < len(p.nodes); i++ {
-        if isSelectable(p.nodes[i]) {
-            p.cursor = i
-            return
-        }
-    }
+	for i := p.cursor + 1; i < len(p.nodes); i++ {
+		if isSelectable(p.nodes[i]) {
+			p.cursor = i
+			return
+		}
+	}
 }
 
 // TabNext moves to the next sibling at the same depth level, wrapping around
 // within the current depth's peer set.
 func (p *ProcListModel) TabNext() {
-    if len(p.nodes) == 0 {
-        return
-    }
-    depth := nodeDepth(p.nodes[p.cursor])
+	if len(p.nodes) == 0 {
+		return
+	}
+	depth := nodeDepth(p.nodes[p.cursor])
 
-    // collect all sibling indices at the same depth within the same scope
-    peers := p.peersAtDepth(p.cursor, depth)
-    if len(peers) == 0 {
-        return
-    }
+	// collect all sibling indices at the same depth within the same scope
+	peers := p.peersAtDepth(p.cursor, depth)
+	if len(peers) == 0 {
+		return
+	}
 
-    // find current position among peers and advance (with wrap)
-    for i, idx := range peers {
-        if idx == p.cursor {
-            p.cursor = peers[(i+1)%len(peers)]
-            return
-        }
-    }
+	// find current position among peers and advance (with wrap)
+	for i, idx := range peers {
+		if idx == p.cursor {
+			p.cursor = peers[(i+1)%len(peers)]
+			return
+		}
+	}
 }
 
 // peersAtDepth returns the indices of all nodes that are siblings of the node
 // at pos within the same scope (pane for depth 1; parent process block for depth 2;
 // all pane headers for depth 0).
 func (p *ProcListModel) peersAtDepth(pos, depth int) []int {
-    if depth == 0 {
-        var peers []int
-        for i, n := range p.nodes {
-            if n.IsPaneHeader || n.IsWindowHeader {
-                peers = append(peers, i)
-            }
-        }
-        return peers
-    }
+	if depth == 0 {
+		var peers []int
+		for i, n := range p.nodes {
+			if n.IsPaneHeader || n.IsWindowHeader {
+				peers = append(peers, i)
+			}
+		}
+		return peers
+	}
 
-    // find the scope boundaries for depth 1 or 2
-    scopeStart, scopeEnd := 0, len(p.nodes)-1
+	// find the scope boundaries for depth 1 or 2
+	scopeStart, scopeEnd := 0, len(p.nodes)-1
 
-    if depth == 1 {
-        // scope is within the enclosing pane header section
-        for i := pos - 1; i >= 0; i-- {
-            if p.nodes[i].IsPaneHeader {
-                scopeStart = i + 1
-                break
-            }
-        }
-        for i := pos + 1; i < len(p.nodes); i++ {
-            if p.nodes[i].IsPaneHeader {
-                scopeEnd = i - 1
-                break
-            }
-        }
-    } else {
-        // depth == 2: scope is within the enclosing depth-1 parent process block
-        for i := pos - 1; i >= 0; i-- {
-            if p.nodes[i].IsPaneHeader || nodeDepth(p.nodes[i]) == 1 {
-                scopeStart = i + 1
-                break
-            }
-        }
-        for i := pos + 1; i < len(p.nodes); i++ {
-            if p.nodes[i].IsPaneHeader || nodeDepth(p.nodes[i]) == 1 {
-                scopeEnd = i - 1
-                break
-            }
-        }
-    }
+	if depth == 1 {
+		// scope is within the enclosing pane header section
+		for i := pos - 1; i >= 0; i-- {
+			if p.nodes[i].IsPaneHeader {
+				scopeStart = i + 1
+				break
+			}
+		}
+		for i := pos + 1; i < len(p.nodes); i++ {
+			if p.nodes[i].IsPaneHeader {
+				scopeEnd = i - 1
+				break
+			}
+		}
+	} else {
+		// depth == 2: scope is within the enclosing depth-1 parent process block
+		for i := pos - 1; i >= 0; i-- {
+			if p.nodes[i].IsPaneHeader || nodeDepth(p.nodes[i]) == 1 {
+				scopeStart = i + 1
+				break
+			}
+		}
+		for i := pos + 1; i < len(p.nodes); i++ {
+			if p.nodes[i].IsPaneHeader || nodeDepth(p.nodes[i]) == 1 {
+				scopeEnd = i - 1
+				break
+			}
+		}
+	}
 
-    var peers []int
-    for i := scopeStart; i <= scopeEnd; i++ {
-        if nodeDepth(p.nodes[i]) == depth && isSelectable(p.nodes[i]) {
-            peers = append(peers, i)
-        }
-    }
-    return peers
+	var peers []int
+	for i := scopeStart; i <= scopeEnd; i++ {
+		if nodeDepth(p.nodes[i]) == depth && isSelectable(p.nodes[i]) {
+			peers = append(peers, i)
+		}
+	}
+	return peers
 }
 
 func (p *ProcListModel) JumpToNextPane() {
-    for i := p.cursor + 1; i < len(p.nodes); i++ {
-        if p.nodes[i].IsPaneHeader || p.nodes[i].IsWindowHeader {
-            p.cursor = i
-            return
-        }
-    }
+	for i := p.cursor + 1; i < len(p.nodes); i++ {
+		if p.nodes[i].IsPaneHeader || p.nodes[i].IsWindowHeader {
+			p.cursor = i
+			return
+		}
+	}
 }
 
 func (p *ProcListModel) JumpToPrevPane() {
-    for i := p.cursor - 1; i >= 0; i-- {
-        if p.nodes[i].IsPaneHeader || p.nodes[i].IsWindowHeader {
-            p.cursor = i
-            return
-        }
-    }
+	for i := p.cursor - 1; i >= 0; i-- {
+		if p.nodes[i].IsPaneHeader || p.nodes[i].IsWindowHeader {
+			p.cursor = i
+			return
+		}
+	}
 }
 
 func (p *ProcListModel) GotoTop() {
-    p.cursor = 0
-    p.offset = 0
+	p.cursor = 0
+	p.offset = 0
 }
 
 func (p *ProcListModel) GotoBottom() {
-    for i := len(p.nodes) - 1; i >= 0; i-- {
-        if isSelectable(p.nodes[i]) {
-            p.cursor = i
-            return
-        }
-    }
+	for i := len(p.nodes) - 1; i >= 0; i-- {
+		if isSelectable(p.nodes[i]) {
+			p.cursor = i
+			return
+		}
+	}
 }
 
 // ToggleCollapse flips the collapsed state of the cursor node if it is a
 // depth-1 process with children. Returns true if a toggle occurred.
 // The caller must re-call SetWindowData to rebuild nodes after a toggle.
 func (p *ProcListModel) ToggleCollapse() bool {
-    if p.cursor < 0 || p.cursor >= len(p.nodes) {
-        return false
-    }
-    n := p.nodes[p.cursor]
-    if n.IsPaneHeader || n.IsIdle || n.Depth != 1 || !n.HasChildren {
-        return false
-    }
-    if p.collapsedPIDs == nil {
-        p.collapsedPIDs = make(map[int32]bool)
-    }
-    p.collapsedPIDs[n.Proc.PID] = !p.collapsedPIDs[n.Proc.PID]
-    return true
+	if p.cursor < 0 || p.cursor >= len(p.nodes) {
+		return false
+	}
+	n := p.nodes[p.cursor]
+	if n.IsPaneHeader || n.IsIdle || n.Depth != 1 || !n.HasChildren {
+		return false
+	}
+	if p.collapsedPIDs == nil {
+		p.collapsedPIDs = make(map[int32]bool)
+	}
+	p.collapsedPIDs[n.Proc.PID] = !p.collapsedPIDs[n.Proc.PID]
+	return true
 }
 
 // Expand expands the focused depth-1 process node if it has children and is collapsed.
 // Returns true if a change occurred; the caller must re-call SetWindowData.
 func (p *ProcListModel) Expand() bool {
-    if p.cursor < 0 || p.cursor >= len(p.nodes) {
-        return false
-    }
-    n := p.nodes[p.cursor]
-    if n.IsPaneHeader || n.IsIdle || n.Depth != 1 || !n.HasChildren {
-        return false
-    }
-    if p.collapsedPIDs == nil {
-        p.collapsedPIDs = make(map[int32]bool)
-    }
-    if !p.collapsedPIDs[n.Proc.PID] {
-        return false
-    }
-    p.collapsedPIDs[n.Proc.PID] = false
-    return true
+	if p.cursor < 0 || p.cursor >= len(p.nodes) {
+		return false
+	}
+	n := p.nodes[p.cursor]
+	if n.IsPaneHeader || n.IsIdle || n.Depth != 1 || !n.HasChildren {
+		return false
+	}
+	if p.collapsedPIDs == nil {
+		p.collapsedPIDs = make(map[int32]bool)
+	}
+	if !p.collapsedPIDs[n.Proc.PID] {
+		return false
+	}
+	p.collapsedPIDs[n.Proc.PID] = false
+	return true
 }
 
 // Collapse collapses the focused node. For depth-1 nodes with children it collapses
 // directly; for nodes at any deeper depth it walks up to the ancestor depth-1 node, moves
 // the cursor there, and collapses it. Returns true if a change occurred; the caller must re-call SetWindowData.
 func (p *ProcListModel) Collapse() bool {
-    if p.cursor < 0 || p.cursor >= len(p.nodes) {
-        return false
-    }
-    n := p.nodes[p.cursor]
-    if n.IsPaneHeader || n.IsIdle {
-        return false
-    }
-    if p.collapsedPIDs == nil {
-        p.collapsedPIDs = make(map[int32]bool)
-    }
-    if n.Depth > 1 {
-        // Walk up to the parent depth-1 node.
-        for i := p.cursor - 1; i >= 0; i-- {
-            if p.nodes[i].IsPaneHeader {
-                break
-            }
-            if p.nodes[i].Depth == 1 {
-                parent := p.nodes[i]
-                if !parent.HasChildren || p.collapsedPIDs[parent.Proc.PID] {
-                    return false
-                }
-                p.cursor = i
-                p.collapsedPIDs[parent.Proc.PID] = true
-                return true
-            }
-        }
-        return false
-    }
-    if n.Depth != 1 || !n.HasChildren {
-        return false
-    }
-    if p.collapsedPIDs[n.Proc.PID] {
-        return false
-    }
-    p.collapsedPIDs[n.Proc.PID] = true
-    return true
+	if p.cursor < 0 || p.cursor >= len(p.nodes) {
+		return false
+	}
+	n := p.nodes[p.cursor]
+	if n.IsPaneHeader || n.IsIdle {
+		return false
+	}
+	if p.collapsedPIDs == nil {
+		p.collapsedPIDs = make(map[int32]bool)
+	}
+	if n.Depth > 1 {
+		// Walk up to the parent depth-1 node.
+		for i := p.cursor - 1; i >= 0; i-- {
+			if p.nodes[i].IsPaneHeader {
+				break
+			}
+			if p.nodes[i].Depth == 1 {
+				parent := p.nodes[i]
+				if !parent.HasChildren || p.collapsedPIDs[parent.Proc.PID] {
+					return false
+				}
+				p.cursor = i
+				p.collapsedPIDs[parent.Proc.PID] = true
+				return true
+			}
+		}
+		return false
+	}
+	if n.Depth != 1 || !n.HasChildren {
+		return false
+	}
+	if p.collapsedPIDs[n.Proc.PID] {
+		return false
+	}
+	p.collapsedPIDs[n.Proc.PID] = true
+	return true
 }
 
 // ExpandAll expands all depth-1 process nodes that have children.
@@ -363,21 +363,21 @@ func (p *ProcListModel) Collapse() bool {
 // pendingSeekKey is set so that applyPendingSeek can restore focus after
 // the rebuild changes indices.
 func (p *ProcListModel) ExpandAll() bool {
-    if p.collapsedPIDs == nil {
-        p.collapsedPIDs = make(map[int32]bool)
-    }
-    p.pendingSeekKey = p.cursorNodeKey()
-    changed := false
-    for _, n := range p.nodes {
-        if n.IsPaneHeader || n.IsIdle || n.Depth != 1 || !n.HasChildren {
-            continue
-        }
-        if p.collapsedPIDs[n.Proc.PID] {
-            p.collapsedPIDs[n.Proc.PID] = false
-            changed = true
-        }
-    }
-    return changed
+	if p.collapsedPIDs == nil {
+		p.collapsedPIDs = make(map[int32]bool)
+	}
+	p.pendingSeekKey = p.cursorNodeKey()
+	changed := false
+	for _, n := range p.nodes {
+		if n.IsPaneHeader || n.IsIdle || n.Depth != 1 || !n.HasChildren {
+			continue
+		}
+		if p.collapsedPIDs[n.Proc.PID] {
+			p.collapsedPIDs[n.Proc.PID] = false
+			changed = true
+		}
+	}
+	return changed
 }
 
 // CollapseAll collapses all depth-1 process nodes that have children.
@@ -385,19 +385,19 @@ func (p *ProcListModel) ExpandAll() bool {
 // pendingSeekKey is set so that applyPendingSeek (called by SetWindowData) can
 // restore focus to the same logical node after the rebuild changes indices.
 func (p *ProcListModel) CollapseAll() bool {
-    if p.collapsedPIDs == nil {
-        p.collapsedPIDs = make(map[int32]bool)
-    }
-    p.pendingSeekKey = p.cursorNodeKey()
-    changed := false
-    for _, n := range p.nodes {
-        if n.IsPaneHeader || n.IsIdle || n.Depth != 1 || !n.HasChildren {
-            continue
-        }
-        if !p.collapsedPIDs[n.Proc.PID] {
-            p.collapsedPIDs[n.Proc.PID] = true
-            changed = true
-        }
-    }
-    return changed
+	if p.collapsedPIDs == nil {
+		p.collapsedPIDs = make(map[int32]bool)
+	}
+	p.pendingSeekKey = p.cursorNodeKey()
+	changed := false
+	for _, n := range p.nodes {
+		if n.IsPaneHeader || n.IsIdle || n.Depth != 1 || !n.HasChildren {
+			continue
+		}
+		if !p.collapsedPIDs[n.Proc.PID] {
+			p.collapsedPIDs[n.Proc.PID] = true
+			changed = true
+		}
+	}
+	return changed
 }

--- a/internal/tui/proclist_open_test.go
+++ b/internal/tui/proclist_open_test.go
@@ -1,104 +1,104 @@
 package tui
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func makeTestProcListWithNodes(nodes []ProcListNode) ProcListModel {
-    m := ProcListModel{}
-    m.nodes = nodes
-    return m
+	m := ProcListModel{}
+	m.nodes = nodes
+	return m
 }
 
 func TestSelectedPane_OnPaneHeader(t *testing.T) {
-    pane := tmux.Pane{Session: "main", WindowIndex: 0, PaneIndex: 1}
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Pane: pane},
-    }
-    m := makeTestProcListWithNodes(nodes)
-    m.cursor = 0
-    got := m.SelectedPane()
-    if got == nil {
-        t.Fatal("expected non-nil pane")
-    }
-    if got.PaneIndex != 1 {
-        t.Errorf("PaneIndex: got %d, want 1", got.PaneIndex)
-    }
+	pane := tmux.Pane{Session: "main", WindowIndex: 0, PaneIndex: 1}
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Pane: pane},
+	}
+	m := makeTestProcListWithNodes(nodes)
+	m.cursor = 0
+	got := m.SelectedPane()
+	if got == nil {
+		t.Fatal("expected non-nil pane")
+	}
+	if got.PaneIndex != 1 {
+		t.Errorf("PaneIndex: got %d, want 1", got.PaneIndex)
+	}
 }
 
 func TestSelectedPane_OnProcessNode(t *testing.T) {
-    pane := tmux.Pane{Session: "main", WindowIndex: 0, PaneIndex: 2}
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Pane: pane},
-        {IsPaneHeader: false, Depth: 1, Pane: pane},
-        {IsPaneHeader: false, Depth: 2, Pane: pane},
-    }
-    m := makeTestProcListWithNodes(nodes)
+	pane := tmux.Pane{Session: "main", WindowIndex: 0, PaneIndex: 2}
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Pane: pane},
+		{IsPaneHeader: false, Depth: 1, Pane: pane},
+		{IsPaneHeader: false, Depth: 2, Pane: pane},
+	}
+	m := makeTestProcListWithNodes(nodes)
 
-    // cursor on depth-1 process
-    m.cursor = 1
-    got := m.SelectedPane()
-    if got == nil {
-        t.Fatal("expected non-nil pane for depth-1 node")
-    }
-    if got.PaneIndex != 2 {
-        t.Errorf("PaneIndex: got %d, want 2", got.PaneIndex)
-    }
+	// cursor on depth-1 process
+	m.cursor = 1
+	got := m.SelectedPane()
+	if got == nil {
+		t.Fatal("expected non-nil pane for depth-1 node")
+	}
+	if got.PaneIndex != 2 {
+		t.Errorf("PaneIndex: got %d, want 2", got.PaneIndex)
+	}
 
-    // cursor on depth-2 subprocess
-    m.cursor = 2
-    got = m.SelectedPane()
-    if got == nil {
-        t.Fatal("expected non-nil pane for depth-2 node")
-    }
-    if got.PaneIndex != 2 {
-        t.Errorf("PaneIndex: got %d, want 2", got.PaneIndex)
-    }
+	// cursor on depth-2 subprocess
+	m.cursor = 2
+	got = m.SelectedPane()
+	if got == nil {
+		t.Fatal("expected non-nil pane for depth-2 node")
+	}
+	if got.PaneIndex != 2 {
+		t.Errorf("PaneIndex: got %d, want 2", got.PaneIndex)
+	}
 }
 
 func TestSelectedPane_OnWindowHeader(t *testing.T) {
-    win0Pane := tmux.Pane{Session: "s", WindowIndex: 0, PaneIndex: 0}
-    win1Pane := tmux.Pane{Session: "s", WindowIndex: 1, PaneIndex: 0}
-    nodes := []ProcListNode{
-        {IsWindowHeader: true, Pane: win0Pane},
-        {IsPaneHeader: true, Pane: win0Pane},
-        {IsWindowHeader: true, Pane: win1Pane},
-        {IsPaneHeader: true, Pane: win1Pane},
-    }
-    m := makeTestProcListWithNodes(nodes)
+	win0Pane := tmux.Pane{Session: "s", WindowIndex: 0, PaneIndex: 0}
+	win1Pane := tmux.Pane{Session: "s", WindowIndex: 1, PaneIndex: 0}
+	nodes := []ProcListNode{
+		{IsWindowHeader: true, Pane: win0Pane},
+		{IsPaneHeader: true, Pane: win0Pane},
+		{IsWindowHeader: true, Pane: win1Pane},
+		{IsPaneHeader: true, Pane: win1Pane},
+	}
+	m := makeTestProcListWithNodes(nodes)
 
-    // cursor on Win 1 header — must return Win 1, not Win 0
-    m.cursor = 2
-    got := m.SelectedPane()
-    if got == nil {
-        t.Fatal("expected non-nil pane for window header node")
-    }
-    if got.WindowIndex != 1 {
-        t.Errorf("WindowIndex: got %d, want 1", got.WindowIndex)
-    }
+	// cursor on Win 1 header — must return Win 1, not Win 0
+	m.cursor = 2
+	got := m.SelectedPane()
+	if got == nil {
+		t.Fatal("expected non-nil pane for window header node")
+	}
+	if got.WindowIndex != 1 {
+		t.Errorf("WindowIndex: got %d, want 1", got.WindowIndex)
+	}
 }
 
 func TestSelectedPane_EmptyList(t *testing.T) {
-    m := makeTestProcListWithNodes(nil)
-    if m.SelectedPane() != nil {
-        t.Error("expected nil for empty node list")
-    }
+	m := makeTestProcListWithNodes(nil)
+	if m.SelectedPane() != nil {
+		t.Error("expected nil for empty node list")
+	}
 }
 
 func TestSelectedPane_StaleCursor(t *testing.T) {
-    pane := tmux.Pane{Session: "main", WindowIndex: 0, PaneIndex: 1}
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Pane: pane},
-    }
-    m := makeTestProcListWithNodes(nodes)
-    m.cursor = 5 // stale: beyond slice bounds
-    got := m.SelectedPane()
-    if got == nil {
-        t.Fatal("expected non-nil pane when cursor is stale but pane header exists")
-    }
-    if got.PaneIndex != 1 {
-        t.Errorf("PaneIndex: got %d, want 1", got.PaneIndex)
-    }
+	pane := tmux.Pane{Session: "main", WindowIndex: 0, PaneIndex: 1}
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Pane: pane},
+	}
+	m := makeTestProcListWithNodes(nodes)
+	m.cursor = 5 // stale: beyond slice bounds
+	got := m.SelectedPane()
+	if got == nil {
+		t.Fatal("expected non-nil pane when cursor is stale but pane header exists")
+	}
+	if got.PaneIndex != 1 {
+		t.Errorf("PaneIndex: got %d, want 1", got.PaneIndex)
+	}
 }

--- a/internal/tui/proclist_render.go
+++ b/internal/tui/proclist_render.go
@@ -1,482 +1,482 @@
 package tui
 
 import (
-    "fmt"
-    "strings"
-    "time"
+	"fmt"
+	"strings"
+	"time"
 
-    "github.com/charmbracelet/lipgloss"
-    "github.com/rtalexk/demux/internal/format"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/query"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rtalexk/demux/internal/format"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/query"
 )
 
 func (p ProcListModel) Render(width, height int, focused bool, title string) string {
-    border := procBorderInactive
-    if focused {
-        border = procBorderActive
-    }
-    innerW := width - 2
+	border := procBorderInactive
+	if focused {
+		border = procBorderActive
+	}
+	innerW := width - 2
 
-    // Right border title: show the primary CWD (session or window path).
-    rightTitle := ""
-    if p.primaryCWD != "" {
-        rightTitle = " " + format.ShortenPath(p.primaryCWD, p.cfg.PathAliases) + " "
-    }
+	// Right border title: show the primary CWD (session or window path).
+	rightTitle := ""
+	if p.primaryCWD != "" {
+		rightTitle = " " + format.ShortenPath(p.primaryCWD, p.cfg.PathAliases) + " "
+	}
 
-    if p.sessionAlert != nil {
-        title += paneSepStyle.Render("──") + " " + alertIcon(p.sessionAlert.Level) + " " + alertBadge(p.sessionAlert.Level, p.sessionAlert.Reason)
-    }
+	if p.sessionAlert != nil {
+		title += paneSepStyle.Render("──") + " " + alertIcon(p.sessionAlert.Level) + " " + alertBadge(p.sessionAlert.Level, p.sessionAlert.Reason)
+	}
 
-    if len(p.nodes) == 0 {
-        hint := "Select a window with Enter"
-        inner := noSelectionStyle.Render(hint)
-        return injectBorderTitles(border.Width(width-2).Height(height-2).Render(inner), title, rightTitle)
-    }
+	if len(p.nodes) == 0 {
+		hint := "Select a window with Enter"
+		inner := noSelectionStyle.Render(hint)
+		return injectBorderTitles(border.Width(width-2).Height(height-2).Render(inner), title, rightTitle)
+	}
 
-    // build the full rendered line list, tracking node index
-    type renderedLine struct {
-        nodeIdx int
-        text    string
-    }
+	// build the full rendered line list, tracking node index
+	type renderedLine struct {
+		nodeIdx int
+		text    string
+	}
 
-    searchActive := p.searchQuery.Term != "" &&
-        p.searchQuery.Scope != query.ScopeSession &&
-        len(p.queryResult.Sessions) > 0
-    dimStyle := lipgloss.NewStyle().Foreground(activeTheme.ColorFgDim)
+	searchActive := p.searchQuery.Term != "" &&
+		p.searchQuery.Scope != query.ScopeSession &&
+		len(p.queryResult.Sessions) > 0
+	dimStyle := lipgloss.NewStyle().Foreground(activeTheme.ColorFgDim)
 
-    // Pre-compute which panes and windows have at least one matching process so
-    // that ancestor header rows are not dimmed when a descendant matches.
-    paneHasMatch := map[string]bool{}
-    windowHasMatch := map[int]bool{}
-    if searchActive {
-        for _, node := range p.nodes {
-            if node.IsPaneHeader || node.IsWindowHeader || node.IsIdle {
-                continue
-            }
-            if p.procMatchPos(p.curSession, node.Proc.PID) != nil {
-                paneHasMatch[node.Pane.PaneID] = true
-                windowHasMatch[node.Pane.WindowIndex] = true
-            }
-        }
-    }
+	// Pre-compute which panes and windows have at least one matching process so
+	// that ancestor header rows are not dimmed when a descendant matches.
+	paneHasMatch := map[string]bool{}
+	windowHasMatch := map[int]bool{}
+	if searchActive {
+		for _, node := range p.nodes {
+			if node.IsPaneHeader || node.IsWindowHeader || node.IsIdle {
+				continue
+			}
+			if p.procMatchPos(p.curSession, node.Proc.PID) != nil {
+				paneHasMatch[node.Pane.PaneID] = true
+				windowHasMatch[node.Pane.WindowIndex] = true
+			}
+		}
+	}
 
-    var allLines []renderedLine
-    for i, node := range p.nodes {
-        selected := focused && i == p.cursor
-        var line string
-        if node.IsWindowHeader {
-            line = p.renderWindowHeader(node, selected, innerW)
-            if searchActive && !selected {
-                pos := p.windowMatchPos(p.curSession, node.Pane.WindowIndex)
-                if pos != nil {
-                    highlighted := highlightMatchPos(node.Pane.WindowName, pos)
-                    line = strings.Replace(line, node.Pane.WindowName, highlighted, 1)
-                } else if !windowHasMatch[node.Pane.WindowIndex] {
-                    line = dimStyle.Render(stripANSI(line))
-                }
-            }
-        } else if node.IsPaneHeader {
-            paneInnerW := innerW
-            if p.inSessionMode {
-                paneInnerW -= 4
-                if paneInnerW < 0 {
-                    paneInnerW = 0
-                }
-            }
-            hasIdle := i+1 < len(p.nodes) && p.nodes[i+1].IsIdle
-            rendered := p.renderPaneHeader(node, selected, paneInnerW, hasIdle)
-            if hasIdle && !selected {
-                rendered += "  " + paneIdleStyle.Render("idle")
-            }
-            if p.inSessionMode {
-                rendered = "    " + rendered
-            }
-            line = rendered
-            if searchActive && !selected && !paneHasMatch[node.Pane.PaneID] {
-                line = dimStyle.Render(stripANSI(line))
-            }
-        } else if node.IsIdle {
-            continue
-        } else {
-            procInnerW := innerW
-            if p.inSessionMode {
-                procInnerW = innerW - 4
-                if procInnerW < 0 {
-                    procInnerW = 0
-                }
-            }
-            rendered := p.renderProc(node, selected, procInnerW)
-            if p.inSessionMode {
-                parts := strings.SplitN(rendered, "\n", 2)
-                if len(parts) == 2 {
-                    rendered = "    " + parts[0] + "\n" + "    " + parts[1]
-                } else {
-                    rendered = "    " + rendered
-                }
-            }
-            line = rendered
-            if searchActive && !selected {
-                pos := p.procMatchPos(p.curSession, node.Proc.PID)
-                if pos != nil {
-                    highlighted := highlightMatchPos(node.Proc.FriendlyName(), pos)
-                    line = strings.Replace(line, node.Proc.FriendlyName(), highlighted, 1)
-                } else {
-                    line = dimStyle.Render(stripANSI(line))
-                }
-            }
-        }
-        allLines = append(allLines, renderedLine{nodeIdx: i, text: line})
-    }
+	var allLines []renderedLine
+	for i, node := range p.nodes {
+		selected := focused && i == p.cursor
+		var line string
+		if node.IsWindowHeader {
+			line = p.renderWindowHeader(node, selected, innerW)
+			if searchActive && !selected {
+				pos := p.windowMatchPos(p.curSession, node.Pane.WindowIndex)
+				if pos != nil {
+					highlighted := highlightMatchPos(node.Pane.WindowName, pos)
+					line = strings.Replace(line, node.Pane.WindowName, highlighted, 1)
+				} else if !windowHasMatch[node.Pane.WindowIndex] {
+					line = dimStyle.Render(stripANSI(line))
+				}
+			}
+		} else if node.IsPaneHeader {
+			paneInnerW := innerW
+			if p.inSessionMode {
+				paneInnerW -= 4
+				if paneInnerW < 0 {
+					paneInnerW = 0
+				}
+			}
+			hasIdle := i+1 < len(p.nodes) && p.nodes[i+1].IsIdle
+			rendered := p.renderPaneHeader(node, selected, paneInnerW, hasIdle)
+			if hasIdle && !selected {
+				rendered += "  " + paneIdleStyle.Render("idle")
+			}
+			if p.inSessionMode {
+				rendered = "    " + rendered
+			}
+			line = rendered
+			if searchActive && !selected && !paneHasMatch[node.Pane.PaneID] {
+				line = dimStyle.Render(stripANSI(line))
+			}
+		} else if node.IsIdle {
+			continue
+		} else {
+			procInnerW := innerW
+			if p.inSessionMode {
+				procInnerW = innerW - 4
+				if procInnerW < 0 {
+					procInnerW = 0
+				}
+			}
+			rendered := p.renderProc(node, selected, procInnerW)
+			if p.inSessionMode {
+				parts := strings.SplitN(rendered, "\n", 2)
+				if len(parts) == 2 {
+					rendered = "    " + parts[0] + "\n" + "    " + parts[1]
+				} else {
+					rendered = "    " + rendered
+				}
+			}
+			line = rendered
+			if searchActive && !selected {
+				pos := p.procMatchPos(p.curSession, node.Proc.PID)
+				if pos != nil {
+					highlighted := highlightMatchPos(node.Proc.FriendlyName(), pos)
+					line = strings.Replace(line, node.Proc.FriendlyName(), highlighted, 1)
+				} else {
+					line = dimStyle.Render(stripANSI(line))
+				}
+			}
+		}
+		allLines = append(allLines, renderedLine{nodeIdx: i, text: line})
+	}
 
-    maxRows := height - 2
-    if maxRows < 1 {
-        maxRows = 1
-    }
+	maxRows := height - 2
+	if maxRows < 1 {
+		maxRows = 1
+	}
 
-    // Safety clamps (read-only): handle cases where the viewport shrank since
-    // the last clampOffset call (e.g. detail pane expanding after selection change).
-    offset := p.offset
-    if p.cursor < offset {
-        offset = p.cursor
-    }
-    for offset < p.cursor && !procCursorVisible(p.nodes, p.cursor, offset, maxRows) {
-        offset++
-    }
+	// Safety clamps (read-only): handle cases where the viewport shrank since
+	// the last clampOffset call (e.g. detail pane expanding after selection change).
+	offset := p.offset
+	if p.cursor < offset {
+		offset = p.cursor
+	}
+	for offset < p.cursor && !procCursorVisible(p.nodes, p.cursor, offset, maxRows) {
+		offset++
+	}
 
-    // determine scroll hints based on node-level offset
-    hasAbove := offset > 0
-    hasBelow := false // determined after we know how many fit
-    contentRows := maxRows
-    if hasAbove {
-        contentRows--
-    }
-    // tentatively check hasBelow: collect rows from offset
-    rowCount := 0
-    var visible []string
-    startIdx := 0
-    for i, rl := range allLines {
-        if rl.nodeIdx < offset {
-            continue
-        }
-        if startIdx == 0 {
-            startIdx = i
-        }
-        entryRows := strings.Count(rl.text, "\n") + 1
-        if rowCount+entryRows > contentRows {
-            hasBelow = true
-            break
-        }
-        visible = append(visible, rl.text)
-        rowCount += entryRows
-    }
-    // if hasBelow discovered, shrink contentRows by 1 and rebuild visible
-    if hasBelow {
-        contentRows = maxRows
-        if hasAbove {
-            contentRows--
-        }
-        contentRows-- // for ▼ hint
-        rowCount = 0
-        visible = visible[:0]
-        for _, rl := range allLines {
-            if rl.nodeIdx < offset {
-                continue
-            }
-            entryRows := strings.Count(rl.text, "\n") + 1
-            if rowCount+entryRows > contentRows {
-                break
-            }
-            visible = append(visible, rl.text)
-            rowCount += entryRows
-        }
-    }
+	// determine scroll hints based on node-level offset
+	hasAbove := offset > 0
+	hasBelow := false // determined after we know how many fit
+	contentRows := maxRows
+	if hasAbove {
+		contentRows--
+	}
+	// tentatively check hasBelow: collect rows from offset
+	rowCount := 0
+	var visible []string
+	startIdx := 0
+	for i, rl := range allLines {
+		if rl.nodeIdx < offset {
+			continue
+		}
+		if startIdx == 0 {
+			startIdx = i
+		}
+		entryRows := strings.Count(rl.text, "\n") + 1
+		if rowCount+entryRows > contentRows {
+			hasBelow = true
+			break
+		}
+		visible = append(visible, rl.text)
+		rowCount += entryRows
+	}
+	// if hasBelow discovered, shrink contentRows by 1 and rebuild visible
+	if hasBelow {
+		contentRows = maxRows
+		if hasAbove {
+			contentRows--
+		}
+		contentRows-- // for ▼ hint
+		rowCount = 0
+		visible = visible[:0]
+		for _, rl := range allLines {
+			if rl.nodeIdx < offset {
+				continue
+			}
+			entryRows := strings.Count(rl.text, "\n") + 1
+			if rowCount+entryRows > contentRows {
+				break
+			}
+			visible = append(visible, rl.text)
+			rowCount += entryRows
+		}
+	}
 
-    var resultLines []string
-    if hasAbove {
-        resultLines = append(resultLines, hintStyle.Render("▲ more"))
-    }
-    resultLines = append(resultLines, visible...)
-    if hasBelow {
-        resultLines = append(resultLines, hintStyle.Render("▼ more"))
-    }
+	var resultLines []string
+	if hasAbove {
+		resultLines = append(resultLines, hintStyle.Render("▲ more"))
+	}
+	resultLines = append(resultLines, visible...)
+	if hasBelow {
+		resultLines = append(resultLines, hintStyle.Render("▼ more"))
+	}
 
-    inner := strings.Join(resultLines, "\n")
-    return injectBorderTitles(border.Width(width-2).Height(height-2).Render(inner), title, rightTitle)
+	inner := strings.Join(resultLines, "\n")
+	return injectBorderTitles(border.Width(width-2).Height(height-2).Render(inner), title, rightTitle)
 }
 
 func (p ProcListModel) renderPaneHeader(node ProcListNode, selected bool, innerW int, hasIdle bool) string {
-    label := fmt.Sprintf("pane %d", node.Pane.PaneIndex)
+	label := fmt.Sprintf("pane %d", node.Pane.PaneIndex)
 
-    alertSuffix := ""
-    if node.Alert != nil {
-        alertSuffix = "  " + paneSepStyle.Render("────") + "  " + alertIcon(node.Alert.Level) + " " + alertBadge(node.Alert.Level, node.Alert.Reason)
-    }
+	alertSuffix := ""
+	if node.Alert != nil {
+		alertSuffix = "  " + paneSepStyle.Render("────") + "  " + alertIcon(node.Alert.Level) + " " + alertBadge(node.Alert.Level, node.Alert.Reason)
+	}
 
-    pathStr := ""
-    if node.Pane.CWD != "" && node.Pane.CWD != p.primaryCWD {
-        pathStr = format.ShortenPath(node.Pane.CWD, p.cfg.PathAliases)
-    }
-    gitSuffix := ""
-    if node.GitDeviant {
-        if node.GitInfo.Loading {
-            gitSuffix = "  ↪ …"
-        } else {
-            gitSuffix = "  ↪ " + stripANSI(compactGitIndicators(node.GitInfo))
-        }
-    }
+	pathStr := ""
+	if node.Pane.CWD != "" && node.Pane.CWD != p.primaryCWD {
+		pathStr = format.ShortenPath(node.Pane.CWD, p.cfg.PathAliases)
+	}
+	gitSuffix := ""
+	if node.GitDeviant {
+		if node.GitInfo.Loading {
+			gitSuffix = "  ↪ …"
+		} else {
+			gitSuffix = "  ↪ " + stripANSI(compactGitIndicators(node.GitInfo))
+		}
+	}
 
-    if selected {
-        left := label + stripANSI(alertSuffix)
-        rightPart := pathStr + gitSuffix
-        if rightPart != "" && p.cfg.ProcessList.PathRightAlign && innerW > 0 {
-            rightW := len([]rune(rightPart))
-            padCount := innerW - len([]rune(left)) - rightW
-            if padCount < 1 {
-                padCount = 1
-            }
-            return selectedBG.Render(left + strings.Repeat(" ", padCount) + rightPart)
-        }
-        if rightPart != "" {
-            content := left + "  " + rightPart
-            padCount := innerW - len([]rune(content))
-            if padCount < 0 {
-                padCount = 0
-            }
-            return selectedBG.Render(content + strings.Repeat(" ", padCount))
-        }
-        if hasIdle {
-            // Render "label  idle" inline, then fill the remaining width with
-            // the selected background so the row doesn't wrap.
-            const idleVisualW = 6 // len("  idle")
-            padCount := innerW - len([]rune(left)) - idleVisualW
-            if padCount < 0 {
-                padCount = 0
-            }
-            idleRendered := paneIdleStyle.Background(activeTheme.ColorSelected).Render("idle")
-            return selectedBG.Render(left) +
-                selectedBG.Render("  ") +
-                idleRendered +
-                selectedBG.Render(strings.Repeat(" ", padCount))
-        }
-        padCount := innerW - len([]rune(left))
-        if padCount < 0 {
-            padCount = 0
-        }
-        return selectedBG.Render(left + strings.Repeat(" ", padCount))
-    }
+	if selected {
+		left := label + stripANSI(alertSuffix)
+		rightPart := pathStr + gitSuffix
+		if rightPart != "" && p.cfg.ProcessList.PathRightAlign && innerW > 0 {
+			rightW := len([]rune(rightPart))
+			padCount := innerW - len([]rune(left)) - rightW
+			if padCount < 1 {
+				padCount = 1
+			}
+			return selectedBG.Render(left + strings.Repeat(" ", padCount) + rightPart)
+		}
+		if rightPart != "" {
+			content := left + "  " + rightPart
+			padCount := innerW - len([]rune(content))
+			if padCount < 0 {
+				padCount = 0
+			}
+			return selectedBG.Render(content + strings.Repeat(" ", padCount))
+		}
+		if hasIdle {
+			// Render "label  idle" inline, then fill the remaining width with
+			// the selected background so the row doesn't wrap.
+			const idleVisualW = 6 // len("  idle")
+			padCount := innerW - len([]rune(left)) - idleVisualW
+			if padCount < 0 {
+				padCount = 0
+			}
+			idleRendered := paneIdleStyle.Background(activeTheme.ColorSelected).Render("idle")
+			return selectedBG.Render(left) +
+				selectedBG.Render("  ") +
+				idleRendered +
+				selectedBG.Render(strings.Repeat(" ", padCount))
+		}
+		padCount := innerW - len([]rune(left))
+		if padCount < 0 {
+			padCount = 0
+		}
+		return selectedBG.Render(left + strings.Repeat(" ", padCount))
+	}
 
-    rightPart := pathStr + gitSuffix
-    if rightPart == "" || !p.cfg.ProcessList.PathRightAlign || innerW <= 0 {
-        out := paneHeaderStyle.Render(label) + alertSuffix
-        if pathStr != "" {
-            out += "  " + panePathStyle.Render(pathStr)
-        }
-        if node.GitDeviant {
-            if node.GitInfo.Loading {
-                out += "  " + panePathStyle.Render("↪ …")
-            } else {
-                out += "  " + panePathStyle.Render("↪") + " " + compactGitIndicators(node.GitInfo)
-            }
-        }
-        return out
-    }
+	rightPart := pathStr + gitSuffix
+	if rightPart == "" || !p.cfg.ProcessList.PathRightAlign || innerW <= 0 {
+		out := paneHeaderStyle.Render(label) + alertSuffix
+		if pathStr != "" {
+			out += "  " + panePathStyle.Render(pathStr)
+		}
+		if node.GitDeviant {
+			if node.GitInfo.Loading {
+				out += "  " + panePathStyle.Render("↪ …")
+			} else {
+				out += "  " + panePathStyle.Render("↪") + " " + compactGitIndicators(node.GitInfo)
+			}
+		}
+		return out
+	}
 
-    labelW := len([]rune(label + stripANSI(alertSuffix)))
-    rightW := len([]rune(rightPart))
-    fillCount := innerW - labelW - 2 - 2 - rightW
-    if fillCount < 1 {
-        fillCount = 1
-    }
-    out := paneHeaderStyle.Render(label) +
-        alertSuffix +
-        "  " +
-        paneSepStyle.Render(strings.Repeat("─", fillCount)) +
-        "  " +
-        panePathStyle.Render(pathStr)
-    if node.GitDeviant {
-        if node.GitInfo.Loading {
-            out += "  " + panePathStyle.Render("↪ …")
-        } else {
-            out += "  " + panePathStyle.Render("↪") + " " + compactGitIndicators(node.GitInfo)
-        }
-    }
-    return out
+	labelW := len([]rune(label + stripANSI(alertSuffix)))
+	rightW := len([]rune(rightPart))
+	fillCount := innerW - labelW - 2 - 2 - rightW
+	if fillCount < 1 {
+		fillCount = 1
+	}
+	out := paneHeaderStyle.Render(label) +
+		alertSuffix +
+		"  " +
+		paneSepStyle.Render(strings.Repeat("─", fillCount)) +
+		"  " +
+		panePathStyle.Render(pathStr)
+	if node.GitDeviant {
+		if node.GitInfo.Loading {
+			out += "  " + panePathStyle.Render("↪ …")
+		} else {
+			out += "  " + panePathStyle.Render("↪") + " " + compactGitIndicators(node.GitInfo)
+		}
+	}
+	return out
 }
 
 func (p ProcListModel) renderWindowHeader(node ProcListNode, selected bool, innerW int) string {
-    label := fmt.Sprintf("Win %d", node.Pane.WindowIndex)
-    if node.Pane.WindowName != "" {
-        label = fmt.Sprintf("Win %d: %s", node.Pane.WindowIndex, node.Pane.WindowName)
-    }
+	label := fmt.Sprintf("Win %d", node.Pane.WindowIndex)
+	if node.Pane.WindowName != "" {
+		label = fmt.Sprintf("Win %d: %s", node.Pane.WindowIndex, node.Pane.WindowName)
+	}
 
-    alertSuffix := ""
-    if node.Alert != nil {
-        alertSuffix = "  " + paneSepStyle.Render("────") + "  " + alertIcon(node.Alert.Level) + " " + alertBadge(node.Alert.Level, node.Alert.Reason)
-    }
+	alertSuffix := ""
+	if node.Alert != nil {
+		alertSuffix = "  " + paneSepStyle.Render("────") + "  " + alertIcon(node.Alert.Level) + " " + alertBadge(node.Alert.Level, node.Alert.Reason)
+	}
 
-    pathStr := ""
-    if node.Pane.CWD != "" && node.Pane.CWD != p.primaryCWD {
-        pathStr = format.ShortenPath(node.Pane.CWD, p.cfg.PathAliases)
-    }
+	pathStr := ""
+	if node.Pane.CWD != "" && node.Pane.CWD != p.primaryCWD {
+		pathStr = format.ShortenPath(node.Pane.CWD, p.cfg.PathAliases)
+	}
 
-    if selected {
-        left := label + stripANSI(alertSuffix)
-        if pathStr != "" && innerW > 0 {
-            rightW := len([]rune(pathStr))
-            padCount := innerW - len([]rune(left)) - rightW
-            if padCount < 1 {
-                padCount = 1
-            }
-            return selectedBG.Render(left + strings.Repeat(" ", padCount) + pathStr)
-        }
-        if pathStr != "" {
-            content := left + "  " + pathStr
-            padCount := innerW - len([]rune(content))
-            if padCount < 0 {
-                padCount = 0
-            }
-            return selectedBG.Render(content + strings.Repeat(" ", padCount))
-        }
-        padCount := innerW - len([]rune(left))
-        if padCount < 0 {
-            padCount = 0
-        }
-        return selectedBG.Render(left + strings.Repeat(" ", padCount))
-    }
+	if selected {
+		left := label + stripANSI(alertSuffix)
+		if pathStr != "" && innerW > 0 {
+			rightW := len([]rune(pathStr))
+			padCount := innerW - len([]rune(left)) - rightW
+			if padCount < 1 {
+				padCount = 1
+			}
+			return selectedBG.Render(left + strings.Repeat(" ", padCount) + pathStr)
+		}
+		if pathStr != "" {
+			content := left + "  " + pathStr
+			padCount := innerW - len([]rune(content))
+			if padCount < 0 {
+				padCount = 0
+			}
+			return selectedBG.Render(content + strings.Repeat(" ", padCount))
+		}
+		padCount := innerW - len([]rune(left))
+		if padCount < 0 {
+			padCount = 0
+		}
+		return selectedBG.Render(left + strings.Repeat(" ", padCount))
+	}
 
-    if pathStr == "" || innerW <= 0 {
-        out := windowHeaderStyle.Render(label) + alertSuffix
-        if pathStr != "" {
-            out += "  " + panePathStyle.Render(pathStr)
-        }
-        return out
-    }
+	if pathStr == "" || innerW <= 0 {
+		out := windowHeaderStyle.Render(label) + alertSuffix
+		if pathStr != "" {
+			out += "  " + panePathStyle.Render(pathStr)
+		}
+		return out
+	}
 
-    labelW := len([]rune(label + stripANSI(alertSuffix)))
-    rightW := len([]rune(pathStr))
-    fillCount := innerW - labelW - 2 - 2 - rightW
-    if fillCount < 1 {
-        fillCount = 1
-    }
-    return windowHeaderStyle.Render(label) +
-        alertSuffix +
-        "  " +
-        paneSepStyle.Render(strings.Repeat("─", fillCount)) +
-        "  " +
-        panePathStyle.Render(pathStr)
+	labelW := len([]rune(label + stripANSI(alertSuffix)))
+	rightW := len([]rune(pathStr))
+	fillCount := innerW - labelW - 2 - 2 - rightW
+	if fillCount < 1 {
+		fillCount = 1
+	}
+	return windowHeaderStyle.Render(label) +
+		alertSuffix +
+		"  " +
+		paneSepStyle.Render(strings.Repeat("─", fillCount)) +
+		"  " +
+		panePathStyle.Render(pathStr)
 }
 
 // procNameStyle returns the appropriate lipgloss style for a process name
 // based on its type and tree depth.
 func procNameStyle(pr proc.Process, depth int) lipgloss.Style {
-    if depth >= 2 {
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorProcChild)
-    }
-    name := strings.ToLower(pr.FriendlyName())
-    switch {
-    case containsStr(activeProcEditors, name):
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorProcEditor)
-    case containsStr(activeProcAgents, name) || strings.HasPrefix(name, "claude-"):
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorProcClaude)
-    case containsStr(activeProcServers, name):
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorProcServer)
-    default:
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorFgPrimary)
-    }
+	if depth >= 2 {
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorProcChild)
+	}
+	name := strings.ToLower(pr.FriendlyName())
+	switch {
+	case containsStr(activeProcEditors, name):
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorProcEditor)
+	case containsStr(activeProcAgents, name) || strings.HasPrefix(name, "claude-"):
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorProcClaude)
+	case containsStr(activeProcServers, name):
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorProcServer)
+	default:
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorFgPrimary)
+	}
 }
 
 func (p ProcListModel) renderProc(node ProcListNode, selected bool, innerW int) string {
-    pr := node.Proc
-    indent := node.TreePrefix
+	pr := node.Proc
+	indent := node.TreePrefix
 
-    // collapse indicator prefix for depth-1 nodes with children
-    collapsePrefix := ""
-    if node.Depth == 1 && node.HasChildren {
-        if node.Collapsed {
-            collapsePrefix = "▶ "
-        } else {
-            collapsePrefix = "▼ "
-        }
-    }
+	// collapse indicator prefix for depth-1 nodes with children
+	collapsePrefix := ""
+	if node.Depth == 1 && node.HasChildren {
+		if node.Collapsed {
+			collapsePrefix = "▶ "
+		} else {
+			collapsePrefix = "▼ "
+		}
+	}
 
-    // line 1: [indicator]name  pid:N  :port
-    var line1 string
-    if selected {
-        plain := indent + collapsePrefix + pr.FriendlyName()
-        if pr.PID > 0 {
-            plain += fmt.Sprintf("  pid:%d", pr.PID)
-        }
-        if node.Port > 0 {
-            plain += fmt.Sprintf("  :%d", node.Port)
-        }
-        padCount := innerW - len([]rune(plain))
-        if padCount < 0 {
-            padCount = 0
-        }
-        line1 = selectedBG.Render(plain + strings.Repeat(" ", padCount))
-    } else {
-        line1 = treeConnectorStyle.Render(indent) + procNameStyle(pr, node.Depth).Render(collapsePrefix+pr.FriendlyName())
-        if pr.PID > 0 {
-            line1 += "  " + statLabelStyle.Render(fmt.Sprintf("pid:%d", pr.PID))
-        }
-        if node.Port > 0 {
-            line1 += "  " + statValueStyle.Render(fmt.Sprintf(":%d", node.Port))
-        }
-    }
+	// line 1: [indicator]name  pid:N  :port
+	var line1 string
+	if selected {
+		plain := indent + collapsePrefix + pr.FriendlyName()
+		if pr.PID > 0 {
+			plain += fmt.Sprintf("  pid:%d", pr.PID)
+		}
+		if node.Port > 0 {
+			plain += fmt.Sprintf("  :%d", node.Port)
+		}
+		padCount := innerW - len([]rune(plain))
+		if padCount < 0 {
+			padCount = 0
+		}
+		line1 = selectedBG.Render(plain + strings.Repeat(" ", padCount))
+	} else {
+		line1 = treeConnectorStyle.Render(indent) + procNameStyle(pr, node.Depth).Render(collapsePrefix+pr.FriendlyName())
+		if pr.PID > 0 {
+			line1 += "  " + statLabelStyle.Render(fmt.Sprintf("pid:%d", pr.PID))
+		}
+		if node.Port > 0 {
+			line1 += "  " + statValueStyle.Render(fmt.Sprintf(":%d", node.Port))
+		}
+	}
 
-    // line 2: cpu/mem stats; show aggregated totals in parens when collapsed with children
-    statsIndent := treeConnectorStyle.Render(node.StatPrefix) + "  "
-    l := statLabelStyle.Render
-    v := statValueStyle.Render
+	// line 2: cpu/mem stats; show aggregated totals in parens when collapsed with children
+	statsIndent := treeConnectorStyle.Render(node.StatPrefix) + "  "
+	l := statLabelStyle.Render
+	v := statValueStyle.Render
 
-    cpuStr := v(fmt.Sprintf("%.1f%%", pr.CPU))
-    memStr := v(fmt.Sprintf("%.1fMB", float64(pr.MemRSS)/1024/1024))
-    if node.Depth == 1 && node.HasChildren && node.Collapsed {
-        cpuStr += v(fmt.Sprintf(" (%.1f%%)", node.AggCPU))
-        memStr += v(fmt.Sprintf(" (%.1fMB)", float64(node.AggMemRSS)/1024/1024))
-    }
+	cpuStr := v(fmt.Sprintf("%.1f%%", pr.CPU))
+	memStr := v(fmt.Sprintf("%.1fMB", float64(pr.MemRSS)/1024/1024))
+	if node.Depth == 1 && node.HasChildren && node.Collapsed {
+		cpuStr += v(fmt.Sprintf(" (%.1f%%)", node.AggCPU))
+		memStr += v(fmt.Sprintf(" (%.1fMB)", float64(node.AggMemRSS)/1024/1024))
+	}
 
-    line2 := statsIndent +
-        l("cpu:") + cpuStr + "  " +
-        l("mem:") + memStr + "  " +
-        l("up:") + v(formatProcDuration(pr.Uptime))
+	line2 := statsIndent +
+		l("cpu:") + cpuStr + "  " +
+		l("mem:") + memStr + "  " +
+		l("up:") + v(formatProcDuration(pr.Uptime))
 
-    return line1 + "\n" + line2
+	return line1 + "\n" + line2
 }
 
 func formatProcDuration(d time.Duration) string {
-    h := int(d.Hours())
-    m := int(d.Minutes()) % 60
-    s := int(d.Seconds()) % 60
-    switch {
-    case h >= 24:
-        return fmt.Sprintf("%dd%dh", h/24, h%24)
-    case h > 0:
-        return fmt.Sprintf("%dh%dm", h, m)
-    case m > 0:
-        return fmt.Sprintf("%dm", m)
-    default:
-        return fmt.Sprintf("%ds", s)
-    }
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	switch {
+	case h >= 24:
+		return fmt.Sprintf("%dd%dh", h/24, h%24)
+	case h > 0:
+		return fmt.Sprintf("%dh%dm", h, m)
+	case m > 0:
+		return fmt.Sprintf("%dm", m)
+	default:
+		return fmt.Sprintf("%ds", s)
+	}
 }
 
 func stripANSI(s string) string {
-    var result strings.Builder
-    i := 0
-    for i < len(s) {
-        if s[i] == '\033' && i+1 < len(s) && s[i+1] == '[' {
-            i += 2
-            for i < len(s) && s[i] != 'm' {
-                i++
-            }
-            i++ // skip 'm'
-            continue
-        }
-        result.WriteByte(s[i])
-        i++
-    }
-    return result.String()
+	var result strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == '\033' && i+1 < len(s) && s[i+1] == '[' {
+			i += 2
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			i++ // skip 'm'
+			continue
+		}
+		result.WriteByte(s[i])
+		i++
+	}
+	return result.String()
 }
 
 // injectBorderTitle splices title into the top border line of a lipgloss-rendered
@@ -484,208 +484,208 @@ func stripANSI(s string) string {
 // remaining width filled by the border's horizontal fill character.
 // ANSI color codes wrapping the original top line are preserved.
 func injectBorderTitle(rendered, title string) string {
-    if title == "" {
-        return rendered
-    }
-    nl := strings.IndexByte(rendered, '\n')
-    if nl < 0 {
-        return rendered
-    }
-    topLine := rendered[:nl]
-    rest := rendered[nl:] // includes the leading \n
+	if title == "" {
+		return rendered
+	}
+	nl := strings.IndexByte(rendered, '\n')
+	if nl < 0 {
+		return rendered
+	}
+	topLine := rendered[:nl]
+	rest := rendered[nl:] // includes the leading \n
 
-    plain := stripANSI(topLine)
-    runes := []rune(plain)
-    if len(runes) < 4 {
-        return rendered
-    }
+	plain := stripANSI(topLine)
+	runes := []rune(plain)
+	if len(runes) < 4 {
+		return rendered
+	}
 
-    // runes[0]=╭, runes[1..len-2]=─ fill, runes[len-1]=╮
-    cornerLeft := string(runes[0])
-    cornerRight := string(runes[len(runes)-1])
-    fill := string(runes[1])
-    totalInner := len(runes) - 2
+	// runes[0]=╭, runes[1..len-2]=─ fill, runes[len-1]=╮
+	cornerLeft := string(runes[0])
+	cornerRight := string(runes[len(runes)-1])
+	fill := string(runes[1])
+	totalInner := len(runes) - 2
 
-    titleRunes := []rune(title)
-    titleVisible := []rune(stripANSI(title))
-    if len(titleVisible) > totalInner-1 {
-        titleRunes = titleRunes[:totalInner-1]
-        titleVisible = titleVisible[:totalInner-1]
-    }
-    fillCount := totalInner - len(titleVisible)
+	titleRunes := []rune(title)
+	titleVisible := []rune(stripANSI(title))
+	if len(titleVisible) > totalInner-1 {
+		titleRunes = titleRunes[:totalInner-1]
+		titleVisible = titleVisible[:totalInner-1]
+	}
+	fillCount := totalInner - len(titleVisible)
 
-    // Extract ANSI prefix (border color) and suffix (reset) from the original top line.
-    cornerLeftIdx := strings.Index(topLine, cornerLeft)
-    cornerRightIdx := strings.LastIndex(topLine, cornerRight)
-    ansiPrefix := ""
-    ansiSuffix := ""
-    if cornerLeftIdx > 0 {
-        ansiPrefix = topLine[:cornerLeftIdx]
-    }
-    if cornerRightIdx >= 0 {
-        after := cornerRightIdx + len(cornerRight)
-        if after <= len(topLine) {
-            ansiSuffix = topLine[after:]
-        }
-    }
+	// Extract ANSI prefix (border color) and suffix (reset) from the original top line.
+	cornerLeftIdx := strings.Index(topLine, cornerLeft)
+	cornerRightIdx := strings.LastIndex(topLine, cornerRight)
+	ansiPrefix := ""
+	ansiSuffix := ""
+	if cornerLeftIdx > 0 {
+		ansiPrefix = topLine[:cornerLeftIdx]
+	}
+	if cornerRightIdx >= 0 {
+		after := cornerRightIdx + len(cornerRight)
+		if after <= len(topLine) {
+			ansiSuffix = topLine[after:]
+		}
+	}
 
-    // Color the border chars but not the title text, so the title uses the
-    // terminal's default foreground rather than the border color.
-    newTop := ansiPrefix + cornerLeft + ansiSuffix +
-        title +
-        ansiPrefix + strings.Repeat(fill, fillCount) + cornerRight + ansiSuffix
+	// Color the border chars but not the title text, so the title uses the
+	// terminal's default foreground rather than the border color.
+	newTop := ansiPrefix + cornerLeft + ansiSuffix +
+		title +
+		ansiPrefix + strings.Repeat(fill, fillCount) + cornerRight + ansiSuffix
 
-    return newTop + rest
+	return newTop + rest
 }
 
 // injectBorderTitles is like injectBorderTitle but also places rightTitle
 // flush against the right corner of the top border line.
 func injectBorderTitles(rendered, leftTitle, rightTitle string) string {
-    if rightTitle == "" {
-        return injectBorderTitle(rendered, leftTitle)
-    }
-    nl := strings.IndexByte(rendered, '\n')
-    if nl < 0 {
-        return rendered
-    }
-    topLine := rendered[:nl]
-    rest := rendered[nl:]
+	if rightTitle == "" {
+		return injectBorderTitle(rendered, leftTitle)
+	}
+	nl := strings.IndexByte(rendered, '\n')
+	if nl < 0 {
+		return rendered
+	}
+	topLine := rendered[:nl]
+	rest := rendered[nl:]
 
-    plain := stripANSI(topLine)
-    runes := []rune(plain)
-    if len(runes) < 4 {
-        return rendered
-    }
+	plain := stripANSI(topLine)
+	runes := []rune(plain)
+	if len(runes) < 4 {
+		return rendered
+	}
 
-    cornerLeft := string(runes[0])
-    cornerRight := string(runes[len(runes)-1])
-    fill := string(runes[1])
-    totalInner := len(runes) - 2
+	cornerLeft := string(runes[0])
+	cornerRight := string(runes[len(runes)-1])
+	fill := string(runes[1])
+	totalInner := len(runes) - 2
 
-    leftVisible := []rune(stripANSI(leftTitle))
-    rightVisible := []rune(stripANSI(rightTitle))
-    totalUsed := len(leftVisible) + len(rightVisible)
-    if totalUsed >= totalInner {
-        return injectBorderTitle(rendered, leftTitle)
-    }
-    fillCount := totalInner - totalUsed
+	leftVisible := []rune(stripANSI(leftTitle))
+	rightVisible := []rune(stripANSI(rightTitle))
+	totalUsed := len(leftVisible) + len(rightVisible)
+	if totalUsed >= totalInner {
+		return injectBorderTitle(rendered, leftTitle)
+	}
+	fillCount := totalInner - totalUsed
 
-    cornerLeftIdx := strings.Index(topLine, cornerLeft)
-    cornerRightIdx := strings.LastIndex(topLine, cornerRight)
-    ansiPrefix := ""
-    ansiSuffix := ""
-    if cornerLeftIdx > 0 {
-        ansiPrefix = topLine[:cornerLeftIdx]
-    }
-    if cornerRightIdx >= 0 {
-        after := cornerRightIdx + len(cornerRight)
-        if after <= len(topLine) {
-            ansiSuffix = topLine[after:]
-        }
-    }
+	cornerLeftIdx := strings.Index(topLine, cornerLeft)
+	cornerRightIdx := strings.LastIndex(topLine, cornerRight)
+	ansiPrefix := ""
+	ansiSuffix := ""
+	if cornerLeftIdx > 0 {
+		ansiPrefix = topLine[:cornerLeftIdx]
+	}
+	if cornerRightIdx >= 0 {
+		after := cornerRightIdx + len(cornerRight)
+		if after <= len(topLine) {
+			ansiSuffix = topLine[after:]
+		}
+	}
 
-    newTop := ansiPrefix + cornerLeft + ansiSuffix +
-        leftTitle +
-        ansiPrefix + strings.Repeat(fill, fillCount) + ansiSuffix +
-        rightTitle +
-        ansiPrefix + cornerRight + ansiSuffix
+	newTop := ansiPrefix + cornerLeft + ansiSuffix +
+		leftTitle +
+		ansiPrefix + strings.Repeat(fill, fillCount) + ansiSuffix +
+		rightTitle +
+		ansiPrefix + cornerRight + ansiSuffix
 
-    return newTop + rest
+	return newTop + rest
 }
 
 // highlightMatchPos returns the name with matched character positions rendered
 // in the accent color. If pos is empty the name is returned unchanged.
 func highlightMatchPos(name string, pos []int) string {
-    if len(pos) == 0 {
-        return name
-    }
-    posSet := make(map[int]bool, len(pos))
-    for _, p := range pos {
-        posSet[p] = true
-    }
-    accentStyle := lipgloss.NewStyle().Foreground(activeTheme.ColorFgSearchHighlight)
-    var b strings.Builder
-    for i, ch := range name {
-        if posSet[i] {
-            b.WriteString(accentStyle.Render(string(ch)))
-        } else {
-            b.WriteRune(ch)
-        }
-    }
-    return b.String()
+	if len(pos) == 0 {
+		return name
+	}
+	posSet := make(map[int]bool, len(pos))
+	for _, p := range pos {
+		posSet[p] = true
+	}
+	accentStyle := lipgloss.NewStyle().Foreground(activeTheme.ColorFgSearchHighlight)
+	var b strings.Builder
+	for i, ch := range name {
+		if posSet[i] {
+			b.WriteString(accentStyle.Render(string(ch)))
+		} else {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
 }
 
 // injectBottomBorderLabel splices label into the bottom border line of a
 // lipgloss-rendered box, centered. ANSI color codes are preserved.
 func injectBottomBorderLabel(rendered, label string) string {
-    if label == "" {
-        return rendered
-    }
-    // Determine the bottom border line.
-    // Lipgloss may or may not append a trailing newline; handle both.
-    var bottomLine, prefix, trailing string
-    lastNL := strings.LastIndexByte(rendered, '\n')
-    if lastNL < 0 {
-        // No newlines at all: entire string is the bottom border.
-        bottomLine = rendered
-        prefix = ""
-        trailing = ""
-    } else if lastNL == len(rendered)-1 {
-        // String ends with \n: bottom border is between prevNL and lastNL.
-        prevNL := strings.LastIndexByte(rendered[:lastNL], '\n')
-        trailing = rendered[lastNL:] // the trailing \n
-        if prevNL < 0 {
-            prefix = ""
-            bottomLine = rendered[:lastNL]
-        } else {
-            prefix = rendered[:prevNL+1]
-            bottomLine = rendered[prevNL+1 : lastNL]
-        }
-    } else {
-        // String does NOT end with \n: bottom border is rendered[lastNL+1:].
-        prefix = rendered[:lastNL+1]
-        bottomLine = rendered[lastNL+1:]
-        trailing = ""
-    }
+	if label == "" {
+		return rendered
+	}
+	// Determine the bottom border line.
+	// Lipgloss may or may not append a trailing newline; handle both.
+	var bottomLine, prefix, trailing string
+	lastNL := strings.LastIndexByte(rendered, '\n')
+	if lastNL < 0 {
+		// No newlines at all: entire string is the bottom border.
+		bottomLine = rendered
+		prefix = ""
+		trailing = ""
+	} else if lastNL == len(rendered)-1 {
+		// String ends with \n: bottom border is between prevNL and lastNL.
+		prevNL := strings.LastIndexByte(rendered[:lastNL], '\n')
+		trailing = rendered[lastNL:] // the trailing \n
+		if prevNL < 0 {
+			prefix = ""
+			bottomLine = rendered[:lastNL]
+		} else {
+			prefix = rendered[:prevNL+1]
+			bottomLine = rendered[prevNL+1 : lastNL]
+		}
+	} else {
+		// String does NOT end with \n: bottom border is rendered[lastNL+1:].
+		prefix = rendered[:lastNL+1]
+		bottomLine = rendered[lastNL+1:]
+		trailing = ""
+	}
 
-    plain := stripANSI(bottomLine)
-    runes := []rune(plain)
-    if len(runes) < 4 {
-        return rendered
-    }
+	plain := stripANSI(bottomLine)
+	runes := []rune(plain)
+	if len(runes) < 4 {
+		return rendered
+	}
 
-    totalInner := len(runes) - 2
-    labelVisible := []rune(stripANSI(label))
-    if len(labelVisible) > totalInner {
-        return rendered
-    }
+	totalInner := len(runes) - 2
+	labelVisible := []rune(stripANSI(label))
+	if len(labelVisible) > totalInner {
+		return rendered
+	}
 
-    fill := string(runes[1])
-    cornerLeft := string(runes[0])
-    cornerRight := string(runes[len(runes)-1])
+	fill := string(runes[1])
+	cornerLeft := string(runes[0])
+	cornerRight := string(runes[len(runes)-1])
 
-    leftPad := (totalInner - len(labelVisible)) / 2
-    rightPad := totalInner - len(labelVisible) - leftPad
+	leftPad := (totalInner - len(labelVisible)) / 2
+	rightPad := totalInner - len(labelVisible) - leftPad
 
-    // Preserve ANSI prefix/suffix from original bottom line.
-    cornerLeftIdx := strings.Index(bottomLine, cornerLeft)
-    cornerRightIdx := strings.LastIndex(bottomLine, cornerRight)
-    ansiPrefix, ansiSuffix := "", ""
-    if cornerLeftIdx > 0 {
-        ansiPrefix = bottomLine[:cornerLeftIdx]
-    }
-    if cornerRightIdx >= 0 {
-        after := cornerRightIdx + len(cornerRight)
-        if after <= len(bottomLine) {
-            ansiSuffix = bottomLine[after:]
-        }
-    }
+	// Preserve ANSI prefix/suffix from original bottom line.
+	cornerLeftIdx := strings.Index(bottomLine, cornerLeft)
+	cornerRightIdx := strings.LastIndex(bottomLine, cornerRight)
+	ansiPrefix, ansiSuffix := "", ""
+	if cornerLeftIdx > 0 {
+		ansiPrefix = bottomLine[:cornerLeftIdx]
+	}
+	if cornerRightIdx >= 0 {
+		after := cornerRightIdx + len(cornerRight)
+		if after <= len(bottomLine) {
+			ansiSuffix = bottomLine[after:]
+		}
+	}
 
-    newBottom := ansiPrefix + cornerLeft + ansiSuffix +
-        strings.Repeat(fill, leftPad) +
-        label +
-        strings.Repeat(fill, rightPad) +
-        ansiPrefix + cornerRight + ansiSuffix
+	newBottom := ansiPrefix + cornerLeft + ansiSuffix +
+		strings.Repeat(fill, leftPad) +
+		label +
+		strings.Repeat(fill, rightPad) +
+		ansiPrefix + cornerRight + ansiSuffix
 
-    return prefix + newBottom + trailing
+	return prefix + newBottom + trailing
 }

--- a/internal/tui/proclist_test.go
+++ b/internal/tui/proclist_test.go
@@ -1,372 +1,372 @@
 package tui
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/git"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 // buildNodes constructs a ProcListNode slice for use in tests.
 // Layout: two panes, each with one depth-1 process and one depth-2 subprocess.
 //
-//    [0] pane header  (depth 0)
-//    [1] proc A       (depth 1)
-//    [2] proc A.child (depth 2)
-//    [3] pane header  (depth 0)
-//    [4] proc B       (depth 1)
-//    [5] proc B.child (depth 2)
+//	[0] pane header  (depth 0)
+//	[1] proc A       (depth 1)
+//	[2] proc A.child (depth 2)
+//	[3] pane header  (depth 0)
+//	[4] proc B       (depth 1)
+//	[5] proc B.child (depth 2)
 func buildNodes() []ProcListNode {
-    return []ProcListNode{
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}, Depth: 0},
-        {Proc: proc.Process{PID: 1, Name: "procA"}, Depth: 1},
-        {Proc: proc.Process{PID: 2, Name: "procA-child"}, Depth: 2},
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}, Depth: 0},
-        {Proc: proc.Process{PID: 3, Name: "procB"}, Depth: 1},
-        {Proc: proc.Process{PID: 4, Name: "procB-child"}, Depth: 2},
-    }
+	return []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}, Depth: 0},
+		{Proc: proc.Process{PID: 1, Name: "procA"}, Depth: 1},
+		{Proc: proc.Process{PID: 2, Name: "procA-child"}, Depth: 2},
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}, Depth: 0},
+		{Proc: proc.Process{PID: 3, Name: "procB"}, Depth: 1},
+		{Proc: proc.Process{PID: 4, Name: "procB-child"}, Depth: 2},
+	}
 }
 
 func modelAt(nodes []ProcListNode, cursor int) ProcListModel {
-    return ProcListModel{nodes: nodes, cursor: cursor}
+	return ProcListModel{nodes: nodes, cursor: cursor}
 }
 
 // ---------- MoveUp tests ----------
 
 func TestMoveUp_MovesLinearlyUp(t *testing.T) {
-    m := modelAt(buildNodes(), 3) // cursor on second pane header
-    m.MoveUp()
-    if m.cursor != 2 {
-        t.Errorf("expected cursor 2, got %d", m.cursor)
-    }
+	m := modelAt(buildNodes(), 3) // cursor on second pane header
+	m.MoveUp()
+	if m.cursor != 2 {
+		t.Errorf("expected cursor 2, got %d", m.cursor)
+	}
 }
 
 func TestMoveUp_AtFirstNode_NoMove(t *testing.T) {
-    m := modelAt(buildNodes(), 0)
-    m.MoveUp()
-    if m.cursor != 0 {
-        t.Errorf("expected cursor to stay at 0, got %d", m.cursor)
-    }
+	m := modelAt(buildNodes(), 0)
+	m.MoveUp()
+	if m.cursor != 0 {
+		t.Errorf("expected cursor to stay at 0, got %d", m.cursor)
+	}
 }
 
 func TestMoveUp_CrossesPaneHeaderLinearly(t *testing.T) {
-    // cursor at procB (index 4) — linear MoveUp goes to pane header at index 3
-    m := modelAt(buildNodes(), 4)
-    m.MoveUp()
-    if m.cursor != 3 {
-        t.Errorf("expected cursor 3, got %d", m.cursor)
-    }
+	// cursor at procB (index 4) — linear MoveUp goes to pane header at index 3
+	m := modelAt(buildNodes(), 4)
+	m.MoveUp()
+	if m.cursor != 3 {
+		t.Errorf("expected cursor 3, got %d", m.cursor)
+	}
 }
 
 func TestMoveUp_CrossesDepthBoundaryLinearly(t *testing.T) {
-    // cursor at procB-child (index 5) — linear MoveUp goes to procB (index 4)
-    m := modelAt(buildNodes(), 5)
-    m.MoveUp()
-    if m.cursor != 4 {
-        t.Errorf("expected cursor 4, got %d", m.cursor)
-    }
+	// cursor at procB-child (index 5) — linear MoveUp goes to procB (index 4)
+	m := modelAt(buildNodes(), 5)
+	m.MoveUp()
+	if m.cursor != 4 {
+		t.Errorf("expected cursor 4, got %d", m.cursor)
+	}
 }
 
 // ---------- MoveDown tests ----------
 
 func TestMoveDown_MovesLinearlyDown(t *testing.T) {
-    m := modelAt(buildNodes(), 0)
-    m.MoveDown()
-    if m.cursor != 1 {
-        t.Errorf("expected cursor 1, got %d", m.cursor)
-    }
+	m := modelAt(buildNodes(), 0)
+	m.MoveDown()
+	if m.cursor != 1 {
+		t.Errorf("expected cursor 1, got %d", m.cursor)
+	}
 }
 
 func TestMoveDown_AtLastNode_NoMove(t *testing.T) {
-    nodes := buildNodes()
-    m := modelAt(nodes, len(nodes)-1)
-    m.MoveDown()
-    if m.cursor != len(nodes)-1 {
-        t.Errorf("expected cursor to stay at %d, got %d", len(nodes)-1, m.cursor)
-    }
+	nodes := buildNodes()
+	m := modelAt(nodes, len(nodes)-1)
+	m.MoveDown()
+	if m.cursor != len(nodes)-1 {
+		t.Errorf("expected cursor to stay at %d, got %d", len(nodes)-1, m.cursor)
+	}
 }
 
 func TestMoveDown_CrossesPaneHeaderLinearly(t *testing.T) {
-    // cursor at procA-child (index 2) — linear MoveDown goes to pane header at index 3
-    m := modelAt(buildNodes(), 2)
-    m.MoveDown()
-    if m.cursor != 3 {
-        t.Errorf("expected cursor 3, got %d", m.cursor)
-    }
+	// cursor at procA-child (index 2) — linear MoveDown goes to pane header at index 3
+	m := modelAt(buildNodes(), 2)
+	m.MoveDown()
+	if m.cursor != 3 {
+		t.Errorf("expected cursor 3, got %d", m.cursor)
+	}
 }
 
 // ---------- TabNext tests ----------
 
 func TestTabNext_Depth0_WrapsAcrossHeaders(t *testing.T) {
-    m := modelAt(buildNodes(), 0)
-    m.TabNext()
-    if m.cursor != 3 {
-        t.Errorf("TabNext from first header: expected 3, got %d", m.cursor)
-    }
-    m.TabNext()
-    if m.cursor != 0 {
-        t.Errorf("TabNext from last header should wrap to 0, got %d", m.cursor)
-    }
+	m := modelAt(buildNodes(), 0)
+	m.TabNext()
+	if m.cursor != 3 {
+		t.Errorf("TabNext from first header: expected 3, got %d", m.cursor)
+	}
+	m.TabNext()
+	if m.cursor != 0 {
+		t.Errorf("TabNext from last header should wrap to 0, got %d", m.cursor)
+	}
 }
 
 func TestTabNext_Depth1_WrapsWithinPane(t *testing.T) {
-    nodes := buildNodes()
-    // Insert a second depth-1 process into pane 0.
-    nodes = append(nodes[:2], append([]ProcListNode{
-        {Proc: proc.Process{PID: 11, Name: "procA2"}, Depth: 1},
-    }, nodes[2:]...)...)
-    // nodes: [0]=pane0, [1]=procA, [2]=procA2, [3]=procA-child, [4]=pane1, ...
-    m := modelAt(nodes, 1)
-    m.TabNext()
-    if m.cursor != 2 {
-        t.Errorf("TabNext depth-1: expected 2, got %d", m.cursor)
-    }
-    m.TabNext()
-    if m.cursor != 1 {
-        t.Errorf("TabNext depth-1 wrap: expected 1, got %d", m.cursor)
-    }
+	nodes := buildNodes()
+	// Insert a second depth-1 process into pane 0.
+	nodes = append(nodes[:2], append([]ProcListNode{
+		{Proc: proc.Process{PID: 11, Name: "procA2"}, Depth: 1},
+	}, nodes[2:]...)...)
+	// nodes: [0]=pane0, [1]=procA, [2]=procA2, [3]=procA-child, [4]=pane1, ...
+	m := modelAt(nodes, 1)
+	m.TabNext()
+	if m.cursor != 2 {
+		t.Errorf("TabNext depth-1: expected 2, got %d", m.cursor)
+	}
+	m.TabNext()
+	if m.cursor != 1 {
+		t.Errorf("TabNext depth-1 wrap: expected 1, got %d", m.cursor)
+	}
 }
 
 func TestTabNext_EmptyNodes_NoOp(t *testing.T) {
-    m := ProcListModel{}
-    m.TabNext() // should not panic
+	m := ProcListModel{}
+	m.TabNext() // should not panic
 }
 
 func TestTabNext_SingleNode_StaysInPlace(t *testing.T) {
-    m := modelAt([]ProcListNode{{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}}, 0)
-    m.TabNext()
-    if m.cursor != 0 {
-        t.Errorf("expected cursor to stay at 0 with single node, got %d", m.cursor)
-    }
+	m := modelAt([]ProcListNode{{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}}, 0)
+	m.TabNext()
+	if m.cursor != 0 {
+		t.Errorf("expected cursor to stay at 0 with single node, got %d", m.cursor)
+	}
 }
 
 // buildIdleNodes creates a node list where pane 0 has an idle placeholder.
 //
-//    [0] pane header  (depth 0)
-//    [1] idle         (depth 1, IsIdle=true)
-//    [2] pane header  (depth 0)
-//    [3] proc B       (depth 1)
+//	[0] pane header  (depth 0)
+//	[1] idle         (depth 1, IsIdle=true)
+//	[2] pane header  (depth 0)
+//	[3] proc B       (depth 1)
 func buildIdleNodes() []ProcListNode {
-    return []ProcListNode{
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}, Depth: 0},
-        {IsIdle: true, Depth: 1},
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}, Depth: 0},
-        {Proc: proc.Process{PID: 3, Name: "procB"}, Depth: 1},
-    }
+	return []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}, Depth: 0},
+		{IsIdle: true, Depth: 1},
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}, Depth: 0},
+		{Proc: proc.Process{PID: 3, Name: "procB"}, Depth: 1},
+	}
 }
 
 // ---------- isSelectable ----------
 
 func TestIsSelectable_FalseForIdleNode(t *testing.T) {
-    if isSelectable(ProcListNode{IsIdle: true}) {
-        t.Error("idle node should not be selectable")
-    }
+	if isSelectable(ProcListNode{IsIdle: true}) {
+		t.Error("idle node should not be selectable")
+	}
 }
 
 func TestIsSelectable_TrueForProcNode(t *testing.T) {
-    if !isSelectable(ProcListNode{Proc: proc.Process{PID: 1}}) {
-        t.Error("process node should be selectable")
-    }
+	if !isSelectable(ProcListNode{Proc: proc.Process{PID: 1}}) {
+		t.Error("process node should be selectable")
+	}
 }
 
 func TestIsSelectable_TrueForPaneHeader(t *testing.T) {
-    if !isSelectable(ProcListNode{IsPaneHeader: true}) {
-        t.Error("pane header should be selectable")
-    }
+	if !isSelectable(ProcListNode{IsPaneHeader: true}) {
+		t.Error("pane header should be selectable")
+	}
 }
 
 // ---------- Idle node skipping in MoveUp/MoveDown ----------
 
 func TestMoveDown_SkipsIdleNode(t *testing.T) {
-    nodes := buildIdleNodes()
-    m := modelAt(nodes, 0) // cursor on first pane header
-    m.MoveDown()
-    // idle at [1] should be skipped; next selectable is pane header at [2]
-    if m.cursor != 2 {
-        t.Errorf("expected cursor=2 (skip idle), got %d", m.cursor)
-    }
+	nodes := buildIdleNodes()
+	m := modelAt(nodes, 0) // cursor on first pane header
+	m.MoveDown()
+	// idle at [1] should be skipped; next selectable is pane header at [2]
+	if m.cursor != 2 {
+		t.Errorf("expected cursor=2 (skip idle), got %d", m.cursor)
+	}
 }
 
 func TestMoveUp_SkipsIdleNode(t *testing.T) {
-    nodes := buildIdleNodes()
-    m := modelAt(nodes, 2) // cursor on second pane header
-    m.MoveUp()
-    // going up from [2]: [1] is idle (skip), [0] is pane header (selectable)
-    if m.cursor != 0 {
-        t.Errorf("expected cursor=0 (skip idle), got %d", m.cursor)
-    }
+	nodes := buildIdleNodes()
+	m := modelAt(nodes, 2) // cursor on second pane header
+	m.MoveUp()
+	// going up from [2]: [1] is idle (skip), [0] is pane header (selectable)
+	if m.cursor != 0 {
+		t.Errorf("expected cursor=0 (skip idle), got %d", m.cursor)
+	}
 }
 
 func TestMoveDown_StopsAtLastSelectableNode(t *testing.T) {
-    // when last node is idle, MoveDown should not move past the last selectable
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-        {Proc: proc.Process{PID: 1, Name: "procA"}, Depth: 1},
-        {IsIdle: true, Depth: 1},
-    }
-    m := modelAt(nodes, 1) // cursor on procA
-    m.MoveDown()
-    // idle at [2] is not selectable — cursor stays at [1]
-    if m.cursor != 1 {
-        t.Errorf("expected cursor=1 (no selectable node below), got %d", m.cursor)
-    }
+	// when last node is idle, MoveDown should not move past the last selectable
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+		{Proc: proc.Process{PID: 1, Name: "procA"}, Depth: 1},
+		{IsIdle: true, Depth: 1},
+	}
+	m := modelAt(nodes, 1) // cursor on procA
+	m.MoveDown()
+	// idle at [2] is not selectable — cursor stays at [1]
+	if m.cursor != 1 {
+		t.Errorf("expected cursor=1 (no selectable node below), got %d", m.cursor)
+	}
 }
 
 // ---------- GotoTop / GotoBottom ----------
 
 func TestGotoTop_SetsCursorAndOffsetToZero(t *testing.T) {
-    m := modelAt(buildNodes(), 5)
-    m.offset = 3
-    m.GotoTop()
-    if m.cursor != 0 {
-        t.Errorf("expected cursor=0, got %d", m.cursor)
-    }
-    if m.offset != 0 {
-        t.Errorf("expected offset=0, got %d", m.offset)
-    }
+	m := modelAt(buildNodes(), 5)
+	m.offset = 3
+	m.GotoTop()
+	if m.cursor != 0 {
+		t.Errorf("expected cursor=0, got %d", m.cursor)
+	}
+	if m.offset != 0 {
+		t.Errorf("expected offset=0, got %d", m.offset)
+	}
 }
 
 func TestGotoBottom_MovesToLastSelectableNode(t *testing.T) {
-    nodes := buildNodes()
-    m := modelAt(nodes, 0)
-    m.GotoBottom()
-    if m.cursor != len(nodes)-1 {
-        t.Errorf("expected cursor=%d, got %d", len(nodes)-1, m.cursor)
-    }
+	nodes := buildNodes()
+	m := modelAt(nodes, 0)
+	m.GotoBottom()
+	if m.cursor != len(nodes)-1 {
+		t.Errorf("expected cursor=%d, got %d", len(nodes)-1, m.cursor)
+	}
 }
 
 func TestGotoBottom_SkipsTrailingIdleNode(t *testing.T) {
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-        {Proc: proc.Process{PID: 1, Name: "procA"}, Depth: 1},
-        {IsIdle: true, Depth: 1},
-    }
-    m := modelAt(nodes, 0)
-    m.GotoBottom()
-    // procA at [1] is the last selectable; idle at [2] must be skipped
-    if m.cursor != 1 {
-        t.Errorf("expected cursor=1, got %d", m.cursor)
-    }
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+		{Proc: proc.Process{PID: 1, Name: "procA"}, Depth: 1},
+		{IsIdle: true, Depth: 1},
+	}
+	m := modelAt(nodes, 0)
+	m.GotoBottom()
+	// procA at [1] is the last selectable; idle at [2] must be skipped
+	if m.cursor != 1 {
+		t.Errorf("expected cursor=1, got %d", m.cursor)
+	}
 }
 
 func TestGotoBottom_EmptyNodes_NoPanic(t *testing.T) {
-    m := ProcListModel{}
-    m.GotoBottom() // should not panic
+	m := ProcListModel{}
+	m.GotoBottom() // should not panic
 }
 
 // ---------- SelectedNode ----------
 
 func TestSelectedNode_ReturnsNilForIdleNode(t *testing.T) {
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-        {IsIdle: true, Depth: 1},
-    }
-    m := modelAt(nodes, 1) // cursor on idle node
-    if m.SelectedNode() != nil {
-        t.Error("expected nil for idle node")
-    }
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+		{IsIdle: true, Depth: 1},
+	}
+	m := modelAt(nodes, 1) // cursor on idle node
+	if m.SelectedNode() != nil {
+		t.Error("expected nil for idle node")
+	}
 }
 
 func TestSelectedNode_ReturnsProcNode(t *testing.T) {
-    nodes := buildNodes()
-    m := modelAt(nodes, 1) // cursor on procA
-    n := m.SelectedNode()
-    if n == nil {
-        t.Fatal("expected non-nil node")
-    }
-    if n.Proc.PID != 1 {
-        t.Errorf("expected PID=1, got %d", n.Proc.PID)
-    }
+	nodes := buildNodes()
+	m := modelAt(nodes, 1) // cursor on procA
+	n := m.SelectedNode()
+	if n == nil {
+		t.Fatal("expected non-nil node")
+	}
+	if n.Proc.PID != 1 {
+		t.Errorf("expected PID=1, got %d", n.Proc.PID)
+	}
 }
 
 func TestSelectedNode_ReturnsNilForEmptyModel(t *testing.T) {
-    m := ProcListModel{}
-    if m.SelectedNode() != nil {
-        t.Error("expected nil for empty model")
-    }
+	m := ProcListModel{}
+	if m.SelectedNode() != nil {
+		t.Error("expected nil for empty model")
+	}
 }
 
 // ---------- nodeRows ----------
 
 func TestNodeRows_PaneHeaderIsOneRow(t *testing.T) {
-    if nodeRows(ProcListNode{IsPaneHeader: true}) != 1 {
-        t.Error("expected 1 row for pane header")
-    }
+	if nodeRows(ProcListNode{IsPaneHeader: true}) != 1 {
+		t.Error("expected 1 row for pane header")
+	}
 }
 
 func TestNodeRows_IdleIsZeroRows(t *testing.T) {
-    if nodeRows(ProcListNode{IsIdle: true}) != 0 {
-        t.Error("expected 0 rows for idle placeholder (rendered inline on pane header)")
-    }
+	if nodeRows(ProcListNode{IsIdle: true}) != 0 {
+		t.Error("expected 0 rows for idle placeholder (rendered inline on pane header)")
+	}
 }
 
 func TestNodeRows_ProcIsTwoRows(t *testing.T) {
-    if nodeRows(ProcListNode{Proc: proc.Process{PID: 1}}) != 2 {
-        t.Error("expected 2 rows for process node")
-    }
+	if nodeRows(ProcListNode{Proc: proc.Process{PID: 1}}) != 2 {
+		t.Error("expected 2 rows for process node")
+	}
 }
 
 func TestNodeRows_WindowHeader_IsOneRow(t *testing.T) {
-    if nodeRows(ProcListNode{IsWindowHeader: true}) != 1 {
-        t.Error("expected window header to occupy 1 row")
-    }
+	if nodeRows(ProcListNode{IsWindowHeader: true}) != 1 {
+		t.Error("expected window header to occupy 1 row")
+	}
 }
 
 func TestIsSelectable_WindowHeader_IsTrue(t *testing.T) {
-    if !isSelectable(ProcListNode{IsWindowHeader: true}) {
-        t.Error("expected window header to be selectable")
-    }
+	if !isSelectable(ProcListNode{IsWindowHeader: true}) {
+		t.Error("expected window header to be selectable")
+	}
 }
 
 // ---------- clampOffset ----------
 
 func TestClampOffset_EmptyNodes(t *testing.T) {
-    m := ProcListModel{}
-    m.clampOffset(10) // must not panic
-    if m.offset != 0 {
-        t.Errorf("expected offset=0 for empty nodes, got %d", m.offset)
-    }
+	m := ProcListModel{}
+	m.clampOffset(10) // must not panic
+	if m.offset != 0 {
+		t.Errorf("expected offset=0 for empty nodes, got %d", m.offset)
+	}
 }
 
 func TestClampOffset_CursorFitsInViewport_NoChange(t *testing.T) {
-    // cursor=1, only 2 nodes, large maxRows — offset should stay 0
-    nodes := buildNodes()
-    m := modelAt(nodes, 1)
-    m.offset = 0
-    m.clampOffset(20)
-    if m.offset != 0 {
-        t.Errorf("expected offset=0 when cursor fits, got %d", m.offset)
-    }
+	// cursor=1, only 2 nodes, large maxRows — offset should stay 0
+	nodes := buildNodes()
+	m := modelAt(nodes, 1)
+	m.offset = 0
+	m.clampOffset(20)
+	if m.offset != 0 {
+		t.Errorf("expected offset=0 when cursor fits, got %d", m.offset)
+	}
 }
 
 func TestClampOffset_AdvancesOffsetWhenCursorRowsExceedAvailable(t *testing.T) {
-    // nodes: pane header (1 row) + 4 processes (2 rows each) = 10 rows total
-    // maxRows=6 → cursor at last process (index 5) won't fit without scrolling
-    nodes := buildNodes()
-    m := modelAt(nodes, 5)
-    m.offset = 0
-    m.clampOffset(6)
-    if m.offset == 0 {
-        t.Error("expected offset to advance when cursor is far below viewport")
-    }
-    // verify cursor is visible according to the same hint logic used by Render
-    if !procCursorVisible(nodes, m.cursor, m.offset, 6) {
-        t.Errorf("cursor not visible after clamp: offset=%d cursor=%d", m.offset, m.cursor)
-    }
+	// nodes: pane header (1 row) + 4 processes (2 rows each) = 10 rows total
+	// maxRows=6 → cursor at last process (index 5) won't fit without scrolling
+	nodes := buildNodes()
+	m := modelAt(nodes, 5)
+	m.offset = 0
+	m.clampOffset(6)
+	if m.offset == 0 {
+		t.Error("expected offset to advance when cursor is far below viewport")
+	}
+	// verify cursor is visible according to the same hint logic used by Render
+	if !procCursorVisible(nodes, m.cursor, m.offset, 6) {
+		t.Errorf("cursor not visible after clamp: offset=%d cursor=%d", m.offset, m.cursor)
+	}
 }
 
 func TestClampOffset_CursorAboveOffset_ClampsUp(t *testing.T) {
-    nodes := buildNodes()
-    m := modelAt(nodes, 1)
-    m.offset = 3 // cursor is above viewport
-    m.clampOffset(10)
-    if m.offset != 1 {
-        t.Errorf("expected offset=cursor=1 when cursor above viewport, got %d", m.offset)
-    }
+	nodes := buildNodes()
+	m := modelAt(nodes, 1)
+	m.offset = 3 // cursor is above viewport
+	m.clampOffset(10)
+	if m.offset != 1 {
+		t.Errorf("expected offset=cursor=1 when cursor above viewport, got %d", m.offset)
+	}
 }
 
 // ---------- procCursorVisible ----------
@@ -374,11 +374,11 @@ func TestClampOffset_CursorAboveOffset_ClampsUp(t *testing.T) {
 // buildHeaderNodes returns n pane-header nodes (1 row each) for simple
 // viewport arithmetic in scroll tests.
 func buildHeaderNodes(n int) []ProcListNode {
-    nodes := make([]ProcListNode, n)
-    for i := range nodes {
-        nodes[i] = ProcListNode{IsPaneHeader: true}
-    }
-    return nodes
+	nodes := make([]ProcListNode, n)
+	for i := range nodes {
+		nodes[i] = ProcListNode{IsPaneHeader: true}
+	}
+	return nodes
 }
 
 // TestProcCursorVisible_SecondToLastTriggersHasBelow is the regression test for
@@ -386,29 +386,29 @@ func buildHeaderNodes(n int) []ProcListNode {
 // whether nodes after the cursor would cause a ▼ hint — making the cursor
 // appear visible when Render would actually hide it behind the hint row.
 func TestProcCursorVisible_SecondToLastTriggersHasBelow(t *testing.T) {
-    // 9 single-row nodes, viewport fits 8. cursor=7 (second to last).
-    // Node 8 overflows → ▼ hint → effective content = 7 → cursor=7 is NOT visible.
-    nodes := buildHeaderNodes(9)
-    if procCursorVisible(nodes, 7, 0, 8) {
-        t.Error("cursor=7 (second to last of 9) should NOT be visible: node 8 causes ▼ hint that cuts it off")
-    }
+	// 9 single-row nodes, viewport fits 8. cursor=7 (second to last).
+	// Node 8 overflows → ▼ hint → effective content = 7 → cursor=7 is NOT visible.
+	nodes := buildHeaderNodes(9)
+	if procCursorVisible(nodes, 7, 0, 8) {
+		t.Error("cursor=7 (second to last of 9) should NOT be visible: node 8 causes ▼ hint that cuts it off")
+	}
 }
 
 func TestProcCursorVisible_LastNodeNoHasBelow(t *testing.T) {
-    // cursor at the very last node — no ▼ hint, so it should be visible
-    // even though it fills the viewport exactly.
-    nodes := buildHeaderNodes(8)
-    if !procCursorVisible(nodes, 7, 0, 8) {
-        t.Error("cursor at last node should be visible when all nodes fit exactly")
-    }
+	// cursor at the very last node — no ▼ hint, so it should be visible
+	// even though it fills the viewport exactly.
+	nodes := buildHeaderNodes(8)
+	if !procCursorVisible(nodes, 7, 0, 8) {
+		t.Error("cursor at last node should be visible when all nodes fit exactly")
+	}
 }
 
 func TestProcCursorVisible_AllFitNoScroll(t *testing.T) {
-    // Entire list fits in viewport with no hints needed.
-    nodes := buildHeaderNodes(5)
-    if !procCursorVisible(nodes, 4, 0, 10) {
-        t.Error("cursor should be visible when list easily fits in viewport")
-    }
+	// Entire list fits in viewport with no hints needed.
+	nodes := buildHeaderNodes(5)
+	if !procCursorVisible(nodes, 4, 0, 10) {
+		t.Error("cursor should be visible when list easily fits in viewport")
+	}
 }
 
 // ---------- Render downward safety clamp ----------
@@ -418,575 +418,575 @@ func TestProcCursorVisible_AllFitNoScroll(t *testing.T) {
 // shrinking procH. The stale p.offset (valid for the larger viewport) left the
 // cursor outside the visible area. Render must re-clamp read-only.
 func TestRender_SafetyClampWhenViewportShrinks(t *testing.T) {
-    nodes := buildNodes() // 6 nodes, 10 rows total
-    m := modelAt(nodes, 5)
-    // Simulate offset that was valid for a tall viewport but is now stale.
-    m.offset = 0
+	nodes := buildNodes() // 6 nodes, 10 rows total
+	m := modelAt(nodes, 5)
+	// Simulate offset that was valid for a tall viewport but is now stale.
+	m.offset = 0
 
-    // height=6 → maxRows=4 (tiny viewport, cursor=5 can't fit at offset=0)
-    rendered := m.Render(40, 6, true, "")
-    plain := stripANSI(rendered)
+	// height=6 → maxRows=4 (tiny viewport, cursor=5 can't fit at offset=0)
+	rendered := m.Render(40, 6, true, "")
+	plain := stripANSI(rendered)
 
-    // cursor is procB-child (PID 4); its name must appear in the rendered output
-    if !strings.Contains(plain, "procB-child") {
-        t.Errorf("cursor node 'procB-child' should be visible after read-only safety clamp; got:\n%s", plain)
-    }
+	// cursor is procB-child (PID 4); its name must appear in the rendered output
+	if !strings.Contains(plain, "procB-child") {
+		t.Errorf("cursor node 'procB-child' should be visible after read-only safety clamp; got:\n%s", plain)
+	}
 }
 
 // ---------- aggStats ----------
 
 func TestAggStats_LeafNode_ReturnsSelf(t *testing.T) {
-    tree := map[int32][]proc.Process{}
-    cpu, mem := aggStats(proc.Process{PID: 1, CPU: 2.5, MemRSS: 1024}, tree)
-    if cpu != 2.5 {
-        t.Errorf("expected cpu=2.5, got %.2f", cpu)
-    }
-    if mem != 1024 {
-        t.Errorf("expected mem=1024, got %d", mem)
-    }
+	tree := map[int32][]proc.Process{}
+	cpu, mem := aggStats(proc.Process{PID: 1, CPU: 2.5, MemRSS: 1024}, tree)
+	if cpu != 2.5 {
+		t.Errorf("expected cpu=2.5, got %.2f", cpu)
+	}
+	if mem != 1024 {
+		t.Errorf("expected mem=1024, got %d", mem)
+	}
 }
 
 func TestAggStats_WithChildren_IncludesDescendants(t *testing.T) {
-    parent := proc.Process{PID: 10, CPU: 1.0, MemRSS: 100}
-    child1 := proc.Process{PID: 11, CPU: 0.5, MemRSS: 50}
-    child2 := proc.Process{PID: 12, CPU: 0.3, MemRSS: 30}
-    grandchild := proc.Process{PID: 13, CPU: 0.2, MemRSS: 20}
-    tree := map[int32][]proc.Process{
-        10: {child1, child2},
-        11: {grandchild},
-    }
-    cpu, mem := aggStats(parent, tree)
-    if cpu != 2.0 {
-        t.Errorf("expected cpu=2.0, got %.2f", cpu)
-    }
-    if mem != 200 {
-        t.Errorf("expected mem=200, got %d", mem)
-    }
+	parent := proc.Process{PID: 10, CPU: 1.0, MemRSS: 100}
+	child1 := proc.Process{PID: 11, CPU: 0.5, MemRSS: 50}
+	child2 := proc.Process{PID: 12, CPU: 0.3, MemRSS: 30}
+	grandchild := proc.Process{PID: 13, CPU: 0.2, MemRSS: 20}
+	tree := map[int32][]proc.Process{
+		10: {child1, child2},
+		11: {grandchild},
+	}
+	cpu, mem := aggStats(parent, tree)
+	if cpu != 2.0 {
+		t.Errorf("expected cpu=2.0, got %.2f", cpu)
+	}
+	if mem != 200 {
+		t.Errorf("expected mem=200, got %d", mem)
+	}
 }
 
 // ---------- SetWindowData collapse defaults ----------
 
 func buildTestPane(panePID int32) tmux.Pane {
-    return tmux.Pane{
-        Session:     "test",
-        WindowIndex: 0,
-        PaneIndex:   0,
-        PanePID:     panePID,
-    }
+	return tmux.Pane{
+		Session:     "test",
+		WindowIndex: 0,
+		PaneIndex:   0,
+		PanePID:     panePID,
+	}
 }
 
 func TestSetWindowData_CollapseHidesChildren(t *testing.T) {
-    shell := proc.Process{PID: 200, PPID: 0, Name: "zsh"}
-    parent := proc.Process{PID: 201, PPID: 200, Name: "node"}
-    child := proc.Process{PID: 202, PPID: 201, Name: "esbuild"}
-    procs := []proc.Process{shell, parent, child}
+	shell := proc.Process{PID: 200, PPID: 0, Name: "zsh"}
+	parent := proc.Process{PID: 201, PPID: 200, Name: "node"}
+	child := proc.Process{PID: 202, PPID: 201, Name: "esbuild"}
+	procs := []proc.Process{shell, parent, child}
 
-    pane := buildTestPane(200)
-    var m ProcListModel
-    m.SetWindowData(
-        []tmux.Pane{pane}, "test", 0,
-        procs, map[int32]string{},
-        map[string]git.Info{}, nil, config.Config{},
-    )
+	pane := buildTestPane(200)
+	var m ProcListModel
+	m.SetWindowData(
+		[]tmux.Pane{pane}, "test", 0,
+		procs, map[int32]string{},
+		map[string]git.Info{}, nil, config.Config{},
+	)
 
-    // esbuild (depth-2 child of node) should NOT appear — parent collapsed by default
-    for _, n := range m.nodes {
-        if n.Proc.PID == 202 {
-            t.Error("esbuild (depth-2 child) should be hidden when parent is collapsed by default")
-        }
-    }
+	// esbuild (depth-2 child of node) should NOT appear — parent collapsed by default
+	for _, n := range m.nodes {
+		if n.Proc.PID == 202 {
+			t.Error("esbuild (depth-2 child) should be hidden when parent is collapsed by default")
+		}
+	}
 
-    // node (PID 201) should have HasChildren=true and Collapsed=true
-    var nodeProc *ProcListNode
-    for i := range m.nodes {
-        if m.nodes[i].Proc.PID == 201 {
-            nodeProc = &m.nodes[i]
-        }
-    }
-    if nodeProc == nil {
-        t.Fatal("node proc (PID 201) not found in node list")
-    }
-    if !nodeProc.HasChildren {
-        t.Error("expected HasChildren=true for node with child esbuild")
-    }
-    if !nodeProc.Collapsed {
-        t.Error("expected Collapsed=true by default")
-    }
+	// node (PID 201) should have HasChildren=true and Collapsed=true
+	var nodeProc *ProcListNode
+	for i := range m.nodes {
+		if m.nodes[i].Proc.PID == 201 {
+			nodeProc = &m.nodes[i]
+		}
+	}
+	if nodeProc == nil {
+		t.Fatal("node proc (PID 201) not found in node list")
+	}
+	if !nodeProc.HasChildren {
+		t.Error("expected HasChildren=true for node with child esbuild")
+	}
+	if !nodeProc.Collapsed {
+		t.Error("expected Collapsed=true by default")
+	}
 }
 
 func TestSetWindowData_ExpandedShowsChildren(t *testing.T) {
-    shell := proc.Process{PID: 300, PPID: 0, Name: "zsh"}
-    parent := proc.Process{PID: 301, PPID: 300, Name: "node"}
-    child := proc.Process{PID: 302, PPID: 301, Name: "esbuild"}
-    procs := []proc.Process{shell, parent, child}
+	shell := proc.Process{PID: 300, PPID: 0, Name: "zsh"}
+	parent := proc.Process{PID: 301, PPID: 300, Name: "node"}
+	child := proc.Process{PID: 302, PPID: 301, Name: "esbuild"}
+	procs := []proc.Process{shell, parent, child}
 
-    pane := buildTestPane(300)
-    var m ProcListModel
-    // First call establishes the window and defaults PID 301 to collapsed.
-    m.SetWindowData(
-        []tmux.Pane{pane}, "test", 0,
-        procs, map[int32]string{},
-        map[string]git.Info{}, nil, config.Config{},
-    )
-    // Simulate a toggle — expand PID 301.
-    m.collapsedPIDs[301] = false
-    // Second call for the same window (windowChanged=false) — map is preserved.
-    m.SetWindowData(
-        []tmux.Pane{pane}, "test", 0,
-        procs, map[int32]string{},
-        map[string]git.Info{}, nil, config.Config{},
-    )
+	pane := buildTestPane(300)
+	var m ProcListModel
+	// First call establishes the window and defaults PID 301 to collapsed.
+	m.SetWindowData(
+		[]tmux.Pane{pane}, "test", 0,
+		procs, map[int32]string{},
+		map[string]git.Info{}, nil, config.Config{},
+	)
+	// Simulate a toggle — expand PID 301.
+	m.collapsedPIDs[301] = false
+	// Second call for the same window (windowChanged=false) — map is preserved.
+	m.SetWindowData(
+		[]tmux.Pane{pane}, "test", 0,
+		procs, map[int32]string{},
+		map[string]git.Info{}, nil, config.Config{},
+	)
 
-    found := false
-    for _, n := range m.nodes {
-        if n.Proc.PID == 302 {
-            found = true
-        }
-    }
-    if !found {
-        t.Error("esbuild (depth-2) should be visible when parent is expanded")
-    }
+	found := false
+	for _, n := range m.nodes {
+		if n.Proc.PID == 302 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("esbuild (depth-2) should be visible when parent is expanded")
+	}
 }
 
 func TestSetWindowData_AggStats_SetOnCollapsedNode(t *testing.T) {
-    shell := proc.Process{PID: 400, PPID: 0, Name: "zsh"}
-    parent := proc.Process{PID: 401, PPID: 400, Name: "node", CPU: 1.0, MemRSS: 100}
-    child := proc.Process{PID: 402, PPID: 401, Name: "esbuild", CPU: 0.5, MemRSS: 50}
-    procs := []proc.Process{shell, parent, child}
+	shell := proc.Process{PID: 400, PPID: 0, Name: "zsh"}
+	parent := proc.Process{PID: 401, PPID: 400, Name: "node", CPU: 1.0, MemRSS: 100}
+	child := proc.Process{PID: 402, PPID: 401, Name: "esbuild", CPU: 0.5, MemRSS: 50}
+	procs := []proc.Process{shell, parent, child}
 
-    pane := buildTestPane(400)
-    var m ProcListModel
-    m.SetWindowData(
-        []tmux.Pane{pane}, "test", 0,
-        procs, map[int32]string{},
-        map[string]git.Info{}, nil, config.Config{},
-    )
+	pane := buildTestPane(400)
+	var m ProcListModel
+	m.SetWindowData(
+		[]tmux.Pane{pane}, "test", 0,
+		procs, map[int32]string{},
+		map[string]git.Info{}, nil, config.Config{},
+	)
 
-    var nodeProc *ProcListNode
-    for i := range m.nodes {
-        if m.nodes[i].Proc.PID == 401 {
-            nodeProc = &m.nodes[i]
-        }
-    }
-    if nodeProc == nil {
-        t.Fatal("node proc (PID 401) not found")
-    }
-    if !nodeProc.HasChildren {
-        t.Error("expected HasChildren=true for node with child esbuild")
-    }
-    if !nodeProc.Collapsed {
-        t.Error("expected Collapsed=true by default")
-    }
-    if nodeProc.AggCPU != 1.5 {
-        t.Errorf("expected AggCPU=1.5, got %.2f", nodeProc.AggCPU)
-    }
-    if nodeProc.AggMemRSS != 150 {
-        t.Errorf("expected AggMemRSS=150, got %d", nodeProc.AggMemRSS)
-    }
+	var nodeProc *ProcListNode
+	for i := range m.nodes {
+		if m.nodes[i].Proc.PID == 401 {
+			nodeProc = &m.nodes[i]
+		}
+	}
+	if nodeProc == nil {
+		t.Fatal("node proc (PID 401) not found")
+	}
+	if !nodeProc.HasChildren {
+		t.Error("expected HasChildren=true for node with child esbuild")
+	}
+	if !nodeProc.Collapsed {
+		t.Error("expected Collapsed=true by default")
+	}
+	if nodeProc.AggCPU != 1.5 {
+		t.Errorf("expected AggCPU=1.5, got %.2f", nodeProc.AggCPU)
+	}
+	if nodeProc.AggMemRSS != 150 {
+		t.Errorf("expected AggMemRSS=150, got %d", nodeProc.AggMemRSS)
+	}
 }
 
 // ---------- ToggleCollapse ----------
 
 func TestToggleCollapse_Depth1WithChildren_TogglesAndReturnsTrue(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: true},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10}, Depth: 1, HasChildren: true, Collapsed: true},
-        },
-        cursor: 1,
-    }
-    toggled := m.ToggleCollapse()
-    if !toggled {
-        t.Error("expected ToggleCollapse to return true")
-    }
-    if m.collapsedPIDs[10] != false {
-        t.Error("expected PID 10 to be expanded after toggle")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: true},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10}, Depth: 1, HasChildren: true, Collapsed: true},
+		},
+		cursor: 1,
+	}
+	toggled := m.ToggleCollapse()
+	if !toggled {
+		t.Error("expected ToggleCollapse to return true")
+	}
+	if m.collapsedPIDs[10] != false {
+		t.Error("expected PID 10 to be expanded after toggle")
+	}
 }
 
 func TestToggleCollapse_Depth1NoChildren_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 20}, Depth: 1, HasChildren: false},
-        },
-        cursor: 1,
-    }
-    toggled := m.ToggleCollapse()
-    if toggled {
-        t.Error("expected ToggleCollapse to return false for node without children")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 20}, Depth: 1, HasChildren: false},
+		},
+		cursor: 1,
+	}
+	toggled := m.ToggleCollapse()
+	if toggled {
+		t.Error("expected ToggleCollapse to return false for node without children")
+	}
 }
 
 func TestToggleCollapse_PaneHeader_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-        },
-        cursor: 0,
-    }
-    if m.ToggleCollapse() {
-        t.Error("expected false for pane header")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+		},
+		cursor: 0,
+	}
+	if m.ToggleCollapse() {
+		t.Error("expected false for pane header")
+	}
 }
 
 func TestToggleCollapse_ExpandedToCollapsed(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{30: false},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 30}, Depth: 1, HasChildren: true, Collapsed: false},
-        },
-        cursor: 1,
-    }
-    m.ToggleCollapse()
-    if m.collapsedPIDs[30] != true {
-        t.Error("expected PID 30 to be collapsed after toggle")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{30: false},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 30}, Depth: 1, HasChildren: true, Collapsed: false},
+		},
+		cursor: 1,
+	}
+	m.ToggleCollapse()
+	if m.collapsedPIDs[30] != true {
+		t.Error("expected PID 30 to be collapsed after toggle")
+	}
 }
 
 func TestToggleCollapse_EmptyNodes_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{}
-    if m.ToggleCollapse() {
-        t.Error("expected false for empty model")
-    }
+	m := ProcListModel{}
+	if m.ToggleCollapse() {
+		t.Error("expected false for empty model")
+	}
 }
 
 func TestToggleCollapse_IdleNode_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {IsIdle: true, Depth: 1},
-        },
-        cursor: 1,
-    }
-    if m.ToggleCollapse() {
-        t.Error("expected false for idle node")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{IsIdle: true, Depth: 1},
+		},
+		cursor: 1,
+	}
+	if m.ToggleCollapse() {
+		t.Error("expected false for idle node")
+	}
 }
 
 // ---------- Expand ----------
 
 func TestExpand_CollapsedNode_ExpandsAndReturnsTrue(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: true},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "proc"}, Depth: 1, HasChildren: true},
-        },
-        cursor: 1,
-    }
-    if !m.Expand() {
-        t.Error("expected Expand to return true for collapsed node")
-    }
-    if m.collapsedPIDs[10] {
-        t.Error("expected PID 10 to be expanded after Expand()")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: true},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "proc"}, Depth: 1, HasChildren: true},
+		},
+		cursor: 1,
+	}
+	if !m.Expand() {
+		t.Error("expected Expand to return true for collapsed node")
+	}
+	if m.collapsedPIDs[10] {
+		t.Error("expected PID 10 to be expanded after Expand()")
+	}
 }
 
 func TestExpand_AlreadyExpanded_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: false},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "proc"}, Depth: 1, HasChildren: true},
-        },
-        cursor: 1,
-    }
-    if m.Expand() {
-        t.Error("expected Expand to return false when node is already expanded")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: false},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "proc"}, Depth: 1, HasChildren: true},
+		},
+		cursor: 1,
+	}
+	if m.Expand() {
+		t.Error("expected Expand to return false when node is already expanded")
+	}
 }
 
 func TestExpand_PaneHeader_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{},
-        nodes:         []ProcListNode{{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}},
-        cursor:        0,
-    }
-    if m.Expand() {
-        t.Error("expected false for pane header")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{},
+		nodes:         []ProcListNode{{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}},
+		cursor:        0,
+	}
+	if m.Expand() {
+		t.Error("expected false for pane header")
+	}
 }
 
 func TestExpand_NoChildren_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{},
-        nodes: []ProcListNode{
-            {Proc: proc.Process{PID: 5, Name: "proc"}, Depth: 1, HasChildren: false},
-        },
-        cursor: 0,
-    }
-    if m.Expand() {
-        t.Error("expected false for node without children")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{},
+		nodes: []ProcListNode{
+			{Proc: proc.Process{PID: 5, Name: "proc"}, Depth: 1, HasChildren: false},
+		},
+		cursor: 0,
+	}
+	if m.Expand() {
+		t.Error("expected false for node without children")
+	}
 }
 
 // ---------- Collapse ----------
 
 func TestCollapse_ExpandedNode_CollapsesAndReturnsTrue(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{20: false},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 20, Name: "proc"}, Depth: 1, HasChildren: true},
-        },
-        cursor: 1,
-    }
-    if !m.Collapse() {
-        t.Error("expected Collapse to return true for expanded node")
-    }
-    if !m.collapsedPIDs[20] {
-        t.Error("expected PID 20 to be collapsed after Collapse()")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{20: false},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 20, Name: "proc"}, Depth: 1, HasChildren: true},
+		},
+		cursor: 1,
+	}
+	if !m.Collapse() {
+		t.Error("expected Collapse to return true for expanded node")
+	}
+	if !m.collapsedPIDs[20] {
+		t.Error("expected PID 20 to be collapsed after Collapse()")
+	}
 }
 
 func TestCollapse_AlreadyCollapsed_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{20: true},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 20, Name: "proc"}, Depth: 1, HasChildren: true},
-        },
-        cursor: 1,
-    }
-    if m.Collapse() {
-        t.Error("expected Collapse to return false when node is already collapsed")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{20: true},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 20, Name: "proc"}, Depth: 1, HasChildren: true},
+		},
+		cursor: 1,
+	}
+	if m.Collapse() {
+		t.Error("expected Collapse to return false when node is already collapsed")
+	}
 }
 
 func TestCollapse_PaneHeader_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{},
-        nodes:         []ProcListNode{{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}},
-        cursor:        0,
-    }
-    if m.Collapse() {
-        t.Error("expected false for pane header")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{},
+		nodes:         []ProcListNode{{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}},
+		cursor:        0,
+	}
+	if m.Collapse() {
+		t.Error("expected false for pane header")
+	}
 }
 
 func TestCollapse_Depth2Node_CollapsesParentAndMovesCursor(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{20: false},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 20, Name: "parent"}, Depth: 1, HasChildren: true},
-            {Proc: proc.Process{PID: 21, Name: "child"}, Depth: 2},
-        },
-        cursor: 2, // depth-2 child
-    }
-    if !m.Collapse() {
-        t.Error("expected Collapse to return true for depth-2 node")
-    }
-    if !m.collapsedPIDs[20] {
-        t.Error("expected parent PID 20 to be collapsed")
-    }
-    if m.cursor != 1 {
-        t.Errorf("expected cursor to move to parent (1), got %d", m.cursor)
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{20: false},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 20, Name: "parent"}, Depth: 1, HasChildren: true},
+			{Proc: proc.Process{PID: 21, Name: "child"}, Depth: 2},
+		},
+		cursor: 2, // depth-2 child
+	}
+	if !m.Collapse() {
+		t.Error("expected Collapse to return true for depth-2 node")
+	}
+	if !m.collapsedPIDs[20] {
+		t.Error("expected parent PID 20 to be collapsed")
+	}
+	if m.cursor != 1 {
+		t.Errorf("expected cursor to move to parent (1), got %d", m.cursor)
+	}
 }
 
 func TestCollapse_Depth2Node_ParentAlreadyCollapsed_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{20: true},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 20, Name: "parent"}, Depth: 1, HasChildren: true},
-            {Proc: proc.Process{PID: 21, Name: "child"}, Depth: 2},
-        },
-        cursor: 2,
-    }
-    if m.Collapse() {
-        t.Error("expected false when parent is already collapsed")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{20: true},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 20, Name: "parent"}, Depth: 1, HasChildren: true},
+			{Proc: proc.Process{PID: 21, Name: "child"}, Depth: 2},
+		},
+		cursor: 2,
+	}
+	if m.Collapse() {
+		t.Error("expected false when parent is already collapsed")
+	}
 }
 
 // ---------- ExpandAll ----------
 
 func TestExpandAll_CollapsedNodes_ExpandsAndReturnsTrue(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: true, 20: true},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}},
-            {Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
-        },
-    }
-    if !m.ExpandAll() {
-        t.Error("expected ExpandAll to return true when nodes are collapsed")
-    }
-    if m.collapsedPIDs[10] || m.collapsedPIDs[20] {
-        t.Error("expected all nodes to be expanded after ExpandAll()")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: true, 20: true},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}},
+			{Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
+		},
+	}
+	if !m.ExpandAll() {
+		t.Error("expected ExpandAll to return true when nodes are collapsed")
+	}
+	if m.collapsedPIDs[10] || m.collapsedPIDs[20] {
+		t.Error("expected all nodes to be expanded after ExpandAll()")
+	}
 }
 
 func TestExpandAll_AllAlreadyExpanded_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: false, 20: false},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}},
-            {Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
-        },
-    }
-    if m.ExpandAll() {
-        t.Error("expected ExpandAll to return false when all are already expanded")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: false, 20: false},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}},
+			{Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
+		},
+	}
+	if m.ExpandAll() {
+		t.Error("expected ExpandAll to return false when all are already expanded")
+	}
 }
 
 func TestExpandAll_NoCollapsibleNodes_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{},
-        nodes:         []ProcListNode{{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}},
-    }
-    if m.ExpandAll() {
-        t.Error("expected ExpandAll to return false with no collapsible nodes")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{},
+		nodes:         []ProcListNode{{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}},
+	}
+	if m.ExpandAll() {
+		t.Error("expected ExpandAll to return false with no collapsible nodes")
+	}
 }
 
 // ---------- CollapseAll ----------
 
 func TestCollapseAll_ExpandedNodes_CollapsesAndReturnsTrue(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: false, 20: false},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}},
-            {Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
-        },
-    }
-    if !m.CollapseAll() {
-        t.Error("expected CollapseAll to return true when nodes are expanded")
-    }
-    if !m.collapsedPIDs[10] || !m.collapsedPIDs[20] {
-        t.Error("expected all nodes to be collapsed after CollapseAll()")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: false, 20: false},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}},
+			{Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
+		},
+	}
+	if !m.CollapseAll() {
+		t.Error("expected CollapseAll to return true when nodes are expanded")
+	}
+	if !m.collapsedPIDs[10] || !m.collapsedPIDs[20] {
+		t.Error("expected all nodes to be collapsed after CollapseAll()")
+	}
 }
 
 func TestCollapseAll_AllAlreadyCollapsed_ReturnsFalse(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: true, 20: true},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}},
-            {Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
-        },
-    }
-    if m.CollapseAll() {
-        t.Error("expected CollapseAll to return false when all are already collapsed")
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: true, 20: true},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 1}},
+			{Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
+		},
+	}
+	if m.CollapseAll() {
+		t.Error("expected CollapseAll to return false when all are already collapsed")
+	}
 }
 
 // CollapseAll with cursor on depth-2 should set pendingSeekKey to the depth-1
 // ancestor's pid key, and applyPendingSeek should restore cursor after rebuild.
 func TestCollapseAll_CursorOnDepth2_SeeksToParent(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: false, 20: false},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
-            {Proc: proc.Process{PID: 11, Name: "childA"}, Depth: 2},
-            {Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
-        },
-        cursor: 2, // depth-2 child of procA
-    }
-    m.CollapseAll()
-    if m.pendingSeekKey != "pid:10" {
-        t.Errorf("expected pendingSeekKey=\"pid:10\", got %q", m.pendingSeekKey)
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: false, 20: false},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
+			{Proc: proc.Process{PID: 11, Name: "childA"}, Depth: 2},
+			{Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
+		},
+		cursor: 2, // depth-2 child of procA
+	}
+	m.CollapseAll()
+	if m.pendingSeekKey != "pid:10" {
+		t.Errorf("expected pendingSeekKey=\"pid:10\", got %q", m.pendingSeekKey)
+	}
 
-    // Simulate rebuild: depth-2 nodes gone, D1(pid=10) now at index 1.
-    m.nodes = []ProcListNode{
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-        {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true, Collapsed: true},
-        {Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true, Collapsed: true},
-    }
-    m.applyPendingSeek()
+	// Simulate rebuild: depth-2 nodes gone, D1(pid=10) now at index 1.
+	m.nodes = []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+		{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true, Collapsed: true},
+		{Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true, Collapsed: true},
+	}
+	m.applyPendingSeek()
 
-    if m.cursor != 1 {
-        t.Errorf("expected cursor=1 (procA, pid=10), got %d", m.cursor)
-    }
-    if m.pendingSeekKey != "" {
-        t.Errorf("expected pendingSeekKey to be cleared, got %q", m.pendingSeekKey)
-    }
+	if m.cursor != 1 {
+		t.Errorf("expected cursor=1 (procA, pid=10), got %d", m.cursor)
+	}
+	if m.pendingSeekKey != "" {
+		t.Errorf("expected pendingSeekKey to be cleared, got %q", m.pendingSeekKey)
+	}
 }
 
 // CollapseAll with cursor on a depth-3 node should seek to the depth-1 ancestor.
 func TestCollapseAll_CursorOnDepth3_SeeksToDepth1Ancestor(t *testing.T) {
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: false, 20: false},
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
-            {Proc: proc.Process{PID: 11, Name: "childA"}, Depth: 2},
-            {Proc: proc.Process{PID: 12, Name: "grandchildA"}, Depth: 3},
-            {Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
-        },
-        cursor: 3, // depth-3 grandchild of procA
-    }
-    m.CollapseAll()
-    if m.pendingSeekKey != "pid:10" {
-        t.Errorf("expected pendingSeekKey=\"pid:10\", got %q", m.pendingSeekKey)
-    }
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: false, 20: false},
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
+			{Proc: proc.Process{PID: 11, Name: "childA"}, Depth: 2},
+			{Proc: proc.Process{PID: 12, Name: "grandchildA"}, Depth: 3},
+			{Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true},
+		},
+		cursor: 3, // depth-3 grandchild of procA
+	}
+	m.CollapseAll()
+	if m.pendingSeekKey != "pid:10" {
+		t.Errorf("expected pendingSeekKey=\"pid:10\", got %q", m.pendingSeekKey)
+	}
 
-    m.nodes = []ProcListNode{
-        {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-        {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true, Collapsed: true},
-        {Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true, Collapsed: true},
-    }
-    m.applyPendingSeek()
+	m.nodes = []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+		{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true, Collapsed: true},
+		{Proc: proc.Process{PID: 20, Name: "procB"}, Depth: 1, HasChildren: true, Collapsed: true},
+	}
+	m.applyPendingSeek()
 
-    if m.cursor != 1 {
-        t.Errorf("expected cursor=1 (procA, pid=10), got %d", m.cursor)
-    }
+	if m.cursor != 1 {
+		t.Errorf("expected cursor=1 (procA, pid=10), got %d", m.cursor)
+	}
 }
 
 // CollapseAll with cursor on a pane header should keep focus on that same pane
 // header even when preceding windows lose children and indices shift.
 func TestCollapseAll_CursorOnPaneHeader_SeeksToPaneHeader(t *testing.T) {
-    // Session mode: Win0 has expanded D1(pid=10) with D2(pid=11), Win1 has a
-    // pane header (cursor) with an idle node.
-    m := ProcListModel{
-        collapsedPIDs: map[int32]bool{10: false},
-        nodes: []ProcListNode{
-            {IsWindowHeader: true, Pane: tmux.Pane{WindowIndex: 0}},
-            {IsPaneHeader: true, Pane: tmux.Pane{WindowIndex: 0, PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
-            {Proc: proc.Process{PID: 11, Name: "childA"}, Depth: 2},
-            {IsWindowHeader: true, Pane: tmux.Pane{WindowIndex: 1}},
-            {IsPaneHeader: true, Pane: tmux.Pane{WindowIndex: 1, PaneIndex: 0}}, // cursor
-            {IsIdle: true, Depth: 1},
-        },
-        cursor: 5, // pane header of Win1
-    }
-    m.CollapseAll()
-    if m.pendingSeekKey != "pane:1:0" {
-        t.Errorf("expected pendingSeekKey=\"pane:1:0\", got %q", m.pendingSeekKey)
-    }
+	// Session mode: Win0 has expanded D1(pid=10) with D2(pid=11), Win1 has a
+	// pane header (cursor) with an idle node.
+	m := ProcListModel{
+		collapsedPIDs: map[int32]bool{10: false},
+		nodes: []ProcListNode{
+			{IsWindowHeader: true, Pane: tmux.Pane{WindowIndex: 0}},
+			{IsPaneHeader: true, Pane: tmux.Pane{WindowIndex: 0, PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
+			{Proc: proc.Process{PID: 11, Name: "childA"}, Depth: 2},
+			{IsWindowHeader: true, Pane: tmux.Pane{WindowIndex: 1}},
+			{IsPaneHeader: true, Pane: tmux.Pane{WindowIndex: 1, PaneIndex: 0}}, // cursor
+			{IsIdle: true, Depth: 1},
+		},
+		cursor: 5, // pane header of Win1
+	}
+	m.CollapseAll()
+	if m.pendingSeekKey != "pane:1:0" {
+		t.Errorf("expected pendingSeekKey=\"pane:1:0\", got %q", m.pendingSeekKey)
+	}
 
-    // Simulate rebuild: Win0's D2 is gone; pane header of Win1 shifts from 5→4.
-    m.nodes = []ProcListNode{
-        {IsWindowHeader: true, Pane: tmux.Pane{WindowIndex: 0}},
-        {IsPaneHeader: true, Pane: tmux.Pane{WindowIndex: 0, PaneIndex: 0}},
-        {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true, Collapsed: true},
-        {IsWindowHeader: true, Pane: tmux.Pane{WindowIndex: 1}},
-        {IsPaneHeader: true, Pane: tmux.Pane{WindowIndex: 1, PaneIndex: 0}}, // now index 4
-        {IsIdle: true, Depth: 1},
-    }
-    m.applyPendingSeek()
+	// Simulate rebuild: Win0's D2 is gone; pane header of Win1 shifts from 5→4.
+	m.nodes = []ProcListNode{
+		{IsWindowHeader: true, Pane: tmux.Pane{WindowIndex: 0}},
+		{IsPaneHeader: true, Pane: tmux.Pane{WindowIndex: 0, PaneIndex: 0}},
+		{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true, Collapsed: true},
+		{IsWindowHeader: true, Pane: tmux.Pane{WindowIndex: 1}},
+		{IsPaneHeader: true, Pane: tmux.Pane{WindowIndex: 1, PaneIndex: 0}}, // now index 4
+		{IsIdle: true, Depth: 1},
+	}
+	m.applyPendingSeek()
 
-    if m.cursor != 4 {
-        t.Errorf("expected cursor=4 (pane header Win1), got %d", m.cursor)
-    }
+	if m.cursor != 4 {
+		t.Errorf("expected cursor=4 (pane header Win1), got %d", m.cursor)
+	}
 }
 
 // ---------- clampOffset cursor bounds ----------
@@ -994,559 +994,559 @@ func TestCollapseAll_CursorOnPaneHeader_SeeksToPaneHeader(t *testing.T) {
 // Regression: CollapseAll shrinks p.nodes; clampOffset must clamp p.cursor to
 // prevent out-of-bounds panics on subsequent MoveUp/MoveDown calls.
 func TestClampOffset_CursorBeyondNodes_ClampsToBounds(t *testing.T) {
-    m := ProcListModel{
-        nodes: []ProcListNode{
-            {IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
-            {Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
-        },
-        cursor: 15, // out of bounds after a CollapseAll rebuild
-        offset: 15,
-    }
-    m.clampOffset(10)
-    if m.cursor >= len(m.nodes) {
-        t.Errorf("cursor %d still out of bounds (len=%d)", m.cursor, len(m.nodes))
-    }
-    if m.offset < 0 || m.offset >= len(m.nodes) {
-        t.Errorf("offset %d out of bounds (len=%d)", m.offset, len(m.nodes))
-    }
-    // MoveUp must not panic
-    m.MoveUp()
-    // MoveDown must not panic
-    m.MoveDown()
+	m := ProcListModel{
+		nodes: []ProcListNode{
+			{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}},
+			{Proc: proc.Process{PID: 10, Name: "procA"}, Depth: 1, HasChildren: true},
+		},
+		cursor: 15, // out of bounds after a CollapseAll rebuild
+		offset: 15,
+	}
+	m.clampOffset(10)
+	if m.cursor >= len(m.nodes) {
+		t.Errorf("cursor %d still out of bounds (len=%d)", m.cursor, len(m.nodes))
+	}
+	if m.offset < 0 || m.offset >= len(m.nodes) {
+		t.Errorf("offset %d out of bounds (len=%d)", m.offset, len(m.nodes))
+	}
+	// MoveUp must not panic
+	m.MoveUp()
+	// MoveDown must not panic
+	m.MoveDown()
 }
 
 // ---------- renderProc collapse rendering ----------
 
 func TestRenderProc_CollapsedWithChildren_ShowsRightTriangleAndAggStats(t *testing.T) {
-    m := ProcListModel{}
-    node := ProcListNode{
-        Proc:        proc.Process{PID: 1, Name: "node", CPU: 1.0, MemRSS: 100 * 1024 * 1024},
-        Depth:       1,
-        HasChildren: true,
-        Collapsed:   true,
-        AggCPU:      2.5,
-        AggMemRSS:   250 * 1024 * 1024,
-        TreePrefix:  "  └─ ",
-        StatPrefix:  "     ",
-    }
-    line := m.renderProc(node, false, 80)
-    plain := stripANSI(line)
-    if !strings.Contains(plain, "▶") {
-        t.Errorf("expected ▶ prefix for collapsed node, got: %s", plain)
-    }
-    if !strings.Contains(plain, "(2.5%)") {
-        t.Errorf("expected aggregated cpu (2.5%%) in stats, got: %s", plain)
-    }
-    if !strings.Contains(plain, "(250.0MB)") {
-        t.Errorf("expected aggregated mem (250.0MB) in stats, got: %s", plain)
-    }
-    if !strings.Contains(plain, "└─") {
-        t.Errorf("expected tree connector └─ in output, got: %s", plain)
-    }
+	m := ProcListModel{}
+	node := ProcListNode{
+		Proc:        proc.Process{PID: 1, Name: "node", CPU: 1.0, MemRSS: 100 * 1024 * 1024},
+		Depth:       1,
+		HasChildren: true,
+		Collapsed:   true,
+		AggCPU:      2.5,
+		AggMemRSS:   250 * 1024 * 1024,
+		TreePrefix:  "  └─ ",
+		StatPrefix:  "     ",
+	}
+	line := m.renderProc(node, false, 80)
+	plain := stripANSI(line)
+	if !strings.Contains(plain, "▶") {
+		t.Errorf("expected ▶ prefix for collapsed node, got: %s", plain)
+	}
+	if !strings.Contains(plain, "(2.5%)") {
+		t.Errorf("expected aggregated cpu (2.5%%) in stats, got: %s", plain)
+	}
+	if !strings.Contains(plain, "(250.0MB)") {
+		t.Errorf("expected aggregated mem (250.0MB) in stats, got: %s", plain)
+	}
+	if !strings.Contains(plain, "└─") {
+		t.Errorf("expected tree connector └─ in output, got: %s", plain)
+	}
 }
 
 func TestRenderProc_ExpandedWithChildren_ShowsDownTriangle_NoAggStats(t *testing.T) {
-    m := ProcListModel{}
-    node := ProcListNode{
-        Proc:        proc.Process{PID: 2, Name: "node", CPU: 1.0, MemRSS: 100 * 1024 * 1024},
-        Depth:       1,
-        HasChildren: true,
-        Collapsed:   false,
-        AggCPU:      2.5,
-        AggMemRSS:   250 * 1024 * 1024,
-        TreePrefix:  "  └─ ",
-        StatPrefix:  "     ",
-    }
-    line := m.renderProc(node, false, 80)
-    plain := stripANSI(line)
-    if !strings.Contains(plain, "▼") {
-        t.Errorf("expected ▼ prefix for expanded node with children, got: %s", plain)
-    }
-    if strings.Contains(plain, "(2.5%)") {
-        t.Errorf("expanded node should not show agg stats, got: %s", plain)
-    }
-    if !strings.Contains(plain, "└─") {
-        t.Errorf("expected tree connector └─ in output, got: %s", plain)
-    }
+	m := ProcListModel{}
+	node := ProcListNode{
+		Proc:        proc.Process{PID: 2, Name: "node", CPU: 1.0, MemRSS: 100 * 1024 * 1024},
+		Depth:       1,
+		HasChildren: true,
+		Collapsed:   false,
+		AggCPU:      2.5,
+		AggMemRSS:   250 * 1024 * 1024,
+		TreePrefix:  "  └─ ",
+		StatPrefix:  "     ",
+	}
+	line := m.renderProc(node, false, 80)
+	plain := stripANSI(line)
+	if !strings.Contains(plain, "▼") {
+		t.Errorf("expected ▼ prefix for expanded node with children, got: %s", plain)
+	}
+	if strings.Contains(plain, "(2.5%)") {
+		t.Errorf("expanded node should not show agg stats, got: %s", plain)
+	}
+	if !strings.Contains(plain, "└─") {
+		t.Errorf("expected tree connector └─ in output, got: %s", plain)
+	}
 }
 
 func TestRenderProc_NoChildren_NoTriangle(t *testing.T) {
-    m := ProcListModel{}
-    node := ProcListNode{
-        Proc:        proc.Process{PID: 3, Name: "nvim"},
-        Depth:       1,
-        HasChildren: false,
-        TreePrefix:  "  └─ ",
-        StatPrefix:  "     ",
-    }
-    line := m.renderProc(node, false, 80)
-    plain := stripANSI(line)
-    if strings.Contains(plain, "▶") || strings.Contains(plain, "▼") {
-        t.Errorf("no triangle expected for node without children, got: %s", plain)
-    }
-    if !strings.Contains(plain, "└─") {
-        t.Errorf("expected tree connector └─ in output, got: %s", plain)
-    }
+	m := ProcListModel{}
+	node := ProcListNode{
+		Proc:        proc.Process{PID: 3, Name: "nvim"},
+		Depth:       1,
+		HasChildren: false,
+		TreePrefix:  "  └─ ",
+		StatPrefix:  "     ",
+	}
+	line := m.renderProc(node, false, 80)
+	plain := stripANSI(line)
+	if strings.Contains(plain, "▶") || strings.Contains(plain, "▼") {
+		t.Errorf("no triangle expected for node without children, got: %s", plain)
+	}
+	if !strings.Contains(plain, "└─") {
+		t.Errorf("expected tree connector └─ in output, got: %s", plain)
+	}
 }
 
 // ---------- assignTreePrefixes ----------
 
 func TestAssignTreePrefixes_Depth0_Unchanged(t *testing.T) {
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Depth: 0},
-    }
-    assignTreePrefixes(nodes)
-    if nodes[0].TreePrefix != "" || nodes[0].StatPrefix != "" {
-        t.Error("pane header (depth 0) should have empty prefixes")
-    }
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Depth: 0},
+	}
+	assignTreePrefixes(nodes)
+	if nodes[0].TreePrefix != "" || nodes[0].StatPrefix != "" {
+		t.Error("pane header (depth 0) should have empty prefixes")
+	}
 }
 
 func TestAssignTreePrefixes_SingleDepth1_GetsLastConnector(t *testing.T) {
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Depth: 0},
-        {Proc: proc.Process{PID: 1}, Depth: 1},
-    }
-    assignTreePrefixes(nodes)
-    if nodes[1].TreePrefix != "  └─ " {
-        t.Errorf("single depth-1 should get └─, got %q", nodes[1].TreePrefix)
-    }
-    if nodes[1].StatPrefix != "     " {
-        t.Errorf("single depth-1 StatPrefix should be 5 spaces, got %q", nodes[1].StatPrefix)
-    }
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Depth: 0},
+		{Proc: proc.Process{PID: 1}, Depth: 1},
+	}
+	assignTreePrefixes(nodes)
+	if nodes[1].TreePrefix != "  └─ " {
+		t.Errorf("single depth-1 should get └─, got %q", nodes[1].TreePrefix)
+	}
+	if nodes[1].StatPrefix != "     " {
+		t.Errorf("single depth-1 StatPrefix should be 5 spaces, got %q", nodes[1].StatPrefix)
+	}
 }
 
 func TestAssignTreePrefixes_TwoDepth1_CorrectConnectors(t *testing.T) {
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Depth: 0},
-        {Proc: proc.Process{PID: 1}, Depth: 1},
-        {Proc: proc.Process{PID: 2}, Depth: 1},
-    }
-    assignTreePrefixes(nodes)
-    if nodes[1].TreePrefix != "  ├─ " {
-        t.Errorf("first of two depth-1 should get ├─, got %q", nodes[1].TreePrefix)
-    }
-    if nodes[1].StatPrefix != "  │  " {
-        t.Errorf("first of two depth-1 StatPrefix should be '  │  ', got %q", nodes[1].StatPrefix)
-    }
-    if nodes[2].TreePrefix != "  └─ " {
-        t.Errorf("last depth-1 should get └─, got %q", nodes[2].TreePrefix)
-    }
-    if nodes[2].StatPrefix != "     " {
-        t.Errorf("last depth-1 StatPrefix should be 5 spaces, got %q", nodes[2].StatPrefix)
-    }
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Depth: 0},
+		{Proc: proc.Process{PID: 1}, Depth: 1},
+		{Proc: proc.Process{PID: 2}, Depth: 1},
+	}
+	assignTreePrefixes(nodes)
+	if nodes[1].TreePrefix != "  ├─ " {
+		t.Errorf("first of two depth-1 should get ├─, got %q", nodes[1].TreePrefix)
+	}
+	if nodes[1].StatPrefix != "  │  " {
+		t.Errorf("first of two depth-1 StatPrefix should be '  │  ', got %q", nodes[1].StatPrefix)
+	}
+	if nodes[2].TreePrefix != "  └─ " {
+		t.Errorf("last depth-1 should get └─, got %q", nodes[2].TreePrefix)
+	}
+	if nodes[2].StatPrefix != "     " {
+		t.Errorf("last depth-1 StatPrefix should be 5 spaces, got %q", nodes[2].StatPrefix)
+	}
 }
 
 func TestAssignTreePrefixes_Depth2UnderNonLastParent(t *testing.T) {
-    // pane0, procA (non-last), procA-child (last under procA), procB (last)
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Depth: 0},
-        {Proc: proc.Process{PID: 1}, Depth: 1}, // non-last
-        {Proc: proc.Process{PID: 2}, Depth: 2}, // last under PID 1
-        {Proc: proc.Process{PID: 3}, Depth: 1}, // last
-    }
-    assignTreePrefixes(nodes)
-    // procA-child: parent (depth-1, PID 1) is non-last → ancestor cont = "│  "
-    // procA-child is the only child → isLast → "└─ "
-    if nodes[2].TreePrefix != "  │  └─ " {
-        t.Errorf("depth-2 under non-last parent should get '  │  └─ ', got %q", nodes[2].TreePrefix)
-    }
-    if nodes[2].StatPrefix != "  │     " {
-        t.Errorf("depth-2 StatPrefix under non-last parent should be '  │     ', got %q", nodes[2].StatPrefix)
-    }
+	// pane0, procA (non-last), procA-child (last under procA), procB (last)
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Depth: 0},
+		{Proc: proc.Process{PID: 1}, Depth: 1}, // non-last
+		{Proc: proc.Process{PID: 2}, Depth: 2}, // last under PID 1
+		{Proc: proc.Process{PID: 3}, Depth: 1}, // last
+	}
+	assignTreePrefixes(nodes)
+	// procA-child: parent (depth-1, PID 1) is non-last → ancestor cont = "│  "
+	// procA-child is the only child → isLast → "└─ "
+	if nodes[2].TreePrefix != "  │  └─ " {
+		t.Errorf("depth-2 under non-last parent should get '  │  └─ ', got %q", nodes[2].TreePrefix)
+	}
+	if nodes[2].StatPrefix != "  │     " {
+		t.Errorf("depth-2 StatPrefix under non-last parent should be '  │     ', got %q", nodes[2].StatPrefix)
+	}
 }
 
 func TestAssignTreePrefixes_Depth2UnderLastParent(t *testing.T) {
-    // pane0, procA (last), procA-child1 (non-last), procA-child2 (last)
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Depth: 0},
-        {Proc: proc.Process{PID: 1}, Depth: 1}, // last depth-1
-        {Proc: proc.Process{PID: 2}, Depth: 2}, // non-last
-        {Proc: proc.Process{PID: 3}, Depth: 2}, // last
-    }
-    assignTreePrefixes(nodes)
-    // parent (PID 1) is last → ancestor cont = "   " (3 spaces)
-    if nodes[2].TreePrefix != "     ├─ " {
-        t.Errorf("non-last depth-2 under last parent, got %q", nodes[2].TreePrefix)
-    }
-    if nodes[2].StatPrefix != "     │  " {
-        t.Errorf("non-last depth-2 StatPrefix under last parent, got %q", nodes[2].StatPrefix)
-    }
-    if nodes[3].TreePrefix != "     └─ " {
-        t.Errorf("last depth-2 under last parent, got %q", nodes[3].TreePrefix)
-    }
-    if nodes[3].StatPrefix != "        " {
-        t.Errorf("last depth-2 StatPrefix (8 spaces), got %q", nodes[3].StatPrefix)
-    }
+	// pane0, procA (last), procA-child1 (non-last), procA-child2 (last)
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Depth: 0},
+		{Proc: proc.Process{PID: 1}, Depth: 1}, // last depth-1
+		{Proc: proc.Process{PID: 2}, Depth: 2}, // non-last
+		{Proc: proc.Process{PID: 3}, Depth: 2}, // last
+	}
+	assignTreePrefixes(nodes)
+	// parent (PID 1) is last → ancestor cont = "   " (3 spaces)
+	if nodes[2].TreePrefix != "     ├─ " {
+		t.Errorf("non-last depth-2 under last parent, got %q", nodes[2].TreePrefix)
+	}
+	if nodes[2].StatPrefix != "     │  " {
+		t.Errorf("non-last depth-2 StatPrefix under last parent, got %q", nodes[2].StatPrefix)
+	}
+	if nodes[3].TreePrefix != "     └─ " {
+		t.Errorf("last depth-2 under last parent, got %q", nodes[3].TreePrefix)
+	}
+	if nodes[3].StatPrefix != "        " {
+		t.Errorf("last depth-2 StatPrefix (8 spaces), got %q", nodes[3].StatPrefix)
+	}
 }
 
 func TestAssignTreePrefixes_CrossPaneBoundary_ResetsSiblingCount(t *testing.T) {
-    // depth-1 in pane 1 should be treated as last (only child in its pane)
-    nodes := []ProcListNode{
-        {IsPaneHeader: true, Depth: 0},
-        {Proc: proc.Process{PID: 1}, Depth: 1},
-        {IsPaneHeader: true, Depth: 0},
-        {Proc: proc.Process{PID: 2}, Depth: 1},
-    }
-    assignTreePrefixes(nodes)
-    // PID 1 is last in pane 0 (next node at same depth is in another pane, separated by depth-0)
-    if nodes[1].TreePrefix != "  └─ " {
-        t.Errorf("depth-1 in pane 0 should get └─, got %q", nodes[1].TreePrefix)
-    }
-    // PID 2 is last in pane 1
-    if nodes[3].TreePrefix != "  └─ " {
-        t.Errorf("depth-1 in pane 1 should get └─, got %q", nodes[3].TreePrefix)
-    }
+	// depth-1 in pane 1 should be treated as last (only child in its pane)
+	nodes := []ProcListNode{
+		{IsPaneHeader: true, Depth: 0},
+		{Proc: proc.Process{PID: 1}, Depth: 1},
+		{IsPaneHeader: true, Depth: 0},
+		{Proc: proc.Process{PID: 2}, Depth: 1},
+	}
+	assignTreePrefixes(nodes)
+	// PID 1 is last in pane 0 (next node at same depth is in another pane, separated by depth-0)
+	if nodes[1].TreePrefix != "  └─ " {
+		t.Errorf("depth-1 in pane 0 should get └─, got %q", nodes[1].TreePrefix)
+	}
+	// PID 2 is last in pane 1
+	if nodes[3].TreePrefix != "  └─ " {
+		t.Errorf("depth-1 in pane 1 should get └─, got %q", nodes[3].TreePrefix)
+	}
 }
 
 // ---------- renderPaneHeader right-align tests ----------
 
 func paneNode(paneIndex int, cwd string) ProcListNode {
-    return ProcListNode{
-        IsPaneHeader: true,
-        Pane:         tmux.Pane{PaneIndex: paneIndex, CWD: cwd},
-    }
+	return ProcListNode{
+		IsPaneHeader: true,
+		Pane:         tmux.Pane{PaneIndex: paneIndex, CWD: cwd},
+	}
 }
 
 func TestRenderPaneHeader_RightAlign_PathAppearsAtRight(t *testing.T) {
-    p := ProcListModel{
-        cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
-    }
-    node := paneNode(0, "/home/user/project")
-    innerW := 40
-    line := p.renderPaneHeader(node, false, innerW, false)
-    plain := stripANSI(line)
-    runes := []rune(plain)
-    if len(runes) != innerW {
-        t.Errorf("expected line width %d, got %d: %q", innerW, len(runes), plain)
-    }
-    if !strings.HasSuffix(strings.TrimRight(plain, " "), "/home/user/project") {
-        t.Errorf("expected path at right edge, got: %q", plain)
-    }
+	p := ProcListModel{
+		cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
+	}
+	node := paneNode(0, "/home/user/project")
+	innerW := 40
+	line := p.renderPaneHeader(node, false, innerW, false)
+	plain := stripANSI(line)
+	runes := []rune(plain)
+	if len(runes) != innerW {
+		t.Errorf("expected line width %d, got %d: %q", innerW, len(runes), plain)
+	}
+	if !strings.HasSuffix(strings.TrimRight(plain, " "), "/home/user/project") {
+		t.Errorf("expected path at right edge, got: %q", plain)
+	}
 }
 
 func TestRenderPaneHeader_RightAlign_FillCharsPresent(t *testing.T) {
-    p := ProcListModel{
-        cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
-    }
-    node := paneNode(1, "/tmp")
-    innerW := 40
-    line := p.renderPaneHeader(node, false, innerW, false)
-    plain := stripANSI(line)
-    if !strings.Contains(plain, "─") {
-        t.Errorf("expected fill chars (─) in right-aligned line, got: %q", plain)
-    }
+	p := ProcListModel{
+		cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
+	}
+	node := paneNode(1, "/tmp")
+	innerW := 40
+	line := p.renderPaneHeader(node, false, innerW, false)
+	plain := stripANSI(line)
+	if !strings.Contains(plain, "─") {
+		t.Errorf("expected fill chars (─) in right-aligned line, got: %q", plain)
+	}
 }
 
 func TestRenderPaneHeader_LeftAlign_NoFillChars(t *testing.T) {
-    p := ProcListModel{
-        cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: false}},
-    }
-    node := paneNode(0, "/tmp")
-    innerW := 40
-    line := p.renderPaneHeader(node, false, innerW, false)
-    plain := stripANSI(line)
-    if strings.Contains(plain, "─") {
-        t.Errorf("expected no fill chars in left-aligned line, got: %q", plain)
-    }
+	p := ProcListModel{
+		cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: false}},
+	}
+	node := paneNode(0, "/tmp")
+	innerW := 40
+	line := p.renderPaneHeader(node, false, innerW, false)
+	plain := stripANSI(line)
+	if strings.Contains(plain, "─") {
+		t.Errorf("expected no fill chars in left-aligned line, got: %q", plain)
+	}
 }
 
 func TestRenderPaneHeader_RightAlign_NoCWD_NoFill(t *testing.T) {
-    p := ProcListModel{
-        cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
-    }
-    node := paneNode(0, "")
-    innerW := 40
-    line := p.renderPaneHeader(node, false, innerW, false)
-    plain := stripANSI(line)
-    if strings.Contains(plain, "─") {
-        t.Errorf("expected no fill when CWD is empty, got: %q", plain)
-    }
+	p := ProcListModel{
+		cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
+	}
+	node := paneNode(0, "")
+	innerW := 40
+	line := p.renderPaneHeader(node, false, innerW, false)
+	plain := stripANSI(line)
+	if strings.Contains(plain, "─") {
+		t.Errorf("expected no fill when CWD is empty, got: %q", plain)
+	}
 }
 
 func TestRenderPaneHeader_RightAlign_Selected_ContainsLabelAndPath(t *testing.T) {
-    p := ProcListModel{
-        cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
-    }
-    node := paneNode(0, "/home/user/project")
-    innerW := 40
-    line := p.renderPaneHeader(node, true, innerW, false)
-    plain := stripANSI(line)
-    if !strings.Contains(plain, "pane 0") {
-        t.Errorf("expected label in selected right-align line, got: %q", plain)
-    }
-    if !strings.Contains(plain, "/home/user/project") {
-        t.Errorf("expected path in selected right-align line, got: %q", plain)
-    }
-    // selected rows use space padding, not separator chars
-    if strings.Contains(plain, "─") {
-        t.Errorf("selected right-align line should not contain separator chars, got: %q", plain)
-    }
+	p := ProcListModel{
+		cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
+	}
+	node := paneNode(0, "/home/user/project")
+	innerW := 40
+	line := p.renderPaneHeader(node, true, innerW, false)
+	plain := stripANSI(line)
+	if !strings.Contains(plain, "pane 0") {
+		t.Errorf("expected label in selected right-align line, got: %q", plain)
+	}
+	if !strings.Contains(plain, "/home/user/project") {
+		t.Errorf("expected path in selected right-align line, got: %q", plain)
+	}
+	// selected rows use space padding, not separator chars
+	if strings.Contains(plain, "─") {
+		t.Errorf("selected right-align line should not contain separator chars, got: %q", plain)
+	}
 }
 
 // ---------- windowAlertFromMap ----------
 
 func TestWindowAlertFromMap_ReturnsNilForEmptyMap(t *testing.T) {
-    if windowAlertFromMap(nil, "s", 0) != nil {
-        t.Error("expected nil for nil map")
-    }
-    if windowAlertFromMap(map[string]db.Alert{}, "s", 0) != nil {
-        t.Error("expected nil for empty map")
-    }
+	if windowAlertFromMap(nil, "s", 0) != nil {
+		t.Error("expected nil for nil map")
+	}
+	if windowAlertFromMap(map[string]db.Alert{}, "s", 0) != nil {
+		t.Error("expected nil for empty map")
+	}
 }
 
 func TestWindowAlertFromMap_ReturnsWindowLevelAlert(t *testing.T) {
-    a := db.Alert{Target: "s:0", Level: db.LevelInfo}
-    m := map[string]db.Alert{"s:0": a}
-    got := windowAlertFromMap(m, "s", 0)
-    if got == nil || got.Target != "s:0" {
-        t.Errorf("expected alert for s:0, got %v", got)
-    }
+	a := db.Alert{Target: "s:0", Level: db.LevelInfo}
+	m := map[string]db.Alert{"s:0": a}
+	got := windowAlertFromMap(m, "s", 0)
+	if got == nil || got.Target != "s:0" {
+		t.Errorf("expected alert for s:0, got %v", got)
+	}
 }
 
 func TestWindowAlertFromMap_IgnoresPaneLevelAlert(t *testing.T) {
-    // Pane-level alerts (session:N.P) must NOT appear on window headers —
-    // they are displayed exclusively on their pane row to avoid duplication.
-    a := db.Alert{Target: "s:0.1", Level: db.LevelInfo}
-    m := map[string]db.Alert{"s:0.1": a}
-    if windowAlertFromMap(m, "s", 0) != nil {
-        t.Error("expected nil — pane-level alert s:0.1 must not appear on window 0 header")
-    }
+	// Pane-level alerts (session:N.P) must NOT appear on window headers —
+	// they are displayed exclusively on their pane row to avoid duplication.
+	a := db.Alert{Target: "s:0.1", Level: db.LevelInfo}
+	m := map[string]db.Alert{"s:0.1": a}
+	if windowAlertFromMap(m, "s", 0) != nil {
+		t.Error("expected nil — pane-level alert s:0.1 must not appear on window 0 header")
+	}
 }
 
 func TestWindowAlertFromMap_ReturnsWindowAlertAlongsidePaneAlerts(t *testing.T) {
-    // A window-level alert coexists with pane alerts; only the window key is returned.
-    win := db.Alert{Target: "s:1", Level: db.LevelWarn}
-    pane := db.Alert{Target: "s:1.0", Level: db.LevelError}
-    m := map[string]db.Alert{"s:1": win, "s:1.0": pane}
-    got := windowAlertFromMap(m, "s", 1)
-    if got == nil || got.Target != "s:1" {
-        t.Errorf("expected window-level alert s:1, got %v", got)
-    }
+	// A window-level alert coexists with pane alerts; only the window key is returned.
+	win := db.Alert{Target: "s:1", Level: db.LevelWarn}
+	pane := db.Alert{Target: "s:1.0", Level: db.LevelError}
+	m := map[string]db.Alert{"s:1": win, "s:1.0": pane}
+	got := windowAlertFromMap(m, "s", 1)
+	if got == nil || got.Target != "s:1" {
+		t.Errorf("expected window-level alert s:1, got %v", got)
+	}
 }
 
 func TestWindowAlertFromMap_IgnoresOtherWindows(t *testing.T) {
-    a := db.Alert{Target: "s:2", Level: db.LevelInfo}
-    m := map[string]db.Alert{"s:2": a}
-    if windowAlertFromMap(m, "s", 0) != nil {
-        t.Error("expected nil — window 2 alert should not match window 0")
-    }
+	a := db.Alert{Target: "s:2", Level: db.LevelInfo}
+	m := map[string]db.Alert{"s:2": a}
+	if windowAlertFromMap(m, "s", 0) != nil {
+		t.Error("expected nil — window 2 alert should not match window 0")
+	}
 }
 
 // ---------- SetSessionData ----------
 
 func buildSessionPanes() []tmux.Pane {
-    return []tmux.Pane{
-        // window 0, pane 0 — shell PID 10
-        {Session: "s", WindowIndex: 0, PaneIndex: 0, WindowName: "editor", CWD: "/proj", PanePID: 10},
-        // window 0, pane 1 — shell PID 11, same CWD
-        {Session: "s", WindowIndex: 0, PaneIndex: 1, WindowName: "editor", CWD: "/proj", PanePID: 11},
-        // window 1, pane 0 — shell PID 20, different CWD
-        {Session: "s", WindowIndex: 1, PaneIndex: 0, WindowName: "server", CWD: "/other", PanePID: 20},
-    }
+	return []tmux.Pane{
+		// window 0, pane 0 — shell PID 10
+		{Session: "s", WindowIndex: 0, PaneIndex: 0, WindowName: "editor", CWD: "/proj", PanePID: 10},
+		// window 0, pane 1 — shell PID 11, same CWD
+		{Session: "s", WindowIndex: 0, PaneIndex: 1, WindowName: "editor", CWD: "/proj", PanePID: 11},
+		// window 1, pane 0 — shell PID 20, different CWD
+		{Session: "s", WindowIndex: 1, PaneIndex: 0, WindowName: "server", CWD: "/other", PanePID: 20},
+	}
 }
 
 func TestSetSessionData_EmitsWindowHeaders(t *testing.T) {
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    if !m.inSessionMode {
-        t.Error("expected inSessionMode=true after SetSessionData")
-    }
-    if len(m.nodes) == 0 {
-        t.Fatal("expected nodes to be populated")
-    }
-    if !m.nodes[0].IsWindowHeader {
-        t.Error("expected first node to be a window header")
-    }
-    if m.nodes[0].Pane.WindowIndex != 0 {
-        t.Errorf("expected window index 0, got %d", m.nodes[0].Pane.WindowIndex)
-    }
-    if m.nodes[0].Pane.WindowName != "editor" {
-        t.Errorf("expected window name 'editor', got %q", m.nodes[0].Pane.WindowName)
-    }
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	if !m.inSessionMode {
+		t.Error("expected inSessionMode=true after SetSessionData")
+	}
+	if len(m.nodes) == 0 {
+		t.Fatal("expected nodes to be populated")
+	}
+	if !m.nodes[0].IsWindowHeader {
+		t.Error("expected first node to be a window header")
+	}
+	if m.nodes[0].Pane.WindowIndex != 0 {
+		t.Errorf("expected window index 0, got %d", m.nodes[0].Pane.WindowIndex)
+	}
+	if m.nodes[0].Pane.WindowName != "editor" {
+		t.Errorf("expected window name 'editor', got %q", m.nodes[0].Pane.WindowName)
+	}
 }
 
 func TestSetSessionData_WindowsOrderedByIndex(t *testing.T) {
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    var winHeaders []int
-    for _, n := range m.nodes {
-        if n.IsWindowHeader {
-            winHeaders = append(winHeaders, n.Pane.WindowIndex)
-        }
-    }
-    if len(winHeaders) != 2 {
-        t.Fatalf("expected 2 window headers, got %d", len(winHeaders))
-    }
-    if winHeaders[0] != 0 || winHeaders[1] != 1 {
-        t.Errorf("expected windows [0, 1], got %v", winHeaders)
-    }
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	var winHeaders []int
+	for _, n := range m.nodes {
+		if n.IsWindowHeader {
+			winHeaders = append(winHeaders, n.Pane.WindowIndex)
+		}
+	}
+	if len(winHeaders) != 2 {
+		t.Fatalf("expected 2 window headers, got %d", len(winHeaders))
+	}
+	if winHeaders[0] != 0 || winHeaders[1] != 1 {
+		t.Errorf("expected windows [0, 1], got %v", winHeaders)
+	}
 }
 
 func TestSetSessionData_SuppressPaneCWDWhenMatchesWindowCWD(t *testing.T) {
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    // pane 0 and pane 1 of window 0 both have CWD "/proj" == window CWD — should be suppressed
-    for _, n := range m.nodes {
-        if n.IsPaneHeader && n.Pane.WindowIndex == 0 {
-            if n.Pane.CWD != "" {
-                t.Errorf("expected pane CWD suppressed for window 0 pane %d, got %q",
-                    n.Pane.PaneIndex, n.Pane.CWD)
-            }
-        }
-    }
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	// pane 0 and pane 1 of window 0 both have CWD "/proj" == window CWD — should be suppressed
+	for _, n := range m.nodes {
+		if n.IsPaneHeader && n.Pane.WindowIndex == 0 {
+			if n.Pane.CWD != "" {
+				t.Errorf("expected pane CWD suppressed for window 0 pane %d, got %q",
+					n.Pane.PaneIndex, n.Pane.CWD)
+			}
+		}
+	}
 }
 
 func TestSetSessionData_ShowsPaneCWDWhenDivergent(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "s", WindowIndex: 0, PaneIndex: 0, CWD: "/proj", PanePID: 10},
-        {Session: "s", WindowIndex: 0, PaneIndex: 1, CWD: "/other", PanePID: 11}, // divergent
-    }
-    var m ProcListModel
-    m.SetSessionData(panes, "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    found := false
-    for _, n := range m.nodes {
-        if n.IsPaneHeader && n.Pane.PaneIndex == 1 {
-            found = true
-            if n.Pane.CWD != "/other" {
-                t.Errorf("expected divergent pane CWD '/other', got %q", n.Pane.CWD)
-            }
-        }
-    }
-    if !found {
-        t.Error("pane 1 header not found")
-    }
+	panes := []tmux.Pane{
+		{Session: "s", WindowIndex: 0, PaneIndex: 0, CWD: "/proj", PanePID: 10},
+		{Session: "s", WindowIndex: 0, PaneIndex: 1, CWD: "/other", PanePID: 11}, // divergent
+	}
+	var m ProcListModel
+	m.SetSessionData(panes, "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	found := false
+	for _, n := range m.nodes {
+		if n.IsPaneHeader && n.Pane.PaneIndex == 1 {
+			found = true
+			if n.Pane.CWD != "/other" {
+				t.Errorf("expected divergent pane CWD '/other', got %q", n.Pane.CWD)
+			}
+		}
+	}
+	if !found {
+		t.Error("pane 1 header not found")
+	}
 }
 
 func TestSetSessionData_SetsWindowAlert(t *testing.T) {
-    a := db.Alert{Target: "s:0", Level: db.LevelInfo}
-    alertMap := map[string]db.Alert{"s:0": a}
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, alertMap, config.Config{},
-    )
-    if m.nodes[0].Alert == nil {
-        t.Error("expected window header to carry alert")
-    }
+	a := db.Alert{Target: "s:0", Level: db.LevelInfo}
+	alertMap := map[string]db.Alert{"s:0": a}
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, alertMap, config.Config{},
+	)
+	if m.nodes[0].Alert == nil {
+		t.Error("expected window header to carry alert")
+	}
 }
 
 func TestSetSessionData_StoresSessionAlert(t *testing.T) {
-    a := db.Alert{Target: "s", Level: db.LevelWarn, Reason: "needs attention"}
-    alertMap := map[string]db.Alert{"s": a}
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, alertMap, config.Config{},
-    )
-    if m.sessionAlert == nil {
-        t.Fatal("expected sessionAlert to be set")
-    }
-    if m.sessionAlert.Reason != "needs attention" {
-        t.Errorf("unexpected reason: %q", m.sessionAlert.Reason)
-    }
+	a := db.Alert{Target: "s", Level: db.LevelWarn, Reason: "needs attention"}
+	alertMap := map[string]db.Alert{"s": a}
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, alertMap, config.Config{},
+	)
+	if m.sessionAlert == nil {
+		t.Fatal("expected sessionAlert to be set")
+	}
+	if m.sessionAlert.Reason != "needs attention" {
+		t.Errorf("unexpected reason: %q", m.sessionAlert.Reason)
+	}
 }
 
 func TestSetSessionData_ClearsSessionAlertWhenAbsent(t *testing.T) {
-    a := db.Alert{Target: "s", Level: db.LevelWarn, Reason: "old alert"}
-    alertMap := map[string]db.Alert{"s": a}
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, alertMap, config.Config{},
-    )
-    // second call with no session-level alert — field must be cleared
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    if m.sessionAlert != nil {
-        t.Errorf("expected sessionAlert to be nil, got %+v", m.sessionAlert)
-    }
+	a := db.Alert{Target: "s", Level: db.LevelWarn, Reason: "old alert"}
+	alertMap := map[string]db.Alert{"s": a}
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, alertMap, config.Config{},
+	)
+	// second call with no session-level alert — field must be cleared
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	if m.sessionAlert != nil {
+		t.Errorf("expected sessionAlert to be nil, got %+v", m.sessionAlert)
+	}
 }
 
 func TestSetSessionData_SessionAlertRenderedInTitle(t *testing.T) {
-    a := db.Alert{Target: "s", Level: db.LevelWarn, Reason: "needs attention"}
-    alertMap := map[string]db.Alert{"s": a}
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, alertMap, config.Config{},
-    )
-    rendered := m.Render(80, 20, false, " [l] s ")
-    topLine := strings.SplitN(rendered, "\n", 2)[0]
-    plain := stripANSI(topLine)
-    if !strings.Contains(plain, "needs attention") {
-        t.Errorf("expected alert reason in top border, got: %q", plain)
-    }
+	a := db.Alert{Target: "s", Level: db.LevelWarn, Reason: "needs attention"}
+	alertMap := map[string]db.Alert{"s": a}
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, alertMap, config.Config{},
+	)
+	rendered := m.Render(80, 20, false, " [l] s ")
+	topLine := strings.SplitN(rendered, "\n", 2)[0]
+	plain := stripANSI(topLine)
+	if !strings.Contains(plain, "needs attention") {
+		t.Errorf("expected alert reason in top border, got: %q", plain)
+	}
 }
 
 func TestSetSessionData_ResetsCursorOnSessionChange(t *testing.T) {
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    m.cursor = 3
-    m.offset = 2
-    // change to different session — should reset cursor and offset
-    m.SetSessionData(buildSessionPanes(), "other",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    if m.cursor != 0 || m.offset != 0 {
-        t.Errorf("expected cursor=0 offset=0 after session change, got cursor=%d offset=%d",
-            m.cursor, m.offset)
-    }
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	m.cursor = 3
+	m.offset = 2
+	// change to different session — should reset cursor and offset
+	m.SetSessionData(buildSessionPanes(), "other",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	if m.cursor != 0 || m.offset != 0 {
+		t.Errorf("expected cursor=0 offset=0 after session change, got cursor=%d offset=%d",
+			m.cursor, m.offset)
+	}
 }
 
 func TestSetSessionData_SetWindowDataClearsSessionMode(t *testing.T) {
-    pane := buildTestPane(100)
-    var m ProcListModel
-    m.SetSessionData(buildSessionPanes(), "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    if !m.inSessionMode {
-        t.Fatal("expected inSessionMode=true")
-    }
-    m.SetWindowData([]tmux.Pane{pane}, "test", 0,
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    if m.inSessionMode {
-        t.Error("expected inSessionMode=false after SetWindowData")
-    }
+	pane := buildTestPane(100)
+	var m ProcListModel
+	m.SetSessionData(buildSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	if !m.inSessionMode {
+		t.Fatal("expected inSessionMode=true")
+	}
+	m.SetWindowData([]tmux.Pane{pane}, "test", 0,
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	if m.inSessionMode {
+		t.Error("expected inSessionMode=false after SetWindowData")
+	}
 }
 
 // ---------- renderWindowHeader smoke test ----------
 
 func TestRender_SessionMode_ContainsWindowHeader(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "s", WindowIndex: 0, PaneIndex: 0, WindowName: "edit", CWD: "/proj", PanePID: 500},
-        {Session: "s", WindowIndex: 1, PaneIndex: 0, WindowName: "run", CWD: "/proj", PanePID: 501},
-    }
-    var m ProcListModel
-    m.SetSessionData(panes, "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    out := m.Render(80, 20, false, "procs")
-    plain := stripANSI(out)
-    if !strings.Contains(plain, "Win 1") {
-        t.Errorf("expected 'Win 1' in output, got:\n%s", plain)
-    }
+	panes := []tmux.Pane{
+		{Session: "s", WindowIndex: 0, PaneIndex: 0, WindowName: "edit", CWD: "/proj", PanePID: 500},
+		{Session: "s", WindowIndex: 1, PaneIndex: 0, WindowName: "run", CWD: "/proj", PanePID: 501},
+	}
+	var m ProcListModel
+	m.SetSessionData(panes, "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	out := m.Render(80, 20, false, "procs")
+	plain := stripANSI(out)
+	if !strings.Contains(plain, "Win 1") {
+		t.Errorf("expected 'Win 1' in output, got:\n%s", plain)
+	}
 }
 
 func TestRender_SessionMode_PaneHeaderIndented(t *testing.T) {
-    panes := []tmux.Pane{
-        {Session: "s", WindowIndex: 0, PaneIndex: 0, CWD: "/proj", PanePID: 600},
-    }
-    var m ProcListModel
-    m.SetSessionData(panes, "s",
-        nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
-    )
-    out := m.Render(80, 20, false, "procs")
-    plain := stripANSI(out)
-    // pane 0 should appear indented with 4 leading spaces
-    if !strings.Contains(plain, "    pane 0") {
-        t.Errorf("expected '    pane 0' (4-space indent) in output, got:\n%s", plain)
-    }
+	panes := []tmux.Pane{
+		{Session: "s", WindowIndex: 0, PaneIndex: 0, CWD: "/proj", PanePID: 600},
+	}
+	var m ProcListModel
+	m.SetSessionData(panes, "s",
+		nil, map[int32]string{}, map[string]git.Info{}, nil, config.Config{},
+	)
+	out := m.Render(80, 20, false, "procs")
+	plain := stripANSI(out)
+	// pane 0 should appear indented with 4 leading spaces
+	if !strings.Contains(plain, "    pane 0") {
+		t.Errorf("expected '    pane 0' (4-space indent) in output, got:\n%s", plain)
+	}
 }

--- a/internal/tui/proclist_tree.go
+++ b/internal/tui/proclist_tree.go
@@ -1,130 +1,131 @@
 package tui
 
 import (
-    "fmt"
-    "sort"
+	"fmt"
+	"sort"
 
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/proc"
-    "github.com/rtalexk/demux/internal/tmux"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func sortPanes(panes []tmux.Pane) []tmux.Pane {
-    sorted := make([]tmux.Pane, len(panes))
-    copy(sorted, panes)
-    sort.Slice(sorted, func(i, j int) bool { return sorted[i].PaneIndex < sorted[j].PaneIndex })
-    return sorted
+	sorted := make([]tmux.Pane, len(panes))
+	copy(sorted, panes)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].PaneIndex < sorted[j].PaneIndex })
+	return sorted
 }
 
 // assignTreePrefixes fills TreePrefix and StatPrefix on every non-header node.
 // It must be called after p.nodes is fully built by SetWindowData or SetSessionData.
 //
 // Connectors used:
-//   "├─ " non-last sibling at this depth
-//   "└─ " last sibling at this depth
-//   "│  " ancestor continuation (non-last ancestor)
-//   "   " ancestor continuation (last ancestor)
+//
+//	"├─ " non-last sibling at this depth
+//	"└─ " last sibling at this depth
+//	"│  " ancestor continuation (non-last ancestor)
+//	"   " ancestor continuation (last ancestor)
 //
 // The base indent is 2 spaces (pane-level offset), matching the current
 // plain-indent scheme. Each connector/continuation segment is 3 visual columns.
 func assignTreePrefixes(nodes []ProcListNode) {
-    n := len(nodes)
-    for i := range nodes {
-        nd := &nodes[i]
-        if nd.Depth == 0 {
-            continue
-        }
-        depth := nd.Depth
+	n := len(nodes)
+	for i := range nodes {
+		nd := &nodes[i]
+		if nd.Depth == 0 {
+			continue
+		}
+		depth := nd.Depth
 
-        // Determine if this node is the last sibling at its depth.
-        // Stop scanning at a pane header (depth 0) or a shallower depth.
-        isLast := true
-        for j := i + 1; j < n; j++ {
-            jd := nodes[j].Depth
-            if jd == 0 || jd < depth {
-                break
-            }
-            if jd == depth {
-                isLast = false
-                break
-            }
-        }
+		// Determine if this node is the last sibling at its depth.
+		// Stop scanning at a pane header (depth 0) or a shallower depth.
+		isLast := true
+		for j := i + 1; j < n; j++ {
+			jd := nodes[j].Depth
+			if jd == 0 || jd < depth {
+				break
+			}
+			if jd == depth {
+				isLast = false
+				break
+			}
+		}
 
-        // Build the ancestor continuation chain for depths 1..depth-1.
-        // For each ancestor level, scan backward to find the nearest ancestor
-        // node at that depth and check whether it was itself last at that depth.
-        cont := "  " // base 2-space indent
-        for d := 1; d < depth; d++ {
-            ancestorIsLast := true
-            for j := i - 1; j >= 0; j-- {
-                if nodes[j].Depth == 0 {
-                    break // crossed pane boundary
-                }
-                if nodes[j].Depth == d {
-                    // Check whether this ancestor node is last at depth d.
-                    for k := j + 1; k < n; k++ {
-                        kd := nodes[k].Depth
-                        if kd == 0 || kd < d {
-                            break
-                        }
-                        if kd == d {
-                            ancestorIsLast = false
-                            break
-                        }
-                    }
-                    break
-                }
-            }
-            if ancestorIsLast {
-                cont += "   "
-            } else {
-                cont += "│  "
-            }
-        }
+		// Build the ancestor continuation chain for depths 1..depth-1.
+		// For each ancestor level, scan backward to find the nearest ancestor
+		// node at that depth and check whether it was itself last at that depth.
+		cont := "  " // base 2-space indent
+		for d := 1; d < depth; d++ {
+			ancestorIsLast := true
+			for j := i - 1; j >= 0; j-- {
+				if nodes[j].Depth == 0 {
+					break // crossed pane boundary
+				}
+				if nodes[j].Depth == d {
+					// Check whether this ancestor node is last at depth d.
+					for k := j + 1; k < n; k++ {
+						kd := nodes[k].Depth
+						if kd == 0 || kd < d {
+							break
+						}
+						if kd == d {
+							ancestorIsLast = false
+							break
+						}
+					}
+					break
+				}
+			}
+			if ancestorIsLast {
+				cont += "   "
+			} else {
+				cont += "│  "
+			}
+		}
 
-        if isLast {
-            nd.TreePrefix = cont + "└─ "
-            nd.StatPrefix = cont + "   "
-        } else {
-            nd.TreePrefix = cont + "├─ "
-            nd.StatPrefix = cont + "│  "
-        }
-    }
+		if isLast {
+			nd.TreePrefix = cont + "└─ "
+			nd.StatPrefix = cont + "   "
+		} else {
+			nd.TreePrefix = cont + "├─ "
+			nd.StatPrefix = cont + "│  "
+		}
+	}
 }
 
 // aggStats returns the total CPU% and MemRSS for pr and all its descendants.
 func aggStats(pr proc.Process, tree map[int32][]proc.Process) (cpu float64, mem uint64) {
-    cpu = pr.CPU
-    mem = pr.MemRSS
-    for _, child := range tree[pr.PID] {
-        c, m := aggStats(child, tree)
-        cpu += c
-        mem += m
-    }
-    return
+	cpu = pr.CPU
+	mem = pr.MemRSS
+	for _, child := range tree[pr.PID] {
+		c, m := aggStats(child, tree)
+		cpu += c
+		mem += m
+	}
+	return
 }
 
 func containsStr(list []string, s string) bool {
-    for _, v := range list {
-        if v == s {
-            return true
-        }
-    }
-    return false
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 // windowAlertFromMap returns the window-level alert for a window from alertMap.
 // It checks only the exact window target ("session:N"); pane-level alerts
 // ("session:N.P") are not included so they appear only on their pane header.
 func windowAlertFromMap(alertMap map[string]db.Alert, session string, windowIndex int) *db.Alert {
-    if alertMap == nil {
-        return nil
-    }
-    exact := fmt.Sprintf("%s:%d", session, windowIndex)
-    if a, ok := alertMap[exact]; ok {
-        return &a
-    }
-    return nil
+	if alertMap == nil {
+		return nil
+	}
+	exact := fmt.Sprintf("%s:%d", session, windowIndex)
+	if a, ok := alertMap[exact]; ok {
+		return &a
+	}
+	return nil
 }
 
 // isSelectable reports whether the cursor may land on n.
@@ -132,51 +133,51 @@ func isSelectable(n ProcListNode) bool { return !n.IsIdle }
 
 // nodeDepth returns the logical depth of a node: 0 for pane headers, otherwise Depth.
 func nodeDepth(n ProcListNode) int {
-    if n.IsPaneHeader {
-        return 0
-    }
-    return n.Depth
+	if n.IsPaneHeader {
+		return 0
+	}
+	return n.Depth
 }
 
 // nodeRows returns how many terminal rows a node occupies when rendered.
 func nodeRows(n ProcListNode) int {
-    if n.IsIdle {
-        return 0
-    }
-    if n.IsPaneHeader || n.IsWindowHeader {
-        return 1
-    }
-    return 2 // process: name line + stats line
+	if n.IsIdle {
+		return 0
+	}
+	if n.IsPaneHeader || n.IsWindowHeader {
+		return 1
+	}
+	return 2 // process: name line + stats line
 }
 
 // windowMatchPos returns the match positions for a window in the current query
 // result, or nil if the window is not a match.
 func (p *ProcListModel) windowMatchPos(sessionName string, windowIdx int) []int {
-    for _, sm := range p.queryResult.Sessions {
-        if sm.Name != sessionName {
-            continue
-        }
-        for _, wm := range sm.Windows {
-            if wm.Index == windowIdx {
-                return wm.MatchPos
-            }
-        }
-    }
-    return nil
+	for _, sm := range p.queryResult.Sessions {
+		if sm.Name != sessionName {
+			continue
+		}
+		for _, wm := range sm.Windows {
+			if wm.Index == windowIdx {
+				return wm.MatchPos
+			}
+		}
+	}
+	return nil
 }
 
 // procMatchPos returns the match positions for a process in the current query
 // result, or nil if the process is not a match.
 func (p *ProcListModel) procMatchPos(sessionName string, pid int32) []int {
-    for _, sm := range p.queryResult.Sessions {
-        if sm.Name != sessionName {
-            continue
-        }
-        for _, pm := range sm.Procs {
-            if pm.PID == pid {
-                return pm.MatchPos
-            }
-        }
-    }
-    return nil
+	for _, sm := range p.queryResult.Sessions {
+		if sm.Name != sessionName {
+			continue
+		}
+		for _, pm := range sm.Procs {
+			if pm.PID == pid {
+				return pm.MatchPos
+			}
+		}
+	}
+	return nil
 }

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -1,36 +1,36 @@
 package tui
 
 import (
-    "strings"
+	"strings"
 
-    "github.com/charmbracelet/bubbles/textinput"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/lipgloss"
-    "github.com/mattn/go-runewidth"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 )
 
 // SearchInputModel wraps textinput with vim-style insert/normal mode.
 type SearchInputModel struct {
-    input  textinput.Model
-    insert bool // true = insert (editing) mode
+	input  textinput.Model
+	insert bool // true = insert (editing) mode
 }
 
 func NewSearchInputModel() SearchInputModel {
-    ti := textinput.New()
-    ti.Placeholder = "Press f to search..."
-    return SearchInputModel{input: ti}
+	ti := textinput.New()
+	ti.Placeholder = "Press f to search..."
+	return SearchInputModel{input: ti}
 }
 
 // EnterInsertMode focuses the input for typing.
 func (s *SearchInputModel) EnterInsertMode() {
-    s.insert = true
-    s.input.Focus()
+	s.insert = true
+	s.input.Focus()
 }
 
 // ExitInsertMode blurs the input; query text is preserved.
 func (s *SearchInputModel) ExitInsertMode() {
-    s.insert = false
-    s.input.Blur()
+	s.insert = false
+	s.input.Blur()
 }
 
 func (s SearchInputModel) IsInsert() bool { return s.insert }
@@ -45,42 +45,42 @@ func (s SearchInputModel) IsActive() bool { return s.input.Value() != "" }
 func (s *SearchInputModel) Clear() { s.input.SetValue("") }
 
 func (s SearchInputModel) Update(msg tea.Msg) (SearchInputModel, tea.Cmd) {
-    var cmd tea.Cmd
-    s.input, cmd = s.input.Update(msg)
-    return s, cmd
+	var cmd tea.Cmd
+	s.input, cmd = s.input.Update(msg)
+	return s, cmd
 }
 
 // View renders the 3-line bordered search box at the given width.
 func (s SearchInputModel) View(width int) string {
-    const title = "[f] Search"
+	const title = "[f] Search"
 
-    if s.insert {
-        s.input.Placeholder = "Type to search..."
-    } else {
-        s.input.Placeholder = "Press f to search..."
-    }
-    inputView := s.input.View()
-    innerWidth := width - 2 // subtract left + right border chars
+	if s.insert {
+		s.input.Placeholder = "Type to search..."
+	} else {
+		s.input.Placeholder = "Press f to search..."
+	}
+	inputView := s.input.View()
+	innerWidth := width - 2 // subtract left + right border chars
 
-    // Determine border color.
-    borderColor := activeTheme.ColorBorder
-    if s.IsActive() {
-        borderColor = activeTheme.ColorSession
-    }
-    borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	// Determine border color.
+	borderColor := activeTheme.ColorBorder
+	if s.IsActive() {
+		borderColor = activeTheme.ColorSession
+	}
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
 
-    // Style the inner content line.
-    innerStyle := lipgloss.NewStyle().Width(innerWidth)
-    mid := borderStyle.Render("│") + innerStyle.Render(inputView) + borderStyle.Render("│")
+	// Style the inner content line.
+	innerStyle := lipgloss.NewStyle().Width(innerWidth)
+	mid := borderStyle.Render("│") + innerStyle.Render(inputView) + borderStyle.Render("│")
 
-    // Build top border with title.
-    titleWidth := runewidth.StringWidth(title)
-    dashCount := innerWidth - titleWidth - 1
-    if dashCount < 0 {
-        dashCount = 0
-    }
-    top := borderStyle.Render("╭─") + title + borderStyle.Render(strings.Repeat("─", dashCount)+"╮")
-    bot := borderStyle.Render("╰" + strings.Repeat("─", innerWidth) + "╯")
+	// Build top border with title.
+	titleWidth := runewidth.StringWidth(title)
+	dashCount := innerWidth - titleWidth - 1
+	if dashCount < 0 {
+		dashCount = 0
+	}
+	top := borderStyle.Render("╭─") + title + borderStyle.Render(strings.Repeat("─", dashCount)+"╮")
+	bot := borderStyle.Render("╰" + strings.Repeat("─", innerWidth) + "╯")
 
-    return top + "\n" + mid + "\n" + bot
+	return top + "\n" + mid + "\n" + bot
 }

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -1,80 +1,80 @@
 package tui
 
 import (
-    "strings"
-    "testing"
+	"strings"
+	"testing"
 
-    "github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 func initSearchStyles() {
-    initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
 }
 
 // --- border shape ---
 
 func TestSearchView_RoundedTopCorners(t *testing.T) {
-    initSearchStyles()
-    out := stripANSI(NewSearchInputModel().View(40))
-    if !strings.Contains(out, "╭") || !strings.Contains(out, "╮") {
-        t.Errorf("expected rounded top corners ╭ ╮, got: %q", out)
-    }
+	initSearchStyles()
+	out := stripANSI(NewSearchInputModel().View(40))
+	if !strings.Contains(out, "╭") || !strings.Contains(out, "╮") {
+		t.Errorf("expected rounded top corners ╭ ╮, got: %q", out)
+	}
 }
 
 func TestSearchView_RoundedBottomCorners(t *testing.T) {
-    initSearchStyles()
-    out := stripANSI(NewSearchInputModel().View(40))
-    if !strings.Contains(out, "╰") || !strings.Contains(out, "╯") {
-        t.Errorf("expected rounded bottom corners ╰ ╯, got: %q", out)
-    }
+	initSearchStyles()
+	out := stripANSI(NewSearchInputModel().View(40))
+	if !strings.Contains(out, "╰") || !strings.Contains(out, "╯") {
+		t.Errorf("expected rounded bottom corners ╰ ╯, got: %q", out)
+	}
 }
 
 // --- title ---
 
 func TestSearchView_TitlePresent(t *testing.T) {
-    initSearchStyles()
-    out := stripANSI(NewSearchInputModel().View(40))
-    if !strings.Contains(out, "[f] Search") {
-        t.Errorf("expected '[f] Search' in output, got: %q", out)
-    }
+	initSearchStyles()
+	out := stripANSI(NewSearchInputModel().View(40))
+	if !strings.Contains(out, "[f] Search") {
+		t.Errorf("expected '[f] Search' in output, got: %q", out)
+	}
 }
 
 func TestSearchView_TitleNotWrappedInBorderColor(t *testing.T) {
-    initSearchStyles()
-    // Title must appear verbatim in the raw output (not inside an ANSI span).
-    raw := NewSearchInputModel().View(40)
-    if !strings.Contains(raw, "[f] Search") {
-        t.Errorf("expected '[f] Search' to appear uncolored in raw output, got: %q", raw)
-    }
+	initSearchStyles()
+	// Title must appear verbatim in the raw output (not inside an ANSI span).
+	raw := NewSearchInputModel().View(40)
+	if !strings.Contains(raw, "[f] Search") {
+		t.Errorf("expected '[f] Search' to appear uncolored in raw output, got: %q", raw)
+	}
 }
 
 // --- placeholder ---
 
 func TestSearchView_DefaultPlaceholder(t *testing.T) {
-    initSearchStyles()
-    out := stripANSI(NewSearchInputModel().View(40))
-    if !strings.Contains(out, "Press f to search") {
-        t.Errorf("expected default placeholder, got: %q", out)
-    }
+	initSearchStyles()
+	out := stripANSI(NewSearchInputModel().View(40))
+	if !strings.Contains(out, "Press f to search") {
+		t.Errorf("expected default placeholder, got: %q", out)
+	}
 }
 
 func TestSearchView_InsertModePlaceholder(t *testing.T) {
-    initSearchStyles()
-    m := NewSearchInputModel()
-    m.EnterInsertMode()
-    out := stripANSI(m.View(40))
-    if !strings.Contains(out, "Type to search") {
-        t.Errorf("expected insert-mode placeholder, got: %q", out)
-    }
+	initSearchStyles()
+	m := NewSearchInputModel()
+	m.EnterInsertMode()
+	out := stripANSI(m.View(40))
+	if !strings.Contains(out, "Type to search") {
+		t.Errorf("expected insert-mode placeholder, got: %q", out)
+	}
 }
 
 func TestSearchView_ExitInsertModeRestoresPlaceholder(t *testing.T) {
-    initSearchStyles()
-    m := NewSearchInputModel()
-    m.EnterInsertMode()
-    m.ExitInsertMode()
-    out := stripANSI(m.View(40))
-    if !strings.Contains(out, "Press f to search") {
-        t.Errorf("expected default placeholder after exiting insert mode, got: %q", out)
-    }
+	initSearchStyles()
+	m := NewSearchInputModel()
+	m.EnterInsertMode()
+	m.ExitInsertMode()
+	out := stripANSI(m.View(40))
+	if !strings.Contains(out, "Press f to search") {
+		t.Errorf("expected default placeholder after exiting insert mode, got: %q", out)
+	}
 }

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -1,156 +1,156 @@
 package tui
 
 import (
-    "fmt"
-    "os"
-    "path/filepath"
-    "sort"
-    "strings"
-    "time"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
 
-    "github.com/charmbracelet/lipgloss"
-    runewidth "github.com/mattn/go-runewidth"
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/git"
-    "github.com/rtalexk/demux/internal/query"
-    "github.com/rtalexk/demux/internal/session"
+	"github.com/charmbracelet/lipgloss"
+	runewidth "github.com/mattn/go-runewidth"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/query"
+	"github.com/rtalexk/demux/internal/session"
 )
 
 // SidebarFilter determines which sessions are visible in the sidebar.
 type SidebarFilter string
 
 const (
-    FilterTmux     SidebarFilter = "t"
-    FilterAll      SidebarFilter = "a"
-    FilterConfig   SidebarFilter = "c"
-    FilterWorktree SidebarFilter = "w"
-    FilterPriority SidebarFilter = "!"
+	FilterTmux     SidebarFilter = "t"
+	FilterAll      SidebarFilter = "a"
+	FilterConfig   SidebarFilter = "c"
+	FilterWorktree SidebarFilter = "w"
+	FilterPriority SidebarFilter = "!"
 )
 
 type SidebarNode struct {
-    Session string
+	Session string
 }
 
 type SidebarModel struct {
-    nodes       []SidebarNode
-    cursor      int
-    offset      int // viewport scroll offset
-    visibleRows int // last known visible row count; used by CursorDown/CursorUp
-    sessions    []session.Session
-    alerts      map[string]db.Alert
-    gitInfo     map[string]git.Info
-    cfg         config.Config
-    filter      SidebarFilter
-    prevSession string // selected session before last filter switch; restored on toggle-off
-    filterHint  string
-    queryResult query.Result
-    launchErr   string // shown inline when last launch attempt failed
+	nodes       []SidebarNode
+	cursor      int
+	offset      int // viewport scroll offset
+	visibleRows int // last known visible row count; used by CursorDown/CursorUp
+	sessions    []session.Session
+	alerts      map[string]db.Alert
+	gitInfo     map[string]git.Info
+	cfg         config.Config
+	filter      SidebarFilter
+	prevSession string // selected session before last filter switch; restored on toggle-off
+	filterHint  string
+	queryResult query.Result
+	launchErr   string // shown inline when last launch attempt failed
 }
 
 func (s *SidebarModel) SetData(sessions []session.Session, alerts []db.Alert, gitInfo map[string]git.Info, cfg config.Config) {
-    s.sessions = sessions
-    s.alerts = make(map[string]db.Alert, len(alerts))
-    for _, a := range alerts {
-        s.alerts[a.Target] = a
-    }
-    s.gitInfo = gitInfo
-    s.cfg = cfg
-    s.rebuildNodes()
+	s.sessions = sessions
+	s.alerts = make(map[string]db.Alert, len(alerts))
+	for _, a := range alerts {
+		s.alerts[a.Target] = a
+	}
+	s.gitInfo = gitInfo
+	s.cfg = cfg
+	s.rebuildNodes()
 }
 
 // SetFilter changes the active sidebar filter. Pressing the current filter's
 // key again toggles back to FilterTmux (the default) and restores the cursor
 // to the session that was selected before the filter was applied.
 func (s *SidebarModel) SetFilter(f SidebarFilter, visibleRows int) {
-    curSession := ""
-    if node := s.Selected(); node != nil {
-        curSession = node.Session
-    }
+	curSession := ""
+	if node := s.Selected(); node != nil {
+		curSession = node.Session
+	}
 
-    var restoreSession string
-    if f == s.filter {
-        restoreSession = s.prevSession
-        s.prevSession = curSession
-        f = FilterTmux
-    } else {
-        s.prevSession = curSession
-    }
+	var restoreSession string
+	if f == s.filter {
+		restoreSession = s.prevSession
+		s.prevSession = curSession
+		f = FilterTmux
+	} else {
+		s.prevSession = curSession
+	}
 
-    s.filter = f
-    s.rebuildNodes()
-    s.clampViewport(visibleRows)
+	s.filter = f
+	s.rebuildNodes()
+	s.clampViewport(visibleRows)
 
-    if restoreSession != "" {
-        for i, n := range s.nodes {
-            if n.Session == restoreSession {
-                s.cursor = i
-                s.clampViewport(visibleRows)
-                break
-            }
-        }
-    }
+	if restoreSession != "" {
+		for i, n := range s.nodes {
+			if n.Session == restoreSession {
+				s.cursor = i
+				s.clampViewport(visibleRows)
+				break
+			}
+		}
+	}
 }
 
 // ActiveFilter returns the current active filter.
 func (s SidebarModel) ActiveFilter() SidebarFilter {
-    return s.filter
+	return s.filter
 }
 
 // alertSeverity maps alert level to a numeric priority (higher = more severe).
 func alertSeverity(level string) int {
-    switch level {
-    case "error":
-        return 3
-    case "warn":
-        return 2
-    case "info":
-        return 1
-    default: // "defer" and unknown values
-        return 0
-    }
+	switch level {
+	case "error":
+		return 3
+	case "warn":
+		return 2
+	case "info":
+		return 1
+	default: // "defer" and unknown values
+		return 0
+	}
 }
 
 // newestSessionAlert returns the most recent alert CreatedAt for a session
 // (checking pane-level targets "session:window.pane"), or zero time if none.
 func (s *SidebarModel) newestSessionAlert(sess string) time.Time {
-    var newest time.Time
-    for target, a := range s.alerts {
-        if strings.HasPrefix(target, sess+":") || target == sess {
-            if a.CreatedAt.After(newest) {
-                newest = a.CreatedAt
-            }
-        }
-    }
-    return newest
+	var newest time.Time
+	for target, a := range s.alerts {
+		if strings.HasPrefix(target, sess+":") || target == sess {
+			if a.CreatedAt.After(newest) {
+				newest = a.CreatedAt
+			}
+		}
+	}
+	return newest
 }
 
 // newestAlertAtSeverity returns the most recent CreatedAt among alerts for a
 // session whose alertSeverity equals sv, or zero time if none match.
 func (s *SidebarModel) newestAlertAtSeverity(sess string, sv int) time.Time {
-    var newest time.Time
-    for target, a := range s.alerts {
-        if strings.HasPrefix(target, sess+":") || target == sess {
-            if alertSeverity(a.Level) == sv && a.CreatedAt.After(newest) {
-                newest = a.CreatedAt
-            }
-        }
-    }
-    return newest
+	var newest time.Time
+	for target, a := range s.alerts {
+		if strings.HasPrefix(target, sess+":") || target == sess {
+			if alertSeverity(a.Level) == sv && a.CreatedAt.After(newest) {
+				newest = a.CreatedAt
+			}
+		}
+	}
+	return newest
 }
 
 // highestSessionAlertSeverity returns the maximum alertSeverity value across
 // all alerts belonging to the session, or -1 if the session has no alerts.
 func (s *SidebarModel) highestSessionAlertSeverity(sess string) int {
-    best := -1
-    for target, a := range s.alerts {
-        if strings.HasPrefix(target, sess+":") || target == sess {
-            if sv := alertSeverity(a.Level); sv > best {
-                best = sv
-            }
-        }
-    }
-    return best
+	best := -1
+	for target, a := range s.alerts {
+		if strings.HasPrefix(target, sess+":") || target == sess {
+			if sv := alertSeverity(a.Level); sv > best {
+				best = sv
+			}
+		}
+	}
+	return best
 }
 
 // BestAlertTargetInSession returns the tmux target string of the best alert
@@ -158,326 +158,326 @@ func (s *SidebarModel) highestSessionAlertSeverity(sess string) int {
 // Returns "" for "default" priority or when the session has no alerts.
 // Unknown values fall back to "severity".
 func (s *SidebarModel) BestAlertTargetInSession(sess, priority string) string {
-    if priority == "default" {
-        return ""
-    }
-    prefix := sess + ":"
-    var best *db.Alert
-    for target, a := range s.alerts {
-        if target != sess && !strings.HasPrefix(target, prefix) {
-            continue
-        }
-        a := a
-        if best == nil {
-            best = &a
-            continue
-        }
-        switch priority {
-        case "newest":
-            if a.CreatedAt.After(best.CreatedAt) {
-                best = &a
-            }
-        case "oldest":
-            if a.CreatedAt.Before(best.CreatedAt) {
-                best = &a
-            }
-        default: // "severity" and unknown values
-            if alertSeverity(a.Level) > alertSeverity(best.Level) ||
-                (alertSeverity(a.Level) == alertSeverity(best.Level) && a.CreatedAt.After(best.CreatedAt)) {
-                best = &a
-            }
-        }
-    }
-    if best == nil {
-        return ""
-    }
-    return best.Target
+	if priority == "default" {
+		return ""
+	}
+	prefix := sess + ":"
+	var best *db.Alert
+	for target, a := range s.alerts {
+		if target != sess && !strings.HasPrefix(target, prefix) {
+			continue
+		}
+		a := a
+		if best == nil {
+			best = &a
+			continue
+		}
+		switch priority {
+		case "newest":
+			if a.CreatedAt.After(best.CreatedAt) {
+				best = &a
+			}
+		case "oldest":
+			if a.CreatedAt.Before(best.CreatedAt) {
+				best = &a
+			}
+		default: // "severity" and unknown values
+			if alertSeverity(a.Level) > alertSeverity(best.Level) ||
+				(alertSeverity(a.Level) == alertSeverity(best.Level) && a.CreatedAt.After(best.CreatedAt)) {
+				best = &a
+			}
+		}
+	}
+	if best == nil {
+		return ""
+	}
+	return best.Target
 }
 
 // visibleSessions returns sessions matching the current filter with IgnoredSessions removed.
 // For FilterWorktree with no resolvable root, returns nil and sets s.filterHint.
 func (s *SidebarModel) visibleSessions() []session.Session {
-    ignore := func(name string) bool {
-        for _, ig := range s.cfg.IgnoredSessions {
-            if ig == name {
-                return true
-            }
-        }
-        return false
-    }
+	ignore := func(name string) bool {
+		for _, ig := range s.cfg.IgnoredSessions {
+			if ig == name {
+				return true
+			}
+		}
+		return false
+	}
 
-    var out []session.Session
+	var out []session.Session
 
-    switch s.filter {
-    case FilterAll:
-        for _, sess := range s.sessions {
-            if !ignore(sess.DisplayName) {
-                out = append(out, sess)
-            }
-        }
+	switch s.filter {
+	case FilterAll:
+		for _, sess := range s.sessions {
+			if !ignore(sess.DisplayName) {
+				out = append(out, sess)
+			}
+		}
 
-    case FilterConfig:
-        for _, sess := range s.sessions {
-            if sess.IsConfig && !ignore(sess.DisplayName) {
-                out = append(out, sess)
-            }
-        }
+	case FilterConfig:
+		for _, sess := range s.sessions {
+			if sess.IsConfig && !ignore(sess.DisplayName) {
+				out = append(out, sess)
+			}
+		}
 
-    case FilterPriority:
-        for _, sess := range s.sessions {
-            if sess.IsLive && !s.newestSessionAlert(sess.DisplayName).IsZero() && !ignore(sess.DisplayName) {
-                out = append(out, sess)
-            }
-        }
+	case FilterPriority:
+		for _, sess := range s.sessions {
+			if sess.IsLive && !s.newestSessionAlert(sess.DisplayName).IsZero() && !ignore(sess.DisplayName) {
+				out = append(out, sess)
+			}
+		}
 
-    case FilterWorktree:
-        var curDisplayName string
-        if s.cursor >= 0 && s.cursor < len(s.nodes) {
-            curDisplayName = s.nodes[s.cursor].Session
-        }
-        var rootRef string
-        for _, sess := range s.sessions {
-            if sess.DisplayName == curDisplayName {
-                rootRef = s.sessionWorktreeRoot(sess)
-                break
-            }
-        }
-        if rootRef == "" {
-            s.filterHint = "no sessions in this worktree"
-            return nil
-        }
-        for _, sess := range s.sessions {
-            if !ignore(sess.DisplayName) {
-                if r := s.sessionWorktreeRoot(sess); r != "" && r == rootRef {
-                    out = append(out, sess)
-                }
-            }
-        }
+	case FilterWorktree:
+		var curDisplayName string
+		if s.cursor >= 0 && s.cursor < len(s.nodes) {
+			curDisplayName = s.nodes[s.cursor].Session
+		}
+		var rootRef string
+		for _, sess := range s.sessions {
+			if sess.DisplayName == curDisplayName {
+				rootRef = s.sessionWorktreeRoot(sess)
+				break
+			}
+		}
+		if rootRef == "" {
+			s.filterHint = "no sessions in this worktree"
+			return nil
+		}
+		for _, sess := range s.sessions {
+			if !ignore(sess.DisplayName) {
+				if r := s.sessionWorktreeRoot(sess); r != "" && r == rootRef {
+					out = append(out, sess)
+				}
+			}
+		}
 
-    default: // FilterTmux and unknown values
-        for _, sess := range s.sessions {
-            if sess.IsLive && !ignore(sess.DisplayName) {
-                out = append(out, sess)
-            }
-        }
-    }
+	default: // FilterTmux and unknown values
+		for _, sess := range s.sessions {
+			if sess.IsLive && !ignore(sess.DisplayName) {
+				out = append(out, sess)
+			}
+		}
+	}
 
-    return out
+	return out
 }
 
 // sessionWorktreeRoot returns the worktree root path for a session, or "".
 // For live sessions: filepath.Dir(gitInfo.RepoRoot).
 // For config sessions with Worktree=true: filepath.Dir(Config.Path).
 func (s *SidebarModel) sessionWorktreeRoot(sess session.Session) string {
-    if sess.IsLive {
-        if info, ok := s.gitInfo[sess.DisplayName]; ok {
-            if info.RepoRoot != "" {
-                return filepath.Dir(info.RepoRoot)
-            }
-            // Session CWD is the worktree root (contains .bare/, git unavailable there).
-            if info.IsWorktreeRoot {
-                return info.Dir
-            }
-        }
-    }
-    if sess.IsConfig && sess.Config != nil && sess.Config.Worktree {
-        p := sess.Config.Path
-        // If p itself is the worktree root container (.bare/ lives here), return p.
-        // Otherwise p is a specific worktree inside a container, so its parent is the root.
-        if fi, err := os.Stat(filepath.Join(p, ".bare")); err == nil && fi.IsDir() {
-            return p
-        }
-        return filepath.Dir(p)
-    }
-    return ""
+	if sess.IsLive {
+		if info, ok := s.gitInfo[sess.DisplayName]; ok {
+			if info.RepoRoot != "" {
+				return filepath.Dir(info.RepoRoot)
+			}
+			// Session CWD is the worktree root (contains .bare/, git unavailable there).
+			if info.IsWorktreeRoot {
+				return info.Dir
+			}
+		}
+	}
+	if sess.IsConfig && sess.Config != nil && sess.Config.Worktree {
+		p := sess.Config.Path
+		// If p itself is the worktree root container (.bare/ lives here), return p.
+		// Otherwise p is a specific worktree inside a container, so its parent is the root.
+		if fi, err := os.Stat(filepath.Join(p, ".bare")); err == nil && fi.IsDir() {
+			return p
+		}
+		return filepath.Dir(p)
+	}
+	return ""
 }
 
 func (s *SidebarModel) rebuildNodes() {
-    var curSession string
-    if s.cursor >= 0 && s.cursor < len(s.nodes) {
-        curSession = s.nodes[s.cursor].Session
-    }
+	var curSession string
+	if s.cursor >= 0 && s.cursor < len(s.nodes) {
+		curSession = s.nodes[s.cursor].Session
+	}
 
-    // Call visibleSessions before clearing s.nodes so FilterWorktree can
-    // read the current cursor session from s.nodes[s.cursor].
-    s.filterHint = ""
-    visible := s.visibleSessions()
+	// Call visibleSessions before clearing s.nodes so FilterWorktree can
+	// read the current cursor session from s.nodes[s.cursor].
+	s.filterHint = ""
+	visible := s.visibleSessions()
 
-    s.nodes = nil
+	s.nodes = nil
 
-    sortKeys := s.cfg.Sidebar.Sort
-    if len(sortKeys) == 0 {
-        sortKeys = []string{"priority", "last_seen", "alphabetical"}
-    }
-    sort.Slice(visible, func(i, j int) bool {
-        si, sj := visible[i], visible[j]
-        for _, key := range sortKeys {
-            switch key {
-            case "priority":
-                svi := s.highestSessionAlertSeverity(si.DisplayName)
-                svj := s.highestSessionAlertSeverity(sj.DisplayName)
-                hasI := svi >= 0
-                hasJ := svj >= 0
-                if hasI != hasJ {
-                    return hasI
-                }
-                if hasI && hasJ {
-                    if svi != svj {
-                        return svi > svj
-                    }
-                    ti := s.newestAlertAtSeverity(si.DisplayName, svi)
-                    tj := s.newestAlertAtSeverity(sj.DisplayName, svj)
-                    if !ti.Equal(tj) {
-                        return ti.After(tj)
-                    }
-                }
-            case "last_seen":
-                if !si.Activity.Equal(sj.Activity) {
-                    return si.Activity.After(sj.Activity)
-                }
-            case "alphabetical":
-                return si.DisplayName < sj.DisplayName
-            }
-        }
-        return false
-    })
+	sortKeys := s.cfg.Sidebar.Sort
+	if len(sortKeys) == 0 {
+		sortKeys = []string{"priority", "last_seen", "alphabetical"}
+	}
+	sort.Slice(visible, func(i, j int) bool {
+		si, sj := visible[i], visible[j]
+		for _, key := range sortKeys {
+			switch key {
+			case "priority":
+				svi := s.highestSessionAlertSeverity(si.DisplayName)
+				svj := s.highestSessionAlertSeverity(sj.DisplayName)
+				hasI := svi >= 0
+				hasJ := svj >= 0
+				if hasI != hasJ {
+					return hasI
+				}
+				if hasI && hasJ {
+					if svi != svj {
+						return svi > svj
+					}
+					ti := s.newestAlertAtSeverity(si.DisplayName, svi)
+					tj := s.newestAlertAtSeverity(sj.DisplayName, svj)
+					if !ti.Equal(tj) {
+						return ti.After(tj)
+					}
+				}
+			case "last_seen":
+				if !si.Activity.Equal(sj.Activity) {
+					return si.Activity.After(sj.Activity)
+				}
+			case "alphabetical":
+				return si.DisplayName < sj.DisplayName
+			}
+		}
+		return false
+	})
 
-    for _, sess := range visible {
-        s.nodes = append(s.nodes, SidebarNode{Session: sess.DisplayName})
-    }
+	for _, sess := range visible {
+		s.nodes = append(s.nodes, SidebarNode{Session: sess.DisplayName})
+	}
 
-    // Apply search filter (score-sort overrides cfg sort).
-    if s.queryResult.Sessions != nil {
-        matchSet := make(map[string]query.SessionMatch, len(s.queryResult.Sessions))
-        for _, sm := range s.queryResult.Sessions {
-            matchSet[sm.Name] = sm
-        }
-        filtered := s.nodes[:0:0]
-        for _, node := range s.nodes {
-            if _, ok := matchSet[node.Session]; ok {
-                filtered = append(filtered, node)
-            }
-        }
-        s.nodes = filtered
+	// Apply search filter (score-sort overrides cfg sort).
+	if s.queryResult.Sessions != nil {
+		matchSet := make(map[string]query.SessionMatch, len(s.queryResult.Sessions))
+		for _, sm := range s.queryResult.Sessions {
+			matchSet[sm.Name] = sm
+		}
+		filtered := s.nodes[:0:0]
+		for _, node := range s.nodes {
+			if _, ok := matchSet[node.Session]; ok {
+				filtered = append(filtered, node)
+			}
+		}
+		s.nodes = filtered
 
-        if s.cfg.Sidebar.SearchSort == "score" {
-            sort.SliceStable(s.nodes, func(i, j int) bool {
-                return matchSet[s.nodes[i].Session].Score > matchSet[s.nodes[j].Session].Score
-            })
-        }
-    }
+		if s.cfg.Sidebar.SearchSort == "score" {
+			sort.SliceStable(s.nodes, func(i, j int) bool {
+				return matchSet[s.nodes[i].Session].Score > matchSet[s.nodes[j].Session].Score
+			})
+		}
+	}
 
-    found := false
-    for i, n := range s.nodes {
-        if n.Session == curSession {
-            s.cursor = i
-            found = true
-            break
-        }
-    }
-    if !found {
-        s.cursor = 0
-    }
-    if s.cursor >= len(s.nodes) {
-        s.cursor = max(0, len(s.nodes)-1)
-    }
+	found := false
+	for i, n := range s.nodes {
+		if n.Session == curSession {
+			s.cursor = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		s.cursor = 0
+	}
+	if s.cursor >= len(s.nodes) {
+		s.cursor = max(0, len(s.nodes)-1)
+	}
 }
 
 func (s SidebarModel) Render(width, height int, focused bool, title, rightTitle string) string {
-    visibleRows := height - 2
-    if visibleRows < 1 {
-        visibleRows = 1
-    }
+	visibleRows := height - 2
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
 
-    // compute display offset without mutating (Bubbletea passes model by value in View)
-    offset := s.offset
-    if s.cursor < offset {
-        offset = s.cursor
-    }
-    if s.cursor >= offset+visibleRows {
-        offset = s.cursor - visibleRows + 1
-    }
-    if offset < 0 {
-        offset = 0
-    }
+	// compute display offset without mutating (Bubbletea passes model by value in View)
+	offset := s.offset
+	if s.cursor < offset {
+		offset = s.cursor
+	}
+	if s.cursor >= offset+visibleRows {
+		offset = s.cursor - visibleRows + 1
+	}
+	if offset < 0 {
+		offset = 0
+	}
 
-    hasAbove := offset > 0
+	hasAbove := offset > 0
 
-    // each hint costs one row; deduct ▲ first, then check ▼ against the
-    // reduced budget so hasBelow is accurate when scrolled down.
-    contentRows := visibleRows
-    if hasAbove {
-        contentRows--
-    }
-    hasBelow := offset+contentRows < len(s.nodes)
-    if hasBelow {
-        contentRows--
-    }
-    if contentRows < 1 {
-        contentRows = 1
-    }
+	// each hint costs one row; deduct ▲ first, then check ▼ against the
+	// reduced budget so hasBelow is accurate when scrolled down.
+	contentRows := visibleRows
+	if hasAbove {
+		contentRows--
+	}
+	hasBelow := offset+contentRows < len(s.nodes)
+	if hasBelow {
+		contentRows--
+	}
+	if contentRows < 1 {
+		contentRows = 1
+	}
 
-    // inner content width (border takes 2)
-    innerW := width - 2
-    centeredHint := func(text string) string {
-        pad := (innerW - len([]rune(text))) / 2
-        if pad < 0 {
-            pad = 0
-        }
-        return hintStyle.Render(strings.Repeat(" ", pad) + text)
-    }
+	// inner content width (border takes 2)
+	innerW := width - 2
+	centeredHint := func(text string) string {
+		pad := (innerW - len([]rune(text))) / 2
+		if pad < 0 {
+			pad = 0
+		}
+		return hintStyle.Render(strings.Repeat(" ", pad) + text)
+	}
 
-    var lines []string
-    if len(s.nodes) == 0 {
-        var hintText string
-        switch {
-        case s.filterHint != "":
-            hintText = s.filterHint
-        case s.filter == FilterPriority:
-            hintText = "no alerts"
-        case s.queryResult.Sessions != nil:
-            hintText = "no results"
-        default:
-            hintText = "no sessions"
-        }
-        lines = append(lines, centeredHint(hintText))
-    } else {
-        if hasAbove {
-            lines = append(lines, centeredHint("▲ more"))
-        }
-        end := offset + contentRows
-        if end > len(s.nodes) {
-            end = len(s.nodes)
-        }
-        for i := offset; i < end; i++ {
-            lines = append(lines, s.renderNode(s.nodes[i], i == s.cursor, focused, width))
-        }
-        if hasBelow {
-            lines = append(lines, centeredHint("▼ more"))
-        }
-    }
+	var lines []string
+	if len(s.nodes) == 0 {
+		var hintText string
+		switch {
+		case s.filterHint != "":
+			hintText = s.filterHint
+		case s.filter == FilterPriority:
+			hintText = "no alerts"
+		case s.queryResult.Sessions != nil:
+			hintText = "no results"
+		default:
+			hintText = "no sessions"
+		}
+		lines = append(lines, centeredHint(hintText))
+	} else {
+		if hasAbove {
+			lines = append(lines, centeredHint("▲ more"))
+		}
+		end := offset + contentRows
+		if end > len(s.nodes) {
+			end = len(s.nodes)
+		}
+		for i := offset; i < end; i++ {
+			lines = append(lines, s.renderNode(s.nodes[i], i == s.cursor, focused, width))
+		}
+		if hasBelow {
+			lines = append(lines, centeredHint("▼ more"))
+		}
+	}
 
-    inner := strings.Join(lines, "\n")
-    if s.launchErr != "" {
-        errLine := lipgloss.NewStyle().
-            Foreground(activeTheme.ColorFgMuted).
-            Italic(true).
-            Width(width - 2).
-            Align(lipgloss.Center).
-            Render("⚠ " + s.launchErr)
-        inner += "\n" + errLine
-    }
-    style := borderInactive
-    if focused {
-        style = borderActive
-    }
-    rendered := injectBorderTitles(style.Width(width-2).Height(height-2).Render(inner), title, rightTitle)
-    shortcutBar := filterShortcutBar(s.filter, width-2)
-    return injectBottomBorderLabel(rendered, shortcutBar)
+	inner := strings.Join(lines, "\n")
+	if s.launchErr != "" {
+		errLine := lipgloss.NewStyle().
+			Foreground(activeTheme.ColorFgMuted).
+			Italic(true).
+			Width(width - 2).
+			Align(lipgloss.Center).
+			Render("⚠ " + s.launchErr)
+		inner += "\n" + errLine
+	}
+	style := borderInactive
+	if focused {
+		style = borderActive
+	}
+	rendered := injectBorderTitles(style.Width(width-2).Height(height-2).Render(inner), title, rightTitle)
+	shortcutBar := filterShortcutBar(s.filter, width-2)
+	return injectBottomBorderLabel(rendered, shortcutBar)
 }
 
 func (s SidebarModel) renderNode(node SidebarNode, selected, focused bool, width int) string {
-    return s.renderSession(node, selected, focused, width)
+	return s.renderSession(node, selected, focused, width)
 }
 
 // alignedRow builds a single sidebar line with the name on the left and
@@ -485,23 +485,23 @@ func (s SidebarModel) renderNode(node SidebarNode, selected, focused bool, width
 // measured by display-column width (runewidth) after stripping ANSI codes,
 // so multi-column glyphs (e.g. emoji) are accounted for correctly.
 func alignedRow(name, indicators string, availWidth int) string {
-    nameW := runewidth.StringWidth(stripANSI(name))
-    indW := runewidth.StringWidth(stripANSI(indicators))
-    pad := availWidth - nameW - indW
-    if pad < 1 {
-        pad = 1
-    }
-    return name + strings.Repeat(" ", pad) + indicators
+	nameW := runewidth.StringWidth(stripANSI(name))
+	indW := runewidth.StringWidth(stripANSI(indicators))
+	pad := availWidth - nameW - indW
+	if pad < 1 {
+		pad = 1
+	}
+	return name + strings.Repeat(" ", pad) + indicators
 }
 
 // FindSession returns a pointer to the Session with the given display name, or nil.
 func (s SidebarModel) FindSession(displayName string) *session.Session {
-    for i := range s.sessions {
-        if s.sessions[i].DisplayName == displayName {
-            return &s.sessions[i]
-        }
-    }
-    return nil
+	for i := range s.sessions {
+		if s.sessions[i].DisplayName == displayName {
+			return &s.sessions[i]
+		}
+	}
+	return nil
 }
 
 // SetLaunchErr stores a launch error message for inline sidebar display.
@@ -512,117 +512,117 @@ func (s *SidebarModel) ClearLaunchErr() { s.launchErr = "" }
 
 // sessionIcon returns the rendered icon for a sidebar session row.
 func sessionIcon(sess session.Session) string {
-    var icon string
-    if sess.IsConfig && sess.Config != nil && sess.Config.Icon != "" {
-        icon = sess.Config.Icon
-    } else if sess.IsLive {
-        icon = activeTheme.IconTmuxSession
-    } else {
-        icon = activeTheme.IconCfgSession
-    }
-    return sessionIconStyle.Render(icon)
+	var icon string
+	if sess.IsConfig && sess.Config != nil && sess.Config.Icon != "" {
+		icon = sess.Config.Icon
+	} else if sess.IsLive {
+		icon = activeTheme.IconTmuxSession
+	} else {
+		icon = activeTheme.IconCfgSession
+	}
+	return sessionIconStyle.Render(icon)
 }
 
 func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, width int) string {
-    var indParts []string
-    if info, ok := s.gitInfo[node.Session]; ok {
-        if selected && focused {
-            if ind := compactGitIndicatorsOnBG(info, activeTheme.ColorSelected); ind != "" {
-                indParts = append(indParts, ind)
-            }
-        } else {
-            if ind := compactGitIndicators(info); ind != "" {
-                indParts = append(indParts, ind)
-            }
-        }
-    }
-    var bestSessionAlert *db.Alert
-    for target, a := range s.alerts {
-        if !strings.HasPrefix(target, node.Session+":") && target != node.Session {
-            continue
-        }
-        a := a
-        if bestSessionAlert == nil || alertSeverity(a.Level) > alertSeverity(bestSessionAlert.Level) ||
-            (alertSeverity(a.Level) == alertSeverity(bestSessionAlert.Level) && a.CreatedAt.After(bestSessionAlert.CreatedAt)) {
-            bestSessionAlert = &a
-        }
-    }
-    if bestSessionAlert != nil {
-        if selected && focused {
-            indParts = append(indParts, alertIconOnBG(bestSessionAlert.Level, activeTheme.ColorSelected))
-        } else {
-            indParts = append(indParts, alertIcon(bestSessionAlert.Level))
-        }
-    }
-    if s.cfg.Sidebar.ShowLastSeen {
-        if sess := s.FindSession(node.Session); sess != nil && !sess.Activity.IsZero() {
-            age := formatAge(sess.Activity, time.Now())
-            if selected && focused {
-                indParts = append(indParts, hintStyle.Background(activeTheme.ColorSelected).Render(age))
-            } else {
-                indParts = append(indParts, hintStyle.Render(age))
-            }
-        }
-    }
-    var indicators string
-    if selected && focused {
-        sep := lipgloss.NewStyle().Background(activeTheme.ColorSelected).Render(" ")
-        indicators = strings.Join(indParts, sep)
-    } else {
-        indicators = strings.Join(indParts, " ")
-    }
+	var indParts []string
+	if info, ok := s.gitInfo[node.Session]; ok {
+		if selected && focused {
+			if ind := compactGitIndicatorsOnBG(info, activeTheme.ColorSelected); ind != "" {
+				indParts = append(indParts, ind)
+			}
+		} else {
+			if ind := compactGitIndicators(info); ind != "" {
+				indParts = append(indParts, ind)
+			}
+		}
+	}
+	var bestSessionAlert *db.Alert
+	for target, a := range s.alerts {
+		if !strings.HasPrefix(target, node.Session+":") && target != node.Session {
+			continue
+		}
+		a := a
+		if bestSessionAlert == nil || alertSeverity(a.Level) > alertSeverity(bestSessionAlert.Level) ||
+			(alertSeverity(a.Level) == alertSeverity(bestSessionAlert.Level) && a.CreatedAt.After(bestSessionAlert.CreatedAt)) {
+			bestSessionAlert = &a
+		}
+	}
+	if bestSessionAlert != nil {
+		if selected && focused {
+			indParts = append(indParts, alertIconOnBG(bestSessionAlert.Level, activeTheme.ColorSelected))
+		} else {
+			indParts = append(indParts, alertIcon(bestSessionAlert.Level))
+		}
+	}
+	if s.cfg.Sidebar.ShowLastSeen {
+		if sess := s.FindSession(node.Session); sess != nil && !sess.Activity.IsZero() {
+			age := formatAge(sess.Activity, time.Now())
+			if selected && focused {
+				indParts = append(indParts, hintStyle.Background(activeTheme.ColorSelected).Render(age))
+			} else {
+				indParts = append(indParts, hintStyle.Render(age))
+			}
+		}
+	}
+	var indicators string
+	if selected && focused {
+		sep := lipgloss.NewStyle().Background(activeTheme.ColorSelected).Render(" ")
+		indicators = strings.Join(indParts, sep)
+	} else {
+		indicators = strings.Join(indParts, " ")
+	}
 
-    // Icon prefix: look up the session and render its icon.
-    iconPrefix := ""
-    if sess := s.FindSession(node.Session); sess != nil {
-        iconPrefix = sessionIcon(*sess) + " "
-    }
-    iconW := runewidth.StringWidth(stripANSI(iconPrefix))
+	// Icon prefix: look up the session and render its icon.
+	iconPrefix := ""
+	if sess := s.FindSession(node.Session); sess != nil {
+		iconPrefix = sessionIcon(*sess) + " "
+	}
+	iconW := runewidth.StringWidth(stripANSI(iconPrefix))
 
-    // Row format: [focus(1)] [gap(2)] [icon(iconW)] [name+indicators(availW)]
-    // Box content = width-2. Selected rows append trail(2), so body must fill
-    // width-2 - 1 - 2 - iconW - 2 = width-7-iconW chars.
-    availW := width - 6 - iconW
-    if availW < 4 {
-        availW = 4
-    }
-    indW := runewidth.StringWidth(stripANSI(indicators))
-    maxName := availW - indW
-    if indW > 0 {
-        maxName-- // alignedRow enforces pad>=1 separator; reserve it so truncation doesn't overflow
-    }
-    if maxName < 4 {
-        maxName = 4
-    }
-    nameStr := node.Session
-    if runewidth.StringWidth(nameStr) > maxName {
-        runes := []rune(nameStr)
-        for runewidth.StringWidth(string(runes)) > maxName-1 {
-            runes = runes[:len(runes)-1]
-        }
-        nameStr = string(runes) + "…"
-    }
+	// Row format: [focus(1)] [gap(2)] [icon(iconW)] [name+indicators(availW)]
+	// Box content = width-2. Selected rows append trail(2), so body must fill
+	// width-2 - 1 - 2 - iconW - 2 = width-7-iconW chars.
+	availW := width - 6 - iconW
+	if availW < 4 {
+		availW = 4
+	}
+	indW := runewidth.StringWidth(stripANSI(indicators))
+	maxName := availW - indW
+	if indW > 0 {
+		maxName-- // alignedRow enforces pad>=1 separator; reserve it so truncation doesn't overflow
+	}
+	if maxName < 4 {
+		maxName = 4
+	}
+	nameStr := node.Session
+	if runewidth.StringWidth(nameStr) > maxName {
+		runes := []rune(nameStr)
+		for runewidth.StringWidth(string(runes)) > maxName-1 {
+			runes = runes[:len(runes)-1]
+		}
+		nameStr = string(runes) + "…"
+	}
 
-    const gap = " " // 1-space gap between focus indicator and icon
-    if selected && focused {
-        pad := availW - runewidth.StringWidth(nameStr) - indW
-        if pad < 0 {
-            pad = 0
-        }
-        indicator := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render("▌")
-        trail := lipgloss.NewStyle().Background(activeTheme.ColorSelected).Render("  ")
-        return indicator + gap + iconPrefix + selectedBG.Bold(true).Render(nameStr+strings.Repeat(" ", pad)) + indicators + trail
-    }
-    if selected {
-        pad := availW - runewidth.StringWidth(nameStr) - indW
-        if pad < 0 {
-            pad = 0
-        }
-        indicator := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render("▌")
-        return indicator + gap + iconPrefix + selectedInactive.Bold(true).Render(nameStr+strings.Repeat(" ", pad)) + indicators
-    }
-    text := alignedRow(nameStr, indicators, availW)
-    return " " + gap + iconPrefix + sessionStyle.Render(text)
+	const gap = " " // 1-space gap between focus indicator and icon
+	if selected && focused {
+		pad := availW - runewidth.StringWidth(nameStr) - indW
+		if pad < 0 {
+			pad = 0
+		}
+		indicator := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render("▌")
+		trail := lipgloss.NewStyle().Background(activeTheme.ColorSelected).Render("  ")
+		return indicator + gap + iconPrefix + selectedBG.Bold(true).Render(nameStr+strings.Repeat(" ", pad)) + indicators + trail
+	}
+	if selected {
+		pad := availW - runewidth.StringWidth(nameStr) - indW
+		if pad < 0 {
+			pad = 0
+		}
+		indicator := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render("▌")
+		return indicator + gap + iconPrefix + selectedInactive.Bold(true).Render(nameStr+strings.Repeat(" ", pad)) + indicators
+	}
+	text := alignedRow(nameStr, indicators, availW)
+	return " " + gap + iconPrefix + sessionStyle.Render(text)
 }
 
 // formatAge returns a fixed-width 3-char age string for a session's last-seen
@@ -630,242 +630,242 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 // ' Xm' / 'XXm' for minutes, ' Xh' / 'XXh' for hours, ' Xd' / 'XXd' for days.
 // Single-digit values are space-padded on the left.
 func formatAge(t, now time.Time) string {
-    d := now.Sub(t)
-    if d < 0 {
-        d = 0
-    }
-    switch {
-    case d < 15*time.Second:
-        return "now"
-    case d < time.Minute:
-        return "<1m"
-    case d < time.Hour:
-        n := int(d.Minutes())
-        if n < 10 {
-            return fmt.Sprintf(" %dm", n)
-        }
-        return fmt.Sprintf("%dm", n)
-    case d < 24*time.Hour:
-        n := int(d.Hours())
-        if n < 10 {
-            return fmt.Sprintf(" %dh", n)
-        }
-        return fmt.Sprintf("%dh", n)
-    default:
-        n := int(d.Hours() / 24)
-        if n < 10 {
-            return fmt.Sprintf(" %dd", n)
-        }
-        return fmt.Sprintf("%dd", n)
-    }
+	d := now.Sub(t)
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < 15*time.Second:
+		return "now"
+	case d < time.Minute:
+		return "<1m"
+	case d < time.Hour:
+		n := int(d.Minutes())
+		if n < 10 {
+			return fmt.Sprintf(" %dm", n)
+		}
+		return fmt.Sprintf("%dm", n)
+	case d < 24*time.Hour:
+		n := int(d.Hours())
+		if n < 10 {
+			return fmt.Sprintf(" %dh", n)
+		}
+		return fmt.Sprintf("%dh", n)
+	default:
+		n := int(d.Hours() / 24)
+		if n < 10 {
+			return fmt.Sprintf(" %dd", n)
+		}
+		return fmt.Sprintf("%dd", n)
+	}
 }
 
 func compactGitIndicators(info git.Info) string {
-    var parts []string
-    if info.Ahead > 0 {
-        parts = append(parts, gitAheadStyle.Render(fmt.Sprintf("↑%d", info.Ahead)))
-    }
-    if info.Behind > 0 {
-        parts = append(parts, gitBehindStyle.Render(fmt.Sprintf("↓%d", info.Behind)))
-    }
-    if info.Dirty {
-        parts = append(parts, gitDirtyStyle.Render("*"))
-    }
-    return strings.Join(parts, " ")
+	var parts []string
+	if info.Ahead > 0 {
+		parts = append(parts, gitAheadStyle.Render(fmt.Sprintf("↑%d", info.Ahead)))
+	}
+	if info.Behind > 0 {
+		parts = append(parts, gitBehindStyle.Render(fmt.Sprintf("↓%d", info.Behind)))
+	}
+	if info.Dirty {
+		parts = append(parts, gitDirtyStyle.Render("*"))
+	}
+	return strings.Join(parts, " ")
 }
 
 // compactGitIndicatorsOnBG renders git indicators with bg baked into each
 // piece so that inner ANSI resets don't strip a parent background colour.
 func compactGitIndicatorsOnBG(info git.Info, bg lipgloss.Color) string {
-    var parts []string
-    if info.Ahead > 0 {
-        parts = append(parts, gitAheadStyle.Background(bg).Render(fmt.Sprintf("↑%d", info.Ahead)))
-    }
-    if info.Behind > 0 {
-        parts = append(parts, gitBehindStyle.Background(bg).Render(fmt.Sprintf("↓%d", info.Behind)))
-    }
-    if info.Dirty {
-        parts = append(parts, gitDirtyStyle.Background(bg).Render("*"))
-    }
-    sep := lipgloss.NewStyle().Background(bg).Render(" ")
-    return strings.Join(parts, sep)
+	var parts []string
+	if info.Ahead > 0 {
+		parts = append(parts, gitAheadStyle.Background(bg).Render(fmt.Sprintf("↑%d", info.Ahead)))
+	}
+	if info.Behind > 0 {
+		parts = append(parts, gitBehindStyle.Background(bg).Render(fmt.Sprintf("↓%d", info.Behind)))
+	}
+	if info.Dirty {
+		parts = append(parts, gitDirtyStyle.Background(bg).Render("*"))
+	}
+	sep := lipgloss.NewStyle().Background(bg).Render(" ")
+	return strings.Join(parts, sep)
 }
 
 func (s *SidebarModel) clampViewport(visibleRows int) {
-    // Reserve 2 rows for the ▲/▼ hint lines so the cursor is always
-    // within the rendered content area regardless of which hints appear.
-    effective := visibleRows - 2
-    if effective < 1 {
-        effective = 1
-    }
-    if s.cursor < s.offset {
-        s.offset = s.cursor
-    }
-    if s.cursor >= s.offset+effective {
-        s.offset = s.cursor - effective + 1
-    }
-    // At the bottom of the list ▼ is absent; reclaim the freed row so the
-    // viewport fills without a trailing blank line.
-    if s.offset > 0 {
-        contentRows := visibleRows - 1 // ▲ is present whenever offset > 0
-        if s.offset+contentRows >= len(s.nodes) {
-            newOffset := len(s.nodes) - contentRows
-            if newOffset < 0 {
-                newOffset = 0
-            }
-            if s.cursor >= newOffset {
-                s.offset = newOffset
-            }
-        }
-    }
-    if s.offset < 0 {
-        s.offset = 0
-    }
+	// Reserve 2 rows for the ▲/▼ hint lines so the cursor is always
+	// within the rendered content area regardless of which hints appear.
+	effective := visibleRows - 2
+	if effective < 1 {
+		effective = 1
+	}
+	if s.cursor < s.offset {
+		s.offset = s.cursor
+	}
+	if s.cursor >= s.offset+effective {
+		s.offset = s.cursor - effective + 1
+	}
+	// At the bottom of the list ▼ is absent; reclaim the freed row so the
+	// viewport fills without a trailing blank line.
+	if s.offset > 0 {
+		contentRows := visibleRows - 1 // ▲ is present whenever offset > 0
+		if s.offset+contentRows >= len(s.nodes) {
+			newOffset := len(s.nodes) - contentRows
+			if newOffset < 0 {
+				newOffset = 0
+			}
+			if s.cursor >= newOffset {
+				s.offset = newOffset
+			}
+		}
+	}
+	if s.offset < 0 {
+		s.offset = 0
+	}
 }
 
 func (s *SidebarModel) MoveUp(visibleRows int) {
-    if s.cursor > 0 {
-        s.cursor--
-    }
-    s.clampViewport(visibleRows)
+	if s.cursor > 0 {
+		s.cursor--
+	}
+	s.clampViewport(visibleRows)
 }
 
 func (s *SidebarModel) MoveDown(visibleRows int) {
-    if s.cursor < len(s.nodes)-1 {
-        s.cursor++
-    }
-    s.clampViewport(visibleRows)
+	if s.cursor < len(s.nodes)-1 {
+		s.cursor++
+	}
+	s.clampViewport(visibleRows)
 }
 
 func (s *SidebarModel) GotoTop(visibleRows int) {
-    s.cursor = 0
-    s.clampViewport(visibleRows)
+	s.cursor = 0
+	s.clampViewport(visibleRows)
 }
 
 func (s *SidebarModel) GotoBottom(visibleRows int) {
-    s.cursor = max(0, len(s.nodes)-1)
-    s.clampViewport(visibleRows)
+	s.cursor = max(0, len(s.nodes)-1)
+	s.clampViewport(visibleRows)
 }
 
 func (s *SidebarModel) MoveToSessionLevel() {}
 
 // TabPrevSession moves the cursor to the previous session node, wrapping around.
 func (s *SidebarModel) TabPrevSession(visibleRows int) {
-    if len(s.nodes) == 0 {
-        return
-    }
-    if s.cursor > 0 {
-        s.cursor--
-    } else {
-        s.cursor = len(s.nodes) - 1
-    }
-    s.clampViewport(visibleRows)
+	if len(s.nodes) == 0 {
+		return
+	}
+	if s.cursor > 0 {
+		s.cursor--
+	} else {
+		s.cursor = len(s.nodes) - 1
+	}
+	s.clampViewport(visibleRows)
 }
 
 // TabNextSession advances the cursor to the next session node, wrapping around.
 func (s *SidebarModel) TabNextSession(visibleRows int) {
-    if len(s.nodes) == 0 {
-        return
-    }
-    if s.cursor < len(s.nodes)-1 {
-        s.cursor++
-    } else {
-        s.cursor = 0
-    }
-    s.clampViewport(visibleRows)
+	if len(s.nodes) == 0 {
+		return
+	}
+	if s.cursor < len(s.nodes)-1 {
+		s.cursor++
+	} else {
+		s.cursor = 0
+	}
+	s.clampViewport(visibleRows)
 }
 
 // SessionCount returns the number of visible (non-ignored) sessions.
 func (s SidebarModel) SessionCount() int {
-    return len(s.nodes)
+	return len(s.nodes)
 }
 
 // FocusNode positions the cursor on the session node matching sess.
 // Returns true if found, false otherwise.
 func (s *SidebarModel) FocusNode(sess string, visibleRows int) bool {
-    for i, n := range s.nodes {
-        if n.Session == sess {
-            s.cursor = i
-            s.clampViewport(visibleRows)
-            return true
-        }
-    }
-    return false
+	for i, n := range s.nodes {
+		if n.Session == sess {
+			s.cursor = i
+			s.clampViewport(visibleRows)
+			return true
+		}
+	}
+	return false
 }
 
 // FocusFirstAlertSession positions the cursor on the first session node that has any alert.
 // Returns true if a matching node was found, false otherwise.
 func (s *SidebarModel) FocusFirstAlertSession(visibleRows int) bool {
-    for i, n := range s.nodes {
-        if !s.newestSessionAlert(n.Session).IsZero() {
-            s.cursor = i
-            s.clampViewport(visibleRows)
-            return true
-        }
-    }
-    return false
+	for i, n := range s.nodes {
+		if !s.newestSessionAlert(n.Session).IsZero() {
+			s.cursor = i
+			s.clampViewport(visibleRows)
+			return true
+		}
+	}
+	return false
 }
 
 // SetSearchResult filters and optionally re-sorts the sidebar nodes by the
 // given query result. Passing an empty Result clears any active filter.
 func (s *SidebarModel) SetSearchResult(r query.Result) {
-    // When clearing the search (empty result), keep the cursor on the same
-    // session so the proclist doesn't change and lose its scroll position.
-    var prevSession string
-    if len(r.Sessions) == 0 {
-        if node := s.Selected(); node != nil {
-            prevSession = node.Session
-        }
-    }
-    s.queryResult = r
-    s.rebuildNodes()
-    if prevSession != "" {
-        for i, node := range s.nodes {
-            if node.Session == prevSession {
-                s.cursor = i
-                s.clampViewport(s.visibleRows)
-                return
-            }
-        }
-    }
-    s.cursor = 0
-    s.offset = 0
+	// When clearing the search (empty result), keep the cursor on the same
+	// session so the proclist doesn't change and lose its scroll position.
+	var prevSession string
+	if len(r.Sessions) == 0 {
+		if node := s.Selected(); node != nil {
+			prevSession = node.Session
+		}
+	}
+	s.queryResult = r
+	s.rebuildNodes()
+	if prevSession != "" {
+		for i, node := range s.nodes {
+			if node.Session == prevSession {
+				s.cursor = i
+				s.clampViewport(s.visibleRows)
+				return
+			}
+		}
+	}
+	s.cursor = 0
+	s.offset = 0
 }
 
 // CursorDown moves the cursor down by one row (used during search insert mode).
 func (s *SidebarModel) CursorDown() {
-    if s.cursor < len(s.nodes)-1 {
-        s.cursor++
-        vr := s.visibleRows
-        if vr < 1 {
-            vr = 1
-        }
-        s.clampViewport(vr)
-    }
+	if s.cursor < len(s.nodes)-1 {
+		s.cursor++
+		vr := s.visibleRows
+		if vr < 1 {
+			vr = 1
+		}
+		s.clampViewport(vr)
+	}
 }
 
 // CursorUp moves the cursor up by one row (used during search insert mode).
 func (s *SidebarModel) CursorUp() {
-    if s.cursor > 0 {
-        s.cursor--
-        vr := s.visibleRows
-        if vr < 1 {
-            vr = 1
-        }
-        s.clampViewport(vr)
-    }
+	if s.cursor > 0 {
+		s.cursor--
+		vr := s.visibleRows
+		if vr < 1 {
+			vr = 1
+		}
+		s.clampViewport(vr)
+	}
 }
 
 // filterShortcuts lists all filter shortcuts in trim-priority order (right-to-left trimming).
 var filterShortcuts = []struct {
-    filter SidebarFilter
-    label  string
+	filter SidebarFilter
+	label  string
 }{
-    {FilterAll, "[a] All"},
-    {FilterTmux, "[t] Tmux"},
-    {FilterConfig, "[c] Cfg"},
-    {FilterWorktree, "[w] Workt"},
-    {FilterPriority, "[!] Prior"},
+	{FilterAll, "[a] All"},
+	{FilterTmux, "[t] Tmux"},
+	{FilterConfig, "[c] Cfg"},
+	{FilterWorktree, "[w] Workt"},
+	{FilterPriority, "[!] Prior"},
 }
 
 // filterShortcutBar builds the centered shortcut string for the sidebar bottom border.
@@ -873,28 +873,28 @@ var filterShortcuts = []struct {
 // Shortcuts are trimmed right-to-left when they don't fit in innerWidth runes.
 // At minimum, "[t] Tmux" (index 1) is always kept.
 func filterShortcutBar(active SidebarFilter, innerWidth int) string {
-    parts := make([]string, len(filterShortcuts))
-    for i, sc := range filterShortcuts {
-        if sc.filter == active {
-            parts[i] = lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Bold(true).Render(sc.label)
-        } else {
-            parts[i] = hintStyle.Render(sc.label)
-        }
-    }
-    // Trim right-to-left until the string fits, keeping at least [t] Tmux (index 1).
-    for end := len(parts); end > 1; end-- {
-        candidate := strings.Join(parts[:end], " ")
-        if len([]rune(stripANSI(candidate))) <= innerWidth {
-            return candidate
-        }
-    }
-    return parts[1] // always show [t] Tmux as fallback
+	parts := make([]string, len(filterShortcuts))
+	for i, sc := range filterShortcuts {
+		if sc.filter == active {
+			parts[i] = lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Bold(true).Render(sc.label)
+		} else {
+			parts[i] = hintStyle.Render(sc.label)
+		}
+	}
+	// Trim right-to-left until the string fits, keeping at least [t] Tmux (index 1).
+	for end := len(parts); end > 1; end-- {
+		candidate := strings.Join(parts[:end], " ")
+		if len([]rune(stripANSI(candidate))) <= innerWidth {
+			return candidate
+		}
+	}
+	return parts[1] // always show [t] Tmux as fallback
 }
 
 func (s SidebarModel) Selected() *SidebarNode {
-    if s.cursor < 0 || s.cursor >= len(s.nodes) {
-        return nil
-    }
-    n := s.nodes[s.cursor]
-    return &n
+	if s.cursor < 0 || s.cursor >= len(s.nodes) {
+		return nil
+	}
+	n := s.nodes[s.cursor]
+	return &n
 }

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1,116 +1,116 @@
 package tui
 
 import (
-    "strings"
-    "testing"
-    "time"
+	"strings"
+	"testing"
+	"time"
 
-    "github.com/charmbracelet/lipgloss"
-    "github.com/rtalexk/demux/internal/config"
-    "github.com/rtalexk/demux/internal/db"
-    "github.com/rtalexk/demux/internal/git"
-    "github.com/rtalexk/demux/internal/query"
-    "github.com/rtalexk/demux/internal/session"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/query"
+	"github.com/rtalexk/demux/internal/session"
 )
 
 // makeNodes builds a flat slice of session-only SidebarNodes for viewport tests.
 func makeNodes(n int) []SidebarNode {
-    nodes := make([]SidebarNode, n)
-    for i := range nodes {
-        nodes[i] = SidebarNode{Session: strings.Repeat("s", i+1)}
-    }
-    return nodes
+	nodes := make([]SidebarNode, n)
+	for i := range nodes {
+		nodes[i] = SidebarNode{Session: strings.Repeat("s", i+1)}
+	}
+	return nodes
 }
 
 func sidebarWithNodes(nodes []SidebarNode) SidebarModel {
-    return SidebarModel{nodes: nodes}
+	return SidebarModel{nodes: nodes}
 }
 
 // makeSessions builds a []session.Session for sidebar tests from a list of display names.
 // Each session is live-only with no panes (sufficient for sort/filter tests).
 func makeSessions(names ...string) []session.Session {
-    sessions := make([]session.Session, len(names))
-    for i, n := range names {
-        sessions[i] = session.Session{
-            DisplayName: n,
-            IsLive:      true,
-        }
-    }
-    return sessions
+	sessions := make([]session.Session, len(names))
+	for i, n := range names {
+		sessions[i] = session.Session{
+			DisplayName: n,
+			IsLive:      true,
+		}
+	}
+	return sessions
 }
 
 // --- clampViewport ---
 
 func TestClampViewport_cursorAboveOffset(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(10))
-    s.cursor = 3
-    s.offset = 5
-    s.clampViewport(4)
-    if s.offset != 3 {
-        t.Errorf("expected offset=3, got %d", s.offset)
-    }
+	s := sidebarWithNodes(makeNodes(10))
+	s.cursor = 3
+	s.offset = 5
+	s.clampViewport(4)
+	if s.offset != 3 {
+		t.Errorf("expected offset=3, got %d", s.offset)
+	}
 }
 
 func TestClampViewport_cursorBelowWindow(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(10))
-    s.cursor = 7
-    s.offset = 0
-    // effective = 4-2 = 2; offset = cursor - effective + 1 = 7-2+1 = 6
-    s.clampViewport(4)
-    if s.offset != 6 {
-        t.Errorf("expected offset=6, got %d", s.offset)
-    }
+	s := sidebarWithNodes(makeNodes(10))
+	s.cursor = 7
+	s.offset = 0
+	// effective = 4-2 = 2; offset = cursor - effective + 1 = 7-2+1 = 6
+	s.clampViewport(4)
+	if s.offset != 6 {
+		t.Errorf("expected offset=6, got %d", s.offset)
+	}
 }
 
 func TestClampViewport_cursorWithinWindow(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(10))
-    s.cursor = 5
-    s.offset = 4
-    s.clampViewport(4) // window 4-7, cursor 5 is inside
-    if s.offset != 4 {
-        t.Errorf("expected offset unchanged=4, got %d", s.offset)
-    }
+	s := sidebarWithNodes(makeNodes(10))
+	s.cursor = 5
+	s.offset = 4
+	s.clampViewport(4) // window 4-7, cursor 5 is inside
+	if s.offset != 4 {
+		t.Errorf("expected offset unchanged=4, got %d", s.offset)
+	}
 }
 
 // --- MoveUp / MoveDown ---
 
 func TestMoveDown_advancesCursorAndClampsViewport(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(5))
-    s.cursor = 0
-    s.offset = 0
-    // effective = 3-2 = 1; cursor=1 >= offset(0)+effective(1) → offset=1
-    s.MoveDown(3)
-    if s.cursor != 1 {
-        t.Errorf("expected cursor=1, got %d", s.cursor)
-    }
-    // cursor=2 >= offset(1)+1 → offset=2
-    s.MoveDown(3)
-    // cursor=3 >= offset(2)+1 → offset=3
-    s.MoveDown(3)
-    if s.cursor != 3 {
-        t.Errorf("expected cursor=3, got %d", s.cursor)
-    }
-    if s.offset != 3 {
-        t.Errorf("expected offset=3, got %d", s.offset)
-    }
+	s := sidebarWithNodes(makeNodes(5))
+	s.cursor = 0
+	s.offset = 0
+	// effective = 3-2 = 1; cursor=1 >= offset(0)+effective(1) → offset=1
+	s.MoveDown(3)
+	if s.cursor != 1 {
+		t.Errorf("expected cursor=1, got %d", s.cursor)
+	}
+	// cursor=2 >= offset(1)+1 → offset=2
+	s.MoveDown(3)
+	// cursor=3 >= offset(2)+1 → offset=3
+	s.MoveDown(3)
+	if s.cursor != 3 {
+		t.Errorf("expected cursor=3, got %d", s.cursor)
+	}
+	if s.offset != 3 {
+		t.Errorf("expected offset=3, got %d", s.offset)
+	}
 }
 
 func TestMoveUp_doesNotGoBelowZero(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(5))
-    s.cursor = 0
-    s.MoveUp(3)
-    if s.cursor != 0 {
-        t.Errorf("expected cursor=0, got %d", s.cursor)
-    }
+	s := sidebarWithNodes(makeNodes(5))
+	s.cursor = 0
+	s.MoveUp(3)
+	if s.cursor != 0 {
+		t.Errorf("expected cursor=0, got %d", s.cursor)
+	}
 }
 
 func TestMoveDown_doesNotExceedLastNode(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(3))
-    s.cursor = 2
-    s.MoveDown(5)
-    if s.cursor != 2 {
-        t.Errorf("expected cursor=2, got %d", s.cursor)
-    }
+	s := sidebarWithNodes(makeNodes(3))
+	s.cursor = 2
+	s.MoveDown(5)
+	if s.cursor != 2 {
+		t.Errorf("expected cursor=2, got %d", s.cursor)
+	}
 }
 
 // TestClampViewport_noBlankRowAtBottom is the regression test for the blank line
@@ -118,89 +118,89 @@ func TestMoveDown_doesNotExceedLastNode(t *testing.T) {
 // effective=visibleRows-2, which left one slot vacant (no ▼ hint at bottom).
 // The fix slides offset back so the freed slot is filled with content.
 func TestClampViewport_noBlankRowAtBottom(t *testing.T) {
-    // 10 nodes, visibleRows=4: conservative effective=2 would set offset=8 for
-    // cursor=9, leaving only nodes 8,9 visible (2 rows) + ▲ = 3 rows and 1 blank.
-    // After fix: offset should be pulled to 7 so nodes 7,8,9 fill all 3 content rows.
-    s := sidebarWithNodes(makeNodes(10))
-    s.cursor = 9
-    s.offset = 0
-    s.clampViewport(4)
-    if s.offset != 7 {
-        t.Errorf("expected offset=7 (fills viewport without blank row), got %d", s.offset)
-    }
+	// 10 nodes, visibleRows=4: conservative effective=2 would set offset=8 for
+	// cursor=9, leaving only nodes 8,9 visible (2 rows) + ▲ = 3 rows and 1 blank.
+	// After fix: offset should be pulled to 7 so nodes 7,8,9 fill all 3 content rows.
+	s := sidebarWithNodes(makeNodes(10))
+	s.cursor = 9
+	s.offset = 0
+	s.clampViewport(4)
+	if s.offset != 7 {
+		t.Errorf("expected offset=7 (fills viewport without blank row), got %d", s.offset)
+	}
 }
 
 func TestRender_noBlankRowAtBottom(t *testing.T) {
-    // Scroll to the last node; the ▲ hint must appear (we're scrolled) and
-    // the last three nodes must all be visible — meaning no slot is wasted.
-    s := sidebarWithNodes(makeNodes(10))
-    s.cursor = 9
-    s.clampViewport(4) // must set offset=7 so nodes 7,8,9 fill contentRows=3
-    out := renderInner(s, 4)
-    if !strings.Contains(out, "▲ more") {
-        t.Error("expected ▲ more when scrolled to bottom")
-    }
-    // nodes[7..9] have names "ssssssss", "sssssssss", "ssssssssss"
-    for _, name := range []string{"ssssssss", "sssssssss", "ssssssssss"} {
-        if !strings.Contains(out, name) {
-            t.Errorf("expected node %q visible at bottom; got:\n%s", name, out)
-        }
-    }
+	// Scroll to the last node; the ▲ hint must appear (we're scrolled) and
+	// the last three nodes must all be visible — meaning no slot is wasted.
+	s := sidebarWithNodes(makeNodes(10))
+	s.cursor = 9
+	s.clampViewport(4) // must set offset=7 so nodes 7,8,9 fill contentRows=3
+	out := renderInner(s, 4)
+	if !strings.Contains(out, "▲ more") {
+		t.Error("expected ▲ more when scrolled to bottom")
+	}
+	// nodes[7..9] have names "ssssssss", "sssssssss", "ssssssssss"
+	for _, name := range []string{"ssssssss", "sssssssss", "ssssssssss"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("expected node %q visible at bottom; got:\n%s", name, out)
+		}
+	}
 }
 
 // --- Render: scroll hints ---
 
 func renderInner(s SidebarModel, visibleRows int) string {
-    // height = visibleRows + 2 (border), width = 40
-    rendered := s.Render(40, visibleRows+2, false, "", "")
-    // strip ANSI so we can search plain text
-    return stripANSI(rendered)
+	// height = visibleRows + 2 (border), width = 40
+	rendered := s.Render(40, visibleRows+2, false, "", "")
+	// strip ANSI so we can search plain text
+	return stripANSI(rendered)
 }
 
 func TestRender_noHintsWhenAllNodesVisible(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(3))
-    out := renderInner(s, 5)
-    if strings.Contains(out, "▲ more") {
-        t.Error("unexpected ▲ more when all nodes fit")
-    }
-    if strings.Contains(out, "▼ more") {
-        t.Error("unexpected ▼ more when all nodes fit")
-    }
+	s := sidebarWithNodes(makeNodes(3))
+	out := renderInner(s, 5)
+	if strings.Contains(out, "▲ more") {
+		t.Error("unexpected ▲ more when all nodes fit")
+	}
+	if strings.Contains(out, "▼ more") {
+		t.Error("unexpected ▼ more when all nodes fit")
+	}
 }
 
 func TestRender_belowHintWhenNodesExtendDown(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(10))
-    s.offset = 0
-    out := renderInner(s, 4)
-    if !strings.Contains(out, "▼ more") {
-        t.Error("expected ▼ more when nodes extend below viewport")
-    }
-    if strings.Contains(out, "▲ more") {
-        t.Error("unexpected ▲ more when offset=0")
-    }
+	s := sidebarWithNodes(makeNodes(10))
+	s.offset = 0
+	out := renderInner(s, 4)
+	if !strings.Contains(out, "▼ more") {
+		t.Error("expected ▼ more when nodes extend below viewport")
+	}
+	if strings.Contains(out, "▲ more") {
+		t.Error("unexpected ▲ more when offset=0")
+	}
 }
 
 func TestRender_aboveHintWhenScrolledDown(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(10))
-    s.offset = 3
-    s.cursor = 3
-    out := renderInner(s, 4)
-    if !strings.Contains(out, "▲ more") {
-        t.Error("expected ▲ more when offset > 0")
-    }
+	s := sidebarWithNodes(makeNodes(10))
+	s.offset = 3
+	s.cursor = 3
+	out := renderInner(s, 4)
+	if !strings.Contains(out, "▲ more") {
+		t.Error("expected ▲ more when offset > 0")
+	}
 }
 
 func TestRender_bothHintsWhenScrolledMid(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(10))
-    s.offset = 3
-    s.cursor = 3
-    out := renderInner(s, 4)
-    if !strings.Contains(out, "▲ more") {
-        t.Error("expected ▲ more")
-    }
-    if !strings.Contains(out, "▼ more") {
-        t.Error("expected ▼ more")
-    }
+	s := sidebarWithNodes(makeNodes(10))
+	s.offset = 3
+	s.cursor = 3
+	out := renderInner(s, 4)
+	if !strings.Contains(out, "▲ more") {
+		t.Error("expected ▲ more")
+	}
+	if !strings.Contains(out, "▼ more") {
+		t.Error("expected ▼ more")
+	}
 }
 
 // TestRender_belowHintWhenScrolledNearBottom is the regression test for the bug
@@ -209,221 +209,221 @@ func TestRender_bothHintsWhenScrolledMid(t *testing.T) {
 // so that ▲ is showing, nodes just off the bottom were miscounted as fitting,
 // suppressing ▼ and leaving a blank row instead.
 func TestRender_belowHintWhenScrolledNearBottom(t *testing.T) {
-    // 10 nodes, visibleRows=4, offset=6 → ▲ costs 1 row → only 3 content rows fit
-    // (nodes 6,7,8). Node 9 is still below, so ▼ must appear.
-    s := sidebarWithNodes(makeNodes(10))
-    s.offset = 6
-    s.cursor = 6
-    out := renderInner(s, 4)
-    if !strings.Contains(out, "▼ more") {
-        t.Error("expected ▼ more: node 9 is out of view but hint was suppressed")
-    }
-    if !strings.Contains(out, "▲ more") {
-        t.Error("expected ▲ more when offset=6")
-    }
+	// 10 nodes, visibleRows=4, offset=6 → ▲ costs 1 row → only 3 content rows fit
+	// (nodes 6,7,8). Node 9 is still below, so ▼ must appear.
+	s := sidebarWithNodes(makeNodes(10))
+	s.offset = 6
+	s.cursor = 6
+	out := renderInner(s, 4)
+	if !strings.Contains(out, "▼ more") {
+		t.Error("expected ▼ more: node 9 is out of view but hint was suppressed")
+	}
+	if !strings.Contains(out, "▲ more") {
+		t.Error("expected ▲ more when offset=6")
+	}
 }
 
 // hints must not add extra rows (total content <= visibleRows)
 func TestRender_hintsDoNotExceedVisibleRows(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(10))
-    s.offset = 3
-    s.cursor = 3
-    visibleRows := 4
-    rendered := s.Render(40, visibleRows+2, false, "", "")
-    // count newlines in the inner content (strip border lines)
-    inner := stripANSI(rendered)
-    lines := strings.Split(strings.TrimRight(inner, "\n"), "\n")
-    // border adds 2 lines (top + bottom); remaining content lines <= visibleRows
-    contentLines := len(lines) - 2
-    if contentLines > visibleRows {
-        t.Errorf("content lines %d exceed visibleRows %d", contentLines, visibleRows)
-    }
+	s := sidebarWithNodes(makeNodes(10))
+	s.offset = 3
+	s.cursor = 3
+	visibleRows := 4
+	rendered := s.Render(40, visibleRows+2, false, "", "")
+	// count newlines in the inner content (strip border lines)
+	inner := stripANSI(rendered)
+	lines := strings.Split(strings.TrimRight(inner, "\n"), "\n")
+	// border adds 2 lines (top + bottom); remaining content lines <= visibleRows
+	contentLines := len(lines) - 2
+	if contentLines > visibleRows {
+		t.Errorf("content lines %d exceed visibleRows %d", contentLines, visibleRows)
+	}
 }
 
 // --- Name truncation ---
 
 func TestRenderSession_longNameTruncated(t *testing.T) {
-    s := sidebarWithNodes([]SidebarNode{
-        {Session: "a-very-long-session-name-that-exceeds-width"},
-    })
-    width := 20
-    text := s.renderSession(s.nodes[0], false, false, width)
-    runes := []rune(stripANSI(text))
-    if len(runes) > width-2 {
-        t.Errorf("rendered length %d exceeds available width %d", len(runes), width-2)
-    }
-    if !strings.Contains(stripANSI(text), "…") {
-        t.Error("expected ellipsis in truncated name")
-    }
+	s := sidebarWithNodes([]SidebarNode{
+		{Session: "a-very-long-session-name-that-exceeds-width"},
+	})
+	width := 20
+	text := s.renderSession(s.nodes[0], false, false, width)
+	runes := []rune(stripANSI(text))
+	if len(runes) > width-2 {
+		t.Errorf("rendered length %d exceeds available width %d", len(runes), width-2)
+	}
+	if !strings.Contains(stripANSI(text), "…") {
+		t.Error("expected ellipsis in truncated name")
+	}
 }
 
 func TestRenderSession_truncatedNameWithIndicators_noOverflow(t *testing.T) {
-    // Regression: when a name is truncated and indicators are present, the
-    // separator space (enforced by alignedRow) must be pre-reserved in maxName
-    // so the row does not exceed availW.
-    initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
-    activity := time.Now().Add(-6 * 24 * time.Hour) // "6d" indicator (3 chars)
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "hf-garmin-credentials-integration", IsLive: true, Activity: activity},
-        },
-        alerts:  map[string]db.Alert{},
-        gitInfo: map[string]git.Info{},
-        cfg:     config.Config{Sidebar: config.SidebarConfig{ShowLastSeen: true}},
-    }
-    s.rebuildNodes()
-    width := 30
-    text := s.renderSession(s.nodes[0], false, false, width)
-    runes := []rune(stripANSI(text))
-    if len(runes) > width-2 {
-        t.Errorf("truncated row length %d exceeds width-2=%d", len(runes), width-2)
-    }
-    if !strings.Contains(stripANSI(text), "…") {
-        t.Error("expected ellipsis in truncated name")
-    }
+	// Regression: when a name is truncated and indicators are present, the
+	// separator space (enforced by alignedRow) must be pre-reserved in maxName
+	// so the row does not exceed availW.
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
+	activity := time.Now().Add(-6 * 24 * time.Hour) // "6d" indicator (3 chars)
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "hf-garmin-credentials-integration", IsLive: true, Activity: activity},
+		},
+		alerts:  map[string]db.Alert{},
+		gitInfo: map[string]git.Info{},
+		cfg:     config.Config{Sidebar: config.SidebarConfig{ShowLastSeen: true}},
+	}
+	s.rebuildNodes()
+	width := 30
+	text := s.renderSession(s.nodes[0], false, false, width)
+	runes := []rune(stripANSI(text))
+	if len(runes) > width-2 {
+		t.Errorf("truncated row length %d exceeds width-2=%d", len(runes), width-2)
+	}
+	if !strings.Contains(stripANSI(text), "…") {
+		t.Error("expected ellipsis in truncated name")
+	}
 }
 
 func TestRenderSession_shortNameNotTruncated(t *testing.T) {
-    s := sidebarWithNodes([]SidebarNode{
-        {Session: "short"},
-    })
-    text := s.renderSession(s.nodes[0], false, false, 40)
-    if strings.Contains(stripANSI(text), "…") {
-        t.Error("unexpected ellipsis for short name")
-    }
+	s := sidebarWithNodes([]SidebarNode{
+		{Session: "short"},
+	})
+	text := s.renderSession(s.nodes[0], false, false, 40)
+	if strings.Contains(stripANSI(text), "…") {
+		t.Error("unexpected ellipsis for short name")
+	}
 }
 
 // --- Right-alignment ---
 
 func TestAlignedRow_indicatorsAtRightEdge(t *testing.T) {
-    row := alignedRow("name", "* ↑2", 20)
-    plain := stripANSI(row)
-    runes := []rune(plain)
-    if len(runes) != 20 {
-        t.Errorf("expected total width 20, got %d: %q", len(runes), plain)
-    }
-    if !strings.HasSuffix(plain, "* ↑2") {
-        t.Errorf("indicators not at right edge: %q", plain)
-    }
+	row := alignedRow("name", "* ↑2", 20)
+	plain := stripANSI(row)
+	runes := []rune(plain)
+	if len(runes) != 20 {
+		t.Errorf("expected total width 20, got %d: %q", len(runes), plain)
+	}
+	if !strings.HasSuffix(plain, "* ↑2") {
+		t.Errorf("indicators not at right edge: %q", plain)
+	}
 }
 
 func TestAlignedRow_noIndicators(t *testing.T) {
-    row := alignedRow("session-a", "", 20)
-    plain := stripANSI(row)
-    // with no indicators the row is just the name (no trailing spaces required)
-    if !strings.HasPrefix(plain, "session-a") {
-        t.Errorf("unexpected content: %q", plain)
-    }
+	row := alignedRow("session-a", "", 20)
+	plain := stripANSI(row)
+	// with no indicators the row is just the name (no trailing spaces required)
+	if !strings.HasPrefix(plain, "session-a") {
+		t.Errorf("unexpected content: %q", plain)
+	}
 }
 
 func TestAlignedRow_minimumOnePadSpace(t *testing.T) {
-    // name + indicators exactly fill availWidth — must still have 1 pad space
-    row := alignedRow("name", "ind", 7) // "name"(4) + "ind"(3) = 7, no room
-    plain := stripANSI(row)
-    if !strings.Contains(plain, " ") {
-        t.Errorf("expected at least one space between name and indicators: %q", plain)
-    }
+	// name + indicators exactly fill availWidth — must still have 1 pad space
+	row := alignedRow("name", "ind", 7) // "name"(4) + "ind"(3) = 7, no room
+	plain := stripANSI(row)
+	if !strings.Contains(plain, " ") {
+		t.Errorf("expected at least one space between name and indicators: %q", plain)
+	}
 }
 
 // --- GotoTop / GotoBottom ---
 
 func TestGotoTop_SetsToFirstAndClampsViewport(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(10))
-    s.cursor = 8
-    s.offset = 5
-    s.GotoTop(10)
-    if s.cursor != 0 {
-        t.Errorf("expected cursor=0, got %d", s.cursor)
-    }
-    if s.offset != 0 {
-        t.Errorf("expected offset=0, got %d", s.offset)
-    }
+	s := sidebarWithNodes(makeNodes(10))
+	s.cursor = 8
+	s.offset = 5
+	s.GotoTop(10)
+	if s.cursor != 0 {
+		t.Errorf("expected cursor=0, got %d", s.cursor)
+	}
+	if s.offset != 0 {
+		t.Errorf("expected offset=0, got %d", s.offset)
+	}
 }
 
 func TestGotoBottom_SetsToLastNode(t *testing.T) {
-    s := sidebarWithNodes(makeNodes(5))
-    s.cursor = 0
-    s.GotoBottom(10)
-    if s.cursor != 4 {
-        t.Errorf("expected cursor=4, got %d", s.cursor)
-    }
+	s := sidebarWithNodes(makeNodes(5))
+	s.cursor = 0
+	s.GotoBottom(10)
+	if s.cursor != 4 {
+		t.Errorf("expected cursor=4, got %d", s.cursor)
+	}
 }
 
 func TestSidebarGotoBottom_EmptyNodes_NoPanic(t *testing.T) {
-    s := SidebarModel{}
-    s.GotoBottom(10) // must not panic, cursor stays at 0
-    if s.cursor != 0 {
-        t.Errorf("expected cursor=0, got %d", s.cursor)
-    }
+	s := SidebarModel{}
+	s.GotoBottom(10) // must not panic, cursor stays at 0
+	if s.cursor != 0 {
+		t.Errorf("expected cursor=0, got %d", s.cursor)
+	}
 }
 
 // --- SessionCount ---
 
 func TestSessionCount_CountsAllNodes(t *testing.T) {
-    nodes := []SidebarNode{
-        {Session: "a"},
-        {Session: "b"},
-    }
-    s := sidebarWithNodes(nodes)
-    if s.SessionCount() != 2 {
-        t.Errorf("expected 2, got %d", s.SessionCount())
-    }
+	nodes := []SidebarNode{
+		{Session: "a"},
+		{Session: "b"},
+	}
+	s := sidebarWithNodes(nodes)
+	if s.SessionCount() != 2 {
+		t.Errorf("expected 2, got %d", s.SessionCount())
+	}
 }
 
 func TestSessionCount_Empty(t *testing.T) {
-    s := SidebarModel{}
-    if s.SessionCount() != 0 {
-        t.Errorf("expected 0, got %d", s.SessionCount())
-    }
+	s := SidebarModel{}
+	if s.SessionCount() != 0 {
+		t.Errorf("expected 0, got %d", s.SessionCount())
+	}
 }
 
 // --- newestSessionAlert ---
 
 func TestNewestSessionAlert_NoAlerts(t *testing.T) {
-    s := SidebarModel{alerts: map[string]db.Alert{}}
-    if !s.newestSessionAlert("sess").IsZero() {
-        t.Error("expected zero time when no alerts for session")
-    }
+	s := SidebarModel{alerts: map[string]db.Alert{}}
+	if !s.newestSessionAlert("sess").IsZero() {
+		t.Error("expected zero time when no alerts for session")
+	}
 }
 
 func TestNewestSessionAlert_IgnoresDifferentSession(t *testing.T) {
-    t1 := time.Now()
-    s := SidebarModel{
-        alerts: map[string]db.Alert{
-            "other:0": {Target: "other:0", CreatedAt: t1},
-        },
-    }
-    if !s.newestSessionAlert("sess").IsZero() {
-        t.Error("expected zero time — alert belongs to a different session")
-    }
+	t1 := time.Now()
+	s := SidebarModel{
+		alerts: map[string]db.Alert{
+			"other:0": {Target: "other:0", CreatedAt: t1},
+		},
+	}
+	if !s.newestSessionAlert("sess").IsZero() {
+		t.Error("expected zero time — alert belongs to a different session")
+	}
 }
 
 func TestNewestSessionAlert_ReturnsNewestAmongWindows(t *testing.T) {
-    t1 := time.Now().Add(-10 * time.Second)
-    t2 := time.Now()
-    s := SidebarModel{
-        alerts: map[string]db.Alert{
-            "sess:0.0": {Target: "sess:0.0", CreatedAt: t1},
-            "sess:1.0": {Target: "sess:1.0", CreatedAt: t2},
-        },
-    }
-    got := s.newestSessionAlert("sess")
-    if !got.Equal(t2) {
-        t.Errorf("expected newest alert time %v, got %v", t2, got)
-    }
+	t1 := time.Now().Add(-10 * time.Second)
+	t2 := time.Now()
+	s := SidebarModel{
+		alerts: map[string]db.Alert{
+			"sess:0.0": {Target: "sess:0.0", CreatedAt: t1},
+			"sess:1.0": {Target: "sess:1.0", CreatedAt: t2},
+		},
+	}
+	got := s.newestSessionAlert("sess")
+	if !got.Equal(t2) {
+		t.Errorf("expected newest alert time %v, got %v", t2, got)
+	}
 }
 
 func TestNewestSessionAlert_MatchesSessionLevelTarget(t *testing.T) {
-    t1 := time.Now()
-    s := SidebarModel{
-        alerts: map[string]db.Alert{
-            "sess": {Target: "sess", CreatedAt: t1},
-        },
-    }
-    got := s.newestSessionAlert("sess")
-    if !got.Equal(t1) {
-        t.Errorf("expected %v, got %v", t1, got)
-    }
+	t1 := time.Now()
+	s := SidebarModel{
+		alerts: map[string]db.Alert{
+			"sess": {Target: "sess", CreatedAt: t1},
+		},
+	}
+	got := s.newestSessionAlert("sess")
+	if !got.Equal(t1) {
+		t.Errorf("expected %v, got %v", t1, got)
+	}
 }
 
 // --- rebuildNodes sorting ---
@@ -433,99 +433,99 @@ func TestNewestSessionAlert_MatchesSessionLevelTarget(t *testing.T) {
 // is non-nil but empty (active search, zero matches), rebuildNodes must
 // produce an empty node list, not the full unfiltered list.
 func TestRebuildNodes_ZeroResultSearch(t *testing.T) {
-    s := SidebarModel{
-        sessions: makeSessions("alpha", "beta", "gamma"),
-        alerts:   map[string]db.Alert{},
-        // Non-nil empty slice = active search with no matches.
-        queryResult: query.Result{Sessions: []query.SessionMatch{}},
-    }
-    s.rebuildNodes()
-    if len(s.nodes) != 0 {
-        t.Errorf("expected 0 nodes for a zero-result search, got %d", len(s.nodes))
-    }
+	s := SidebarModel{
+		sessions: makeSessions("alpha", "beta", "gamma"),
+		alerts:   map[string]db.Alert{},
+		// Non-nil empty slice = active search with no matches.
+		queryResult: query.Result{Sessions: []query.SessionMatch{}},
+	}
+	s.rebuildNodes()
+	if len(s.nodes) != 0 {
+		t.Errorf("expected 0 nodes for a zero-result search, got %d", len(s.nodes))
+	}
 }
 
 func TestRender_NoResultsHint(t *testing.T) {
-    s := SidebarModel{
-        sessions:    makeSessions("alpha", "beta"),
-        alerts:      map[string]db.Alert{},
-        queryResult: query.Result{Sessions: []query.SessionMatch{}},
-    }
-    s.rebuildNodes()
-    out := s.Render(40, 10, false, "", "")
-    if !strings.Contains(stripANSI(out), "no results") {
-        t.Errorf("expected 'no results' hint when search returns zero matches, got: %q", stripANSI(out))
-    }
+	s := SidebarModel{
+		sessions:    makeSessions("alpha", "beta"),
+		alerts:      map[string]db.Alert{},
+		queryResult: query.Result{Sessions: []query.SessionMatch{}},
+	}
+	s.rebuildNodes()
+	out := s.Render(40, 10, false, "", "")
+	if !strings.Contains(stripANSI(out), "no results") {
+		t.Errorf("expected 'no results' hint when search returns zero matches, got: %q", stripANSI(out))
+	}
 }
 
 func TestRebuildNodes_NoAlerts_AlphabeticalOrder(t *testing.T) {
-    s := SidebarModel{
-        sessions: makeSessions("charlie", "alpha", "beta"),
-        alerts:   map[string]db.Alert{},
-    }
-    s.rebuildNodes()
-    var got []string
-    for _, n := range s.nodes {
-        got = append(got, n.Session)
-    }
-    want := []string{"alpha", "beta", "charlie"}
-    if strings.Join(got, ",") != strings.Join(want, ",") {
-        t.Errorf("expected %v, got %v", want, got)
-    }
+	s := SidebarModel{
+		sessions: makeSessions("charlie", "alpha", "beta"),
+		alerts:   map[string]db.Alert{},
+	}
+	s.rebuildNodes()
+	var got []string
+	for _, n := range s.nodes {
+		got = append(got, n.Session)
+	}
+	want := []string{"alpha", "beta", "charlie"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("expected %v, got %v", want, got)
+	}
 }
 
 func TestRebuildNodes_SessionWithAlertSortsFirst(t *testing.T) {
-    t1 := time.Now()
-    s := SidebarModel{
-        sessions: makeSessions("alpha", "beta"),
-        alerts: map[string]db.Alert{
-            "beta:0.0": {Target: "beta:0.0", CreatedAt: t1},
-        },
-    }
-    s.rebuildNodes()
-    if len(s.nodes) == 0 || s.nodes[0].Session != "beta" {
-        t.Errorf("expected beta (has alert) first, got %v", s.nodes[0].Session)
-    }
+	t1 := time.Now()
+	s := SidebarModel{
+		sessions: makeSessions("alpha", "beta"),
+		alerts: map[string]db.Alert{
+			"beta:0.0": {Target: "beta:0.0", CreatedAt: t1},
+		},
+	}
+	s.rebuildNodes()
+	if len(s.nodes) == 0 || s.nodes[0].Session != "beta" {
+		t.Errorf("expected beta (has alert) first, got %v", s.nodes[0].Session)
+	}
 }
 
 func TestRebuildNodes_NewestAlertSessionSortsFirst(t *testing.T) {
-    t1 := time.Now().Add(-time.Minute)
-    t2 := time.Now()
-    s := SidebarModel{
-        sessions: makeSessions("alpha", "beta"),
-        alerts: map[string]db.Alert{
-            "alpha:0.0": {Target: "alpha:0.0", CreatedAt: t1},
-            "beta:0.0":  {Target: "beta:0.0", CreatedAt: t2},
-        },
-    }
-    s.rebuildNodes()
-    if len(s.nodes) == 0 || s.nodes[0].Session != "beta" {
-        t.Errorf("expected beta (newer alert) first, got %v", s.nodes[0].Session)
-    }
+	t1 := time.Now().Add(-time.Minute)
+	t2 := time.Now()
+	s := SidebarModel{
+		sessions: makeSessions("alpha", "beta"),
+		alerts: map[string]db.Alert{
+			"alpha:0.0": {Target: "alpha:0.0", CreatedAt: t1},
+			"beta:0.0":  {Target: "beta:0.0", CreatedAt: t2},
+		},
+	}
+	s.rebuildNodes()
+	if len(s.nodes) == 0 || s.nodes[0].Session != "beta" {
+		t.Errorf("expected beta (newer alert) first, got %v", s.nodes[0].Session)
+	}
 }
 
 // TestRebuildNodes_PrioritySort_SeverityBeatsRecency is the regression test for
 // the bug where a newer info alert sorted before an older warn alert. Severity
 // must be compared first; recency is only a tiebreaker within the same level.
 func TestRebuildNodes_PrioritySort_SeverityBeatsRecency(t *testing.T) {
-    // dm-main has a newer info alert; vem-main has an older warn alert.
-    // warn > info, so vem-main must sort first regardless of timestamp.
-    older := time.Now().Add(-time.Minute)
-    newer := time.Now()
-    s := SidebarModel{
-        sessions: makeSessions("dm-main", "vem-main"),
-        alerts: map[string]db.Alert{
-            "dm-main:0.0":  {Target: "dm-main:0.0", Level: "info", CreatedAt: newer},
-            "vem-main:0.0": {Target: "vem-main:0.0", Level: "warn", CreatedAt: older},
-        },
-    }
-    s.rebuildNodes()
-    if len(s.nodes) < 2 {
-        t.Fatalf("expected 2 nodes, got %d", len(s.nodes))
-    }
-    if s.nodes[0].Session != "vem-main" {
-        t.Errorf("expected vem-main (warn) first, got %q", s.nodes[0].Session)
-    }
+	// dm-main has a newer info alert; vem-main has an older warn alert.
+	// warn > info, so vem-main must sort first regardless of timestamp.
+	older := time.Now().Add(-time.Minute)
+	newer := time.Now()
+	s := SidebarModel{
+		sessions: makeSessions("dm-main", "vem-main"),
+		alerts: map[string]db.Alert{
+			"dm-main:0.0":  {Target: "dm-main:0.0", Level: "info", CreatedAt: newer},
+			"vem-main:0.0": {Target: "vem-main:0.0", Level: "warn", CreatedAt: older},
+		},
+	}
+	s.rebuildNodes()
+	if len(s.nodes) < 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(s.nodes))
+	}
+	if s.nodes[0].Session != "vem-main" {
+		t.Errorf("expected vem-main (warn) first, got %q", s.nodes[0].Session)
+	}
 }
 
 // TestRebuildNodes_PrioritySort_TiebreakerIgnoresLowerLevelAlert is the
@@ -533,690 +533,690 @@ func TestRebuildNodes_PrioritySort_SeverityBeatsRecency(t *testing.T) {
 // sorted before a session with [warn (recent)] because the defer timestamp was
 // used as the tiebreaker instead of restricting to the matching severity.
 func TestRebuildNodes_PrioritySort_TiebreakerIgnoresLowerLevelAlert(t *testing.T) {
-    // hf has a warn (9m) and a newer defer (11s). dm has a warn (7m).
-    // Both highest severities are equal (warn). Tiebreaker must compare only
-    // the warn timestamps: dm's warn (7m) is more recent, so dm sorts first.
-    now := time.Now()
-    s := SidebarModel{
-        sessions: makeSessions("hf-add-to-home-screen", "dm-main"),
-        alerts: map[string]db.Alert{
-            "hf-add-to-home-screen:0.1": {Target: "hf-add-to-home-screen:0.1", Level: "warn", CreatedAt: now.Add(-9 * time.Minute)},
-            "hf-add-to-home-screen":     {Target: "hf-add-to-home-screen", Level: "defer", CreatedAt: now.Add(-11 * time.Second)},
-            "dm-main:0.1":               {Target: "dm-main:0.1", Level: "warn", CreatedAt: now.Add(-7 * time.Minute)},
-        },
-    }
-    s.rebuildNodes()
-    if len(s.nodes) < 2 {
-        t.Fatalf("expected 2 nodes, got %d", len(s.nodes))
-    }
-    if s.nodes[0].Session != "dm-main" {
-        t.Errorf("expected dm-main (newer warn) first, got %q", s.nodes[0].Session)
-    }
+	// hf has a warn (9m) and a newer defer (11s). dm has a warn (7m).
+	// Both highest severities are equal (warn). Tiebreaker must compare only
+	// the warn timestamps: dm's warn (7m) is more recent, so dm sorts first.
+	now := time.Now()
+	s := SidebarModel{
+		sessions: makeSessions("hf-add-to-home-screen", "dm-main"),
+		alerts: map[string]db.Alert{
+			"hf-add-to-home-screen:0.1": {Target: "hf-add-to-home-screen:0.1", Level: "warn", CreatedAt: now.Add(-9 * time.Minute)},
+			"hf-add-to-home-screen":     {Target: "hf-add-to-home-screen", Level: "defer", CreatedAt: now.Add(-11 * time.Second)},
+			"dm-main:0.1":               {Target: "dm-main:0.1", Level: "warn", CreatedAt: now.Add(-7 * time.Minute)},
+		},
+	}
+	s.rebuildNodes()
+	if len(s.nodes) < 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(s.nodes))
+	}
+	if s.nodes[0].Session != "dm-main" {
+		t.Errorf("expected dm-main (newer warn) first, got %q", s.nodes[0].Session)
+	}
 }
 
 // --- Alert filter ---
 
 func TestRebuildNodes_LastSeenSort(t *testing.T) {
-    now := time.Now()
-    older := now.Add(-10 * time.Minute)
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "alpha", IsLive: true, Activity: older},
-            {DisplayName: "beta", IsLive: true, Activity: now},
-        },
-        alerts: map[string]db.Alert{},
-        cfg:    config.Config{Sidebar: config.SidebarConfig{Sort: []string{"last_seen", "priority", "alphabetical"}}},
-    }
-    s.rebuildNodes()
-    var got []string
-    for _, n := range s.nodes {
-        got = append(got, n.Session)
-    }
-    // beta is more recent → should appear first
-    if len(got) < 2 || got[0] != "beta" {
-        t.Errorf("expected beta (more recent) first, got %v", got)
-    }
+	now := time.Now()
+	older := now.Add(-10 * time.Minute)
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "alpha", IsLive: true, Activity: older},
+			{DisplayName: "beta", IsLive: true, Activity: now},
+		},
+		alerts: map[string]db.Alert{},
+		cfg:    config.Config{Sidebar: config.SidebarConfig{Sort: []string{"last_seen", "priority", "alphabetical"}}},
+	}
+	s.rebuildNodes()
+	var got []string
+	for _, n := range s.nodes {
+		got = append(got, n.Session)
+	}
+	// beta is more recent → should appear first
+	if len(got) < 2 || got[0] != "beta" {
+		t.Errorf("expected beta (more recent) first, got %v", got)
+	}
 }
 
 func TestRebuildNodes_LastSeenSort_ThenAlpha(t *testing.T) {
-    now := time.Now()
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "charlie", IsLive: true, Activity: now},
-            {DisplayName: "alpha", IsLive: true, Activity: now},
-            {DisplayName: "beta", IsLive: true, Activity: now},
-        },
-        alerts: map[string]db.Alert{},
-        // all same activity time → falls through to alpha
-        cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"last_seen", "priority", "alphabetical"}}},
-    }
-    s.rebuildNodes()
-    var got []string
-    for _, n := range s.nodes {
-        got = append(got, n.Session)
-    }
-    want := []string{"alpha", "beta", "charlie"}
-    if strings.Join(got, ",") != strings.Join(want, ",") {
-        t.Errorf("expected %v (alpha tiebreak), got %v", want, got)
-    }
+	now := time.Now()
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "charlie", IsLive: true, Activity: now},
+			{DisplayName: "alpha", IsLive: true, Activity: now},
+			{DisplayName: "beta", IsLive: true, Activity: now},
+		},
+		alerts: map[string]db.Alert{},
+		// all same activity time → falls through to alpha
+		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"last_seen", "priority", "alphabetical"}}},
+	}
+	s.rebuildNodes()
+	var got []string
+	for _, n := range s.nodes {
+		got = append(got, n.Session)
+	}
+	want := []string{"alpha", "beta", "charlie"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("expected %v (alpha tiebreak), got %v", want, got)
+	}
 }
 
 func TestToggleAlertFilter_FilterOnHidesSessionsWithoutAlerts(t *testing.T) {
-    t1 := time.Now()
-    s := SidebarModel{
-        sessions: makeSessions("alpha", "beta"),
-        alerts: map[string]db.Alert{
-            "beta:0.0": {Target: "beta:0.0", CreatedAt: t1},
-        },
-        cfg: config.Config{Sidebar: config.SidebarConfig{}},
-    }
-    s.SetFilter(FilterPriority, 10)
-    if s.ActiveFilter() != FilterPriority {
-        t.Error("expected filter to be FilterPriority")
-    }
-    for _, n := range s.nodes {
-        if n.Session == "alpha" {
-            t.Error("expected alpha (no alert) to be hidden")
-        }
-    }
+	t1 := time.Now()
+	s := SidebarModel{
+		sessions: makeSessions("alpha", "beta"),
+		alerts: map[string]db.Alert{
+			"beta:0.0": {Target: "beta:0.0", CreatedAt: t1},
+		},
+		cfg: config.Config{Sidebar: config.SidebarConfig{}},
+	}
+	s.SetFilter(FilterPriority, 10)
+	if s.ActiveFilter() != FilterPriority {
+		t.Error("expected filter to be FilterPriority")
+	}
+	for _, n := range s.nodes {
+		if n.Session == "alpha" {
+			t.Error("expected alpha (no alert) to be hidden")
+		}
+	}
 }
 
 func TestSetFilter_AllFiltersToggle(t *testing.T) {
-    s := SidebarModel{
-        sessions: makeSessions("alpha", "beta"),
-        alerts:   map[string]db.Alert{},
-        cfg:      config.Config{Sidebar: config.SidebarConfig{}},
-        filter:   FilterTmux,
-    }
-    // Move cursor to "beta" (index 1 after rebuild).
-    s.rebuildNodes()
-    s.cursor = 1 // "beta"
+	s := SidebarModel{
+		sessions: makeSessions("alpha", "beta"),
+		alerts:   map[string]db.Alert{},
+		cfg:      config.Config{Sidebar: config.SidebarConfig{}},
+		filter:   FilterTmux,
+	}
+	// Move cursor to "beta" (index 1 after rebuild).
+	s.rebuildNodes()
+	s.cursor = 1 // "beta"
 
-    // Switch to FilterAll — cursor should follow "beta", prevSession saved as "beta".
-    s.SetFilter(FilterAll, 10)
-    if s.ActiveFilter() != FilterAll {
-        t.Fatalf("expected FilterAll, got %q", s.ActiveFilter())
-    }
-    // Move to "alpha" in the all-sessions view.
-    s.cursor = 0
+	// Switch to FilterAll — cursor should follow "beta", prevSession saved as "beta".
+	s.SetFilter(FilterAll, 10)
+	if s.ActiveFilter() != FilterAll {
+		t.Fatalf("expected FilterAll, got %q", s.ActiveFilter())
+	}
+	// Move to "alpha" in the all-sessions view.
+	s.cursor = 0
 
-    // Toggle back — cursor should be restored to "beta".
-    s.SetFilter(FilterAll, 10)
-    if s.ActiveFilter() != FilterTmux {
-        t.Errorf("expected toggle back to FilterTmux, got %q", s.ActiveFilter())
-    }
-    if len(s.nodes) > 0 && s.nodes[s.cursor].Session != "beta" {
-        t.Errorf("expected cursor restored to beta, got %q", s.nodes[s.cursor].Session)
-    }
+	// Toggle back — cursor should be restored to "beta".
+	s.SetFilter(FilterAll, 10)
+	if s.ActiveFilter() != FilterTmux {
+		t.Errorf("expected toggle back to FilterTmux, got %q", s.ActiveFilter())
+	}
+	if len(s.nodes) > 0 && s.nodes[s.cursor].Session != "beta" {
+		t.Errorf("expected cursor restored to beta, got %q", s.nodes[s.cursor].Session)
+	}
 
-    // After toggling back, pressing FilterAll again should go to FilterAll.
-    s.SetFilter(FilterAll, 10)
-    if s.ActiveFilter() != FilterAll {
-        t.Errorf("expected FilterAll after re-press, got %q", s.ActiveFilter())
-    }
+	// After toggling back, pressing FilterAll again should go to FilterAll.
+	s.SetFilter(FilterAll, 10)
+	if s.ActiveFilter() != FilterAll {
+		t.Errorf("expected FilterAll after re-press, got %q", s.ActiveFilter())
+	}
 }
 
 func TestToggleAlertFilter_ToggleOffRestoresAllSessions(t *testing.T) {
-    t1 := time.Now()
-    s := SidebarModel{
-        sessions: makeSessions("alpha", "beta"),
-        alerts: map[string]db.Alert{
-            "beta:0.0": {Target: "beta:0.0", CreatedAt: t1},
-        },
-        cfg: config.Config{Sidebar: config.SidebarConfig{}},
-    }
-    s.SetFilter(FilterPriority, 10) // on
-    s.SetFilter(FilterPriority, 10) // off (toggles back to FilterTmux)
-    if s.ActiveFilter() == FilterPriority {
-        t.Error("expected filter to toggle off")
-    }
-    if len(s.nodes) != 2 {
-        t.Errorf("expected 2 sessions after toggle off, got %d", len(s.nodes))
-    }
+	t1 := time.Now()
+	s := SidebarModel{
+		sessions: makeSessions("alpha", "beta"),
+		alerts: map[string]db.Alert{
+			"beta:0.0": {Target: "beta:0.0", CreatedAt: t1},
+		},
+		cfg: config.Config{Sidebar: config.SidebarConfig{}},
+	}
+	s.SetFilter(FilterPriority, 10) // on
+	s.SetFilter(FilterPriority, 10) // off (toggles back to FilterTmux)
+	if s.ActiveFilter() == FilterPriority {
+		t.Error("expected filter to toggle off")
+	}
+	if len(s.nodes) != 2 {
+		t.Errorf("expected 2 sessions after toggle off, got %d", len(s.nodes))
+	}
 }
 
 func TestAlertFilterActive_ReportsCorrectState(t *testing.T) {
-    s := SidebarModel{
-        sessions: makeSessions("a"),
-        alerts:   map[string]db.Alert{},
-        cfg:      config.Config{Sidebar: config.SidebarConfig{}},
-    }
-    if s.ActiveFilter() == FilterPriority {
-        t.Error("expected not-FilterPriority before SetFilter")
-    }
-    s.SetFilter(FilterPriority, 10)
-    if s.ActiveFilter() != FilterPriority {
-        t.Error("expected FilterPriority after SetFilter")
-    }
+	s := SidebarModel{
+		sessions: makeSessions("a"),
+		alerts:   map[string]db.Alert{},
+		cfg:      config.Config{Sidebar: config.SidebarConfig{}},
+	}
+	if s.ActiveFilter() == FilterPriority {
+		t.Error("expected not-FilterPriority before SetFilter")
+	}
+	s.SetFilter(FilterPriority, 10)
+	if s.ActiveFilter() != FilterPriority {
+		t.Error("expected FilterPriority after SetFilter")
+	}
 }
 
 func TestToggleAlertFilter_NoAlertedWindowFallback_CursorClamped(t *testing.T) {
-    s := SidebarModel{
-        sessions: makeSessions("sess"),
-        alerts:   map[string]db.Alert{},
-        cfg:      config.Config{Sidebar: config.SidebarConfig{}},
-    }
-    s.cursor = 5
-    s.SetFilter(FilterPriority, 10)
-    if s.cursor != 0 {
-        t.Errorf("expected cursor clamped to 0 on empty node list, got %d", s.cursor)
-    }
+	s := SidebarModel{
+		sessions: makeSessions("sess"),
+		alerts:   map[string]db.Alert{},
+		cfg:      config.Config{Sidebar: config.SidebarConfig{}},
+	}
+	s.cursor = 5
+	s.SetFilter(FilterPriority, 10)
+	if s.cursor != 0 {
+		t.Errorf("expected cursor clamped to 0 on empty node list, got %d", s.cursor)
+	}
 }
 
 // --- FocusNode ---
 
 func TestFocusNode_SessionLevel(t *testing.T) {
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "alpha", IsLive: true},
-            {DisplayName: "beta", IsLive: true},
-        },
-        alerts: map[string]db.Alert{},
-        cfg:    config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
-    }
-    s.rebuildNodes()
-    s.FocusNode("beta", 20)
-    node := s.Selected()
-    if node == nil || node.Session != "beta" {
-        t.Errorf("expected session node beta, got %+v", node)
-    }
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "alpha", IsLive: true},
+			{DisplayName: "beta", IsLive: true},
+		},
+		alerts: map[string]db.Alert{},
+		cfg:    config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
+	}
+	s.rebuildNodes()
+	s.FocusNode("beta", 20)
+	node := s.Selected()
+	if node == nil || node.Session != "beta" {
+		t.Errorf("expected session node beta, got %+v", node)
+	}
 }
 
 func TestFocusNode_NoMatch_LeavesCursorAt0(t *testing.T) {
-    s := SidebarModel{
-        sessions: makeSessions("alpha"),
-        alerts:   map[string]db.Alert{},
-    }
-    s.rebuildNodes()
-    s.FocusNode("nonexistent", 20)
-    if s.cursor != 0 {
-        t.Errorf("expected cursor=0, got %d", s.cursor)
-    }
+	s := SidebarModel{
+		sessions: makeSessions("alpha"),
+		alerts:   map[string]db.Alert{},
+	}
+	s.rebuildNodes()
+	s.FocusNode("nonexistent", 20)
+	if s.cursor != 0 {
+		t.Errorf("expected cursor=0, got %d", s.cursor)
+	}
 }
 
 // --- FocusFirstAlertSession ---
 
 func TestFocusFirstAlertSession_MovesToAlertedSession(t *testing.T) {
-    t1 := time.Now()
-    s := SidebarModel{
-        sessions: makeSessions("alpha", "beta"),
-        alerts: map[string]db.Alert{
-            "beta:0.0": {Target: "beta:0.0", Level: "warn", CreatedAt: t1},
-        },
-        cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
-    }
-    s.rebuildNodes()
-    s.FocusFirstAlertSession(20)
-    node := s.Selected()
-    if node == nil || node.Session != "beta" {
-        t.Errorf("expected session node beta, got %+v", node)
-    }
+	t1 := time.Now()
+	s := SidebarModel{
+		sessions: makeSessions("alpha", "beta"),
+		alerts: map[string]db.Alert{
+			"beta:0.0": {Target: "beta:0.0", Level: "warn", CreatedAt: t1},
+		},
+		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
+	}
+	s.rebuildNodes()
+	s.FocusFirstAlertSession(20)
+	node := s.Selected()
+	if node == nil || node.Session != "beta" {
+		t.Errorf("expected session node beta, got %+v", node)
+	}
 }
 
 func TestFocusFirstAlertSession_NoAlerts_LeavesCursorAt0(t *testing.T) {
-    s := SidebarModel{
-        sessions: makeSessions("alpha", "beta"),
-        alerts:   map[string]db.Alert{},
-    }
-    s.rebuildNodes()
-    s.FocusFirstAlertSession(20)
-    if s.cursor != 0 {
-        t.Errorf("expected cursor=0, got %d", s.cursor)
-    }
+	s := SidebarModel{
+		sessions: makeSessions("alpha", "beta"),
+		alerts:   map[string]db.Alert{},
+	}
+	s.rebuildNodes()
+	s.FocusFirstAlertSession(20)
+	if s.cursor != 0 {
+		t.Errorf("expected cursor=0, got %d", s.cursor)
+	}
 }
 
 // --- FocusFirstAlertSession returns bool ---
 
 func TestFocusFirstAlertSession_ReturnsTrue_WhenFound(t *testing.T) {
-    t1 := time.Now()
-    s := SidebarModel{
-        sessions: makeSessions("alpha"),
-        alerts: map[string]db.Alert{
-            "alpha:0.0": {Target: "alpha:0.0", Level: "warn", CreatedAt: t1},
-        },
-        cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
-    }
-    s.rebuildNodes()
-    found := s.FocusFirstAlertSession(20)
-    if !found {
-        t.Error("expected found=true")
-    }
+	t1 := time.Now()
+	s := SidebarModel{
+		sessions: makeSessions("alpha"),
+		alerts: map[string]db.Alert{
+			"alpha:0.0": {Target: "alpha:0.0", Level: "warn", CreatedAt: t1},
+		},
+		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
+	}
+	s.rebuildNodes()
+	found := s.FocusFirstAlertSession(20)
+	if !found {
+		t.Error("expected found=true")
+	}
 }
 
 func TestFocusFirstAlertSession_ReturnsFalse_WhenNotFound(t *testing.T) {
-    s := SidebarModel{
-        sessions: makeSessions("alpha"),
-        alerts:   map[string]db.Alert{},
-    }
-    s.rebuildNodes()
-    found := s.FocusFirstAlertSession(20)
-    if found {
-        t.Error("expected found=false when no alerted sessions")
-    }
+	s := SidebarModel{
+		sessions: makeSessions("alpha"),
+		alerts:   map[string]db.Alert{},
+	}
+	s.rebuildNodes()
+	found := s.FocusFirstAlertSession(20)
+	if found {
+		t.Error("expected found=false when no alerted sessions")
+	}
 }
 
 func makeSidebarWithAlerts(alerts []db.Alert) SidebarModel {
-    s := SidebarModel{}
-    s.alerts = make(map[string]db.Alert, len(alerts))
-    for _, a := range alerts {
-        s.alerts[a.Target] = a
-    }
-    return s
+	s := SidebarModel{}
+	s.alerts = make(map[string]db.Alert, len(alerts))
+	for _, a := range alerts {
+		s.alerts[a.Target] = a
+	}
+	return s
 }
 
 func TestBestAlertTargetInSession_NoAlerts(t *testing.T) {
-    s := makeSidebarWithAlerts(nil)
-    if got := s.BestAlertTargetInSession("work", "severity"); got != "" {
-        t.Errorf("expected empty, got %q", got)
-    }
+	s := makeSidebarWithAlerts(nil)
+	if got := s.BestAlertTargetInSession("work", "severity"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
 }
 
 func TestBestAlertTargetInSession_SingleAlert(t *testing.T) {
-    now := time.Now()
-    s := makeSidebarWithAlerts([]db.Alert{
-        {Target: "work:1.0", Level: db.LevelWarn, CreatedAt: now},
-    })
-    if got := s.BestAlertTargetInSession("work", "severity"); got != "work:1.0" {
-        t.Errorf("expected \"work:1.0\", got %q", got)
-    }
+	now := time.Now()
+	s := makeSidebarWithAlerts([]db.Alert{
+		{Target: "work:1.0", Level: db.LevelWarn, CreatedAt: now},
+	})
+	if got := s.BestAlertTargetInSession("work", "severity"); got != "work:1.0" {
+		t.Errorf("expected \"work:1.0\", got %q", got)
+	}
 }
 
 func TestBestAlertTargetInSession_SeverityPriority(t *testing.T) {
-    now := time.Now()
-    s := makeSidebarWithAlerts([]db.Alert{
-        {Target: "work:1.0", Level: db.LevelWarn,  CreatedAt: now.Add(-time.Minute)},
-        {Target: "work:2.0", Level: db.LevelError, CreatedAt: now.Add(-2 * time.Minute)},
-        {Target: "work:3.0", Level: db.LevelInfo,  CreatedAt: now},
-    })
-    if got := s.BestAlertTargetInSession("work", "severity"); got != "work:2.0" {
-        t.Errorf("expected \"work:2.0\" (highest severity), got %q", got)
-    }
+	now := time.Now()
+	s := makeSidebarWithAlerts([]db.Alert{
+		{Target: "work:1.0", Level: db.LevelWarn, CreatedAt: now.Add(-time.Minute)},
+		{Target: "work:2.0", Level: db.LevelError, CreatedAt: now.Add(-2 * time.Minute)},
+		{Target: "work:3.0", Level: db.LevelInfo, CreatedAt: now},
+	})
+	if got := s.BestAlertTargetInSession("work", "severity"); got != "work:2.0" {
+		t.Errorf("expected \"work:2.0\" (highest severity), got %q", got)
+	}
 }
 
 func TestBestAlertTargetInSession_SeverityTiebreaker(t *testing.T) {
-    base := time.Now()
-    s := makeSidebarWithAlerts([]db.Alert{
-        {Target: "work:1.0", Level: db.LevelError, CreatedAt: base.Add(-time.Minute)},
-        {Target: "work:2.0", Level: db.LevelError, CreatedAt: base},
-    })
-    // equal severity — newest wins
-    if got := s.BestAlertTargetInSession("work", "severity"); got != "work:2.0" {
-        t.Errorf("expected \"work:2.0\" (newer tiebreaker), got %q", got)
-    }
+	base := time.Now()
+	s := makeSidebarWithAlerts([]db.Alert{
+		{Target: "work:1.0", Level: db.LevelError, CreatedAt: base.Add(-time.Minute)},
+		{Target: "work:2.0", Level: db.LevelError, CreatedAt: base},
+	})
+	// equal severity — newest wins
+	if got := s.BestAlertTargetInSession("work", "severity"); got != "work:2.0" {
+		t.Errorf("expected \"work:2.0\" (newer tiebreaker), got %q", got)
+	}
 }
 
 func TestBestAlertTargetInSession_NewestPriority(t *testing.T) {
-    base := time.Now()
-    s := makeSidebarWithAlerts([]db.Alert{
-        {Target: "work:1.0", Level: db.LevelError, CreatedAt: base.Add(-time.Minute)},
-        {Target: "work:2.0", Level: db.LevelInfo,  CreatedAt: base},
-    })
-    if got := s.BestAlertTargetInSession("work", "newest"); got != "work:2.0" {
-        t.Errorf("expected \"work:2.0\" (newest), got %q", got)
-    }
+	base := time.Now()
+	s := makeSidebarWithAlerts([]db.Alert{
+		{Target: "work:1.0", Level: db.LevelError, CreatedAt: base.Add(-time.Minute)},
+		{Target: "work:2.0", Level: db.LevelInfo, CreatedAt: base},
+	})
+	if got := s.BestAlertTargetInSession("work", "newest"); got != "work:2.0" {
+		t.Errorf("expected \"work:2.0\" (newest), got %q", got)
+	}
 }
 
 func TestBestAlertTargetInSession_OldestPriority(t *testing.T) {
-    base := time.Now()
-    s := makeSidebarWithAlerts([]db.Alert{
-        {Target: "work:1.0", Level: db.LevelInfo,  CreatedAt: base.Add(-time.Minute)},
-        {Target: "work:2.0", Level: db.LevelError, CreatedAt: base},
-    })
-    if got := s.BestAlertTargetInSession("work", "oldest"); got != "work:1.0" {
-        t.Errorf("expected \"work:1.0\" (oldest), got %q", got)
-    }
+	base := time.Now()
+	s := makeSidebarWithAlerts([]db.Alert{
+		{Target: "work:1.0", Level: db.LevelInfo, CreatedAt: base.Add(-time.Minute)},
+		{Target: "work:2.0", Level: db.LevelError, CreatedAt: base},
+	})
+	if got := s.BestAlertTargetInSession("work", "oldest"); got != "work:1.0" {
+		t.Errorf("expected \"work:1.0\" (oldest), got %q", got)
+	}
 }
 
 func TestBestAlertTargetInSession_OtherSessionIgnored(t *testing.T) {
-    now := time.Now()
-    s := makeSidebarWithAlerts([]db.Alert{
-        {Target: "other:1.0", Level: db.LevelError, CreatedAt: now},
-        {Target: "work:2.0",  Level: db.LevelInfo,  CreatedAt: now.Add(-time.Minute)},
-    })
-    if got := s.BestAlertTargetInSession("work", "severity"); got != "work:2.0" {
-        t.Errorf("expected only work session alert, got %q", got)
-    }
+	now := time.Now()
+	s := makeSidebarWithAlerts([]db.Alert{
+		{Target: "other:1.0", Level: db.LevelError, CreatedAt: now},
+		{Target: "work:2.0", Level: db.LevelInfo, CreatedAt: now.Add(-time.Minute)},
+	})
+	if got := s.BestAlertTargetInSession("work", "severity"); got != "work:2.0" {
+		t.Errorf("expected only work session alert, got %q", got)
+	}
 }
 
 func TestBestAlertTargetInSession_UnknownPriorityFallsBackToSeverity(t *testing.T) {
-    base := time.Now()
-    s := makeSidebarWithAlerts([]db.Alert{
-        {Target: "work:1.0", Level: db.LevelWarn,  CreatedAt: base.Add(-time.Minute)},
-        {Target: "work:2.0", Level: db.LevelError, CreatedAt: base.Add(-2 * time.Minute)},
-    })
-    if got := s.BestAlertTargetInSession("work", "bogus"); got != "work:2.0" {
-        t.Errorf("expected severity fallback to return \"work:2.0\", got %q", got)
-    }
+	base := time.Now()
+	s := makeSidebarWithAlerts([]db.Alert{
+		{Target: "work:1.0", Level: db.LevelWarn, CreatedAt: base.Add(-time.Minute)},
+		{Target: "work:2.0", Level: db.LevelError, CreatedAt: base.Add(-2 * time.Minute)},
+	})
+	if got := s.BestAlertTargetInSession("work", "bogus"); got != "work:2.0" {
+		t.Errorf("expected severity fallback to return \"work:2.0\", got %q", got)
+	}
 }
 
 func TestBestAlertTargetInSession_DefaultPriority(t *testing.T) {
-    now := time.Now()
-    s := makeSidebarWithAlerts([]db.Alert{
-        {Target: "work:1.0", Level: db.LevelError, CreatedAt: now},
-        {Target: "work:2.0", Level: db.LevelWarn,  CreatedAt: now.Add(-time.Minute)},
-    })
-    // "default" must return "" regardless of what alerts exist
-    if got := s.BestAlertTargetInSession("work", "default"); got != "" {
-        t.Errorf("expected \"\" for default priority, got %q", got)
-    }
+	now := time.Now()
+	s := makeSidebarWithAlerts([]db.Alert{
+		{Target: "work:1.0", Level: db.LevelError, CreatedAt: now},
+		{Target: "work:2.0", Level: db.LevelWarn, CreatedAt: now.Add(-time.Minute)},
+	})
+	// "default" must return "" regardless of what alerts exist
+	if got := s.BestAlertTargetInSession("work", "default"); got != "" {
+		t.Errorf("expected \"\" for default priority, got %q", got)
+	}
 }
 
 // --- visibleSessions filter tests ---
 
 func TestVisibleSessions_FilterTmux(t *testing.T) {
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "live", IsLive: true},
-            {DisplayName: "cfg-only", IsLive: false, IsConfig: true},
-        },
-        filter: FilterTmux,
-    }
-    s.rebuildNodes()
-    if len(s.nodes) != 1 || s.nodes[0].Session != "live" {
-        t.Errorf("FilterTmux should show only live sessions, got %v", s.nodes)
-    }
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "live", IsLive: true},
+			{DisplayName: "cfg-only", IsLive: false, IsConfig: true},
+		},
+		filter: FilterTmux,
+	}
+	s.rebuildNodes()
+	if len(s.nodes) != 1 || s.nodes[0].Session != "live" {
+		t.Errorf("FilterTmux should show only live sessions, got %v", s.nodes)
+	}
 }
 
 func TestVisibleSessions_FilterConfig(t *testing.T) {
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "live", IsLive: true},
-            {DisplayName: "cfg-only", IsLive: false, IsConfig: true},
-            {DisplayName: "both", IsLive: true, IsConfig: true},
-        },
-        filter: FilterConfig,
-    }
-    s.rebuildNodes()
-    if len(s.nodes) != 2 {
-        t.Errorf("FilterConfig should show IsConfig sessions, got %d", len(s.nodes))
-    }
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "live", IsLive: true},
+			{DisplayName: "cfg-only", IsLive: false, IsConfig: true},
+			{DisplayName: "both", IsLive: true, IsConfig: true},
+		},
+		filter: FilterConfig,
+	}
+	s.rebuildNodes()
+	if len(s.nodes) != 2 {
+		t.Errorf("FilterConfig should show IsConfig sessions, got %d", len(s.nodes))
+	}
 }
 
 func TestVisibleSessions_FilterAll(t *testing.T) {
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "live", IsLive: true},
-            {DisplayName: "cfg-only", IsLive: false, IsConfig: true},
-        },
-        filter: FilterAll,
-    }
-    s.rebuildNodes()
-    if len(s.nodes) != 2 {
-        t.Errorf("FilterAll should show all sessions, got %d", len(s.nodes))
-    }
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "live", IsLive: true},
+			{DisplayName: "cfg-only", IsLive: false, IsConfig: true},
+		},
+		filter: FilterAll,
+	}
+	s.rebuildNodes()
+	if len(s.nodes) != 2 {
+		t.Errorf("FilterAll should show all sessions, got %d", len(s.nodes))
+	}
 }
 
 func TestVisibleSessions_FilterPriority_HidesNoAlert(t *testing.T) {
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "alerted", IsLive: true},
-            {DisplayName: "clean", IsLive: true},
-        },
-        alerts: map[string]db.Alert{
-            "alerted": {Target: "alerted", Level: "warn", CreatedAt: time.Now()},
-        },
-        filter: FilterPriority,
-        cfg:    config.Config{},
-    }
-    s.rebuildNodes()
-    if len(s.nodes) != 1 || s.nodes[0].Session != "alerted" {
-        t.Errorf("FilterPriority should show only alerted sessions, got %v", s.nodes)
-    }
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "alerted", IsLive: true},
+			{DisplayName: "clean", IsLive: true},
+		},
+		alerts: map[string]db.Alert{
+			"alerted": {Target: "alerted", Level: "warn", CreatedAt: time.Now()},
+		},
+		filter: FilterPriority,
+		cfg:    config.Config{},
+	}
+	s.rebuildNodes()
+	if len(s.nodes) != 1 || s.nodes[0].Session != "alerted" {
+		t.Errorf("FilterPriority should show only alerted sessions, got %v", s.nodes)
+	}
 }
 
 func TestVisibleSessions_FilterWorktree_NoRoot(t *testing.T) {
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "no-git", IsLive: true},
-        },
-        filter:  FilterWorktree,
-        gitInfo: map[string]git.Info{},
-    }
-    s.nodes = []SidebarNode{{Session: "no-git"}} // pre-set cursor target
-    s.rebuildNodes()
-    if len(s.nodes) != 0 {
-        t.Error("expected empty list when no worktree root resolvable")
-    }
-    out := stripANSI(s.Render(40, 10, false, "", ""))
-    if !strings.Contains(out, "no sessions in this worktree") {
-        t.Errorf("expected hint message in render output, got: %q", out)
-    }
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "no-git", IsLive: true},
+		},
+		filter:  FilterWorktree,
+		gitInfo: map[string]git.Info{},
+	}
+	s.nodes = []SidebarNode{{Session: "no-git"}} // pre-set cursor target
+	s.rebuildNodes()
+	if len(s.nodes) != 0 {
+		t.Error("expected empty list when no worktree root resolvable")
+	}
+	out := stripANSI(s.Render(40, 10, false, "", ""))
+	if !strings.Contains(out, "no sessions in this worktree") {
+		t.Errorf("expected hint message in render output, got: %q", out)
+	}
 }
 
 func TestVisibleSessions_FilterWorktree_MatchesByRoot(t *testing.T) {
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "sess-a", IsLive: true},
-            {DisplayName: "sess-b", IsLive: true},
-            {DisplayName: "other", IsLive: true},
-        },
-        filter: FilterWorktree,
-        gitInfo: map[string]git.Info{
-            "sess-a": {RepoRoot: "/repo/worktrees/a"},
-            "sess-b": {RepoRoot: "/repo/worktrees/b"},
-            "other":  {RepoRoot: "/elsewhere/c"},
-        },
-    }
-    // Cursor on sess-a; its root = /repo/worktrees
-    s.nodes = []SidebarNode{{Session: "sess-a"}}
-    s.rebuildNodes()
-    // Both sess-a and sess-b have root /repo/worktrees, other has /elsewhere
-    if len(s.nodes) != 2 {
-        t.Errorf("expected 2 sessions sharing worktree root, got %d: %v", len(s.nodes), s.nodes)
-    }
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "sess-a", IsLive: true},
+			{DisplayName: "sess-b", IsLive: true},
+			{DisplayName: "other", IsLive: true},
+		},
+		filter: FilterWorktree,
+		gitInfo: map[string]git.Info{
+			"sess-a": {RepoRoot: "/repo/worktrees/a"},
+			"sess-b": {RepoRoot: "/repo/worktrees/b"},
+			"other":  {RepoRoot: "/elsewhere/c"},
+		},
+	}
+	// Cursor on sess-a; its root = /repo/worktrees
+	s.nodes = []SidebarNode{{Session: "sess-a"}}
+	s.rebuildNodes()
+	// Both sess-a and sess-b have root /repo/worktrees, other has /elsewhere
+	if len(s.nodes) != 2 {
+		t.Errorf("expected 2 sessions sharing worktree root, got %d: %v", len(s.nodes), s.nodes)
+	}
 }
 
 func TestRenderSession_ShowsIcon(t *testing.T) {
-    initStyles(Theme{
-        IconTmuxSession: "⊞",
-        IconCfgSession:  "⚙︎",
-        ColorSession:    lipgloss.Color("#89b4fa"),
-        ColorBorder:     lipgloss.Color("#313244"),
-        ColorSelected:   lipgloss.Color("#2a2a4a"),
-        ColorFgMuted:    lipgloss.Color("#9399b2"),
-    }, config.ProcessesConfig{}, nil)
+	initStyles(Theme{
+		IconTmuxSession: "⊞",
+		IconCfgSession:  "⚙︎",
+		ColorSession:    lipgloss.Color("#89b4fa"),
+		ColorBorder:     lipgloss.Color("#313244"),
+		ColorSelected:   lipgloss.Color("#2a2a4a"),
+		ColorFgMuted:    lipgloss.Color("#9399b2"),
+	}, config.ProcessesConfig{}, nil)
 
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "myapp", IsLive: true, IsConfig: false},
-        },
-        filter: FilterTmux,
-    }
-    s.rebuildNodes()
-    row := s.renderSession(s.nodes[0], false, false, 40)
-    plain := stripANSI(row)
-    if !strings.Contains(plain, "⊞") {
-        t.Errorf("expected Tmux icon ⊞ in row, got: %q", plain)
-    }
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "myapp", IsLive: true, IsConfig: false},
+		},
+		filter: FilterTmux,
+	}
+	s.rebuildNodes()
+	row := s.renderSession(s.nodes[0], false, false, 40)
+	plain := stripANSI(row)
+	if !strings.Contains(plain, "⊞") {
+		t.Errorf("expected Tmux icon ⊞ in row, got: %q", plain)
+	}
 }
 
 func TestRenderSession_ShowsConfigIcon(t *testing.T) {
-    initStyles(Theme{
-        IconTmuxSession: "⊞",
-        IconCfgSession:  "⚙︎",
-        ColorSession:    lipgloss.Color("#89b4fa"),
-        ColorBorder:     lipgloss.Color("#313244"),
-        ColorSelected:   lipgloss.Color("#2a2a4a"),
-        ColorFgMuted:    lipgloss.Color("#9399b2"),
-    }, config.ProcessesConfig{}, nil)
+	initStyles(Theme{
+		IconTmuxSession: "⊞",
+		IconCfgSession:  "⚙︎",
+		ColorSession:    lipgloss.Color("#89b4fa"),
+		ColorBorder:     lipgloss.Color("#313244"),
+		ColorSelected:   lipgloss.Color("#2a2a4a"),
+		ColorFgMuted:    lipgloss.Color("#9399b2"),
+	}, config.ProcessesConfig{}, nil)
 
-    cfg := session.ConfigEntry{Name: "dotf-main", Group: "dotf", Path: "/foo", Icon: "★"}
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "dotf-main", IsLive: false, IsConfig: true, Config: &cfg},
-        },
-        filter: FilterConfig,
-    }
-    s.rebuildNodes()
-    row := s.renderSession(s.nodes[0], false, false, 40)
-    plain := stripANSI(row)
-    if !strings.Contains(plain, "★") {
-        t.Errorf("expected config icon ★ in row, got: %q", plain)
-    }
+	cfg := session.ConfigEntry{Name: "dotf-main", Group: "dotf", Path: "/foo", Icon: "★"}
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "dotf-main", IsLive: false, IsConfig: true, Config: &cfg},
+		},
+		filter: FilterConfig,
+	}
+	s.rebuildNodes()
+	row := s.renderSession(s.nodes[0], false, false, 40)
+	plain := stripANSI(row)
+	if !strings.Contains(plain, "★") {
+		t.Errorf("expected config icon ★ in row, got: %q", plain)
+	}
 }
 
 func TestRenderSession_LiveConfigShowsTmuxIcon(t *testing.T) {
-    initStyles(Theme{
-        IconTmuxSession: "⊞",
-        IconCfgSession:  "⚙︎",
-        ColorSession:    lipgloss.Color("#89b4fa"),
-        ColorBorder:     lipgloss.Color("#313244"),
-        ColorSelected:   lipgloss.Color("#2a2a4a"),
-        ColorFgMuted:    lipgloss.Color("#9399b2"),
-    }, config.ProcessesConfig{}, nil)
+	initStyles(Theme{
+		IconTmuxSession: "⊞",
+		IconCfgSession:  "⚙︎",
+		ColorSession:    lipgloss.Color("#89b4fa"),
+		ColorBorder:     lipgloss.Color("#313244"),
+		ColorSelected:   lipgloss.Color("#2a2a4a"),
+		ColorFgMuted:    lipgloss.Color("#9399b2"),
+	}, config.ProcessesConfig{}, nil)
 
-    cfg := session.ConfigEntry{Name: "dotf-main", Group: "dotf", Path: "/foo"}
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "dotf-main", IsLive: true, IsConfig: true, Config: &cfg},
-        },
-        filter: FilterAll,
-    }
-    s.rebuildNodes()
-    row := s.renderSession(s.nodes[0], false, false, 40)
-    plain := stripANSI(row)
-    if !strings.Contains(plain, "⊞") {
-        t.Errorf("expected Tmux icon ⊞ for live config session, got: %q", plain)
-    }
-    if strings.Contains(plain, "⚙︎") {
-        t.Errorf("expected no cfg icon ⚙︎ for live config session, got: %q", plain)
-    }
+	cfg := session.ConfigEntry{Name: "dotf-main", Group: "dotf", Path: "/foo"}
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "dotf-main", IsLive: true, IsConfig: true, Config: &cfg},
+		},
+		filter: FilterAll,
+	}
+	s.rebuildNodes()
+	row := s.renderSession(s.nodes[0], false, false, 40)
+	plain := stripANSI(row)
+	if !strings.Contains(plain, "⊞") {
+		t.Errorf("expected Tmux icon ⊞ for live config session, got: %q", plain)
+	}
+	if strings.Contains(plain, "⚙︎") {
+		t.Errorf("expected no cfg icon ⚙︎ for live config session, got: %q", plain)
+	}
 }
 
 func TestRenderSession_ShowsLastSeen(t *testing.T) {
-    initStyles(Theme{
-        IconTmuxSession: "⊞",
-        IconCfgSession:  "⚙︎",
-    }, config.ProcessesConfig{}, nil)
-    activity := time.Now().Add(-5 * time.Minute)
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "myses", IsLive: true, Activity: activity},
-        },
-        alerts:  map[string]db.Alert{},
-        gitInfo: map[string]git.Info{},
-        cfg: config.Config{
-            Sidebar: config.SidebarConfig{ShowLastSeen: true},
-        },
-    }
-    s.rebuildNodes()
-    row := s.renderSession(s.nodes[0], false, false, 40)
-    plain := stripANSI(row)
-    if !strings.Contains(plain, " 5m") {
-        t.Errorf("expected last-seen ' 5m' in row, got: %q", plain)
-    }
+	initStyles(Theme{
+		IconTmuxSession: "⊞",
+		IconCfgSession:  "⚙︎",
+	}, config.ProcessesConfig{}, nil)
+	activity := time.Now().Add(-5 * time.Minute)
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "myses", IsLive: true, Activity: activity},
+		},
+		alerts:  map[string]db.Alert{},
+		gitInfo: map[string]git.Info{},
+		cfg: config.Config{
+			Sidebar: config.SidebarConfig{ShowLastSeen: true},
+		},
+	}
+	s.rebuildNodes()
+	row := s.renderSession(s.nodes[0], false, false, 40)
+	plain := stripANSI(row)
+	if !strings.Contains(plain, " 5m") {
+		t.Errorf("expected last-seen ' 5m' in row, got: %q", plain)
+	}
 }
 
 func TestRenderSession_HidesLastSeenWhenDisabled(t *testing.T) {
-    initStyles(Theme{
-        IconTmuxSession: "⊞",
-        IconCfgSession:  "⚙︎",
-    }, config.ProcessesConfig{}, nil)
-    activity := time.Now().Add(-5 * time.Minute)
-    s := SidebarModel{
-        sessions: []session.Session{
-            {DisplayName: "xyz", IsLive: true, Activity: activity},
-        },
-        alerts:  map[string]db.Alert{},
-        gitInfo: map[string]git.Info{},
-        cfg: config.Config{
-            Sidebar: config.SidebarConfig{ShowLastSeen: false},
-        },
-    }
-    s.rebuildNodes()
-    row := s.renderSession(s.nodes[0], false, false, 40)
-    plain := stripANSI(row)
-    if strings.Contains(plain, "m") || strings.Contains(plain, "s") || strings.Contains(plain, "h") || strings.Contains(plain, "d") {
-        t.Errorf("expected no age indicator when ShowLastSeen=false, got: %q", plain)
-    }
+	initStyles(Theme{
+		IconTmuxSession: "⊞",
+		IconCfgSession:  "⚙︎",
+	}, config.ProcessesConfig{}, nil)
+	activity := time.Now().Add(-5 * time.Minute)
+	s := SidebarModel{
+		sessions: []session.Session{
+			{DisplayName: "xyz", IsLive: true, Activity: activity},
+		},
+		alerts:  map[string]db.Alert{},
+		gitInfo: map[string]git.Info{},
+		cfg: config.Config{
+			Sidebar: config.SidebarConfig{ShowLastSeen: false},
+		},
+	}
+	s.rebuildNodes()
+	row := s.renderSession(s.nodes[0], false, false, 40)
+	plain := stripANSI(row)
+	if strings.Contains(plain, "m") || strings.Contains(plain, "s") || strings.Contains(plain, "h") || strings.Contains(plain, "d") {
+		t.Errorf("expected no age indicator when ShowLastSeen=false, got: %q", plain)
+	}
 }
 
 func TestFilterShortcutBar_FitsWidth(t *testing.T) {
-    initStyles(Theme{
-        ColorSession: lipgloss.Color("#89b4fa"),
-        ColorFgMuted: lipgloss.Color("#9399b2"),
-    }, config.ProcessesConfig{}, nil)
-    bar := filterShortcutBar(FilterTmux, 50)
-    plain := stripANSI(bar)
-    if !strings.Contains(plain, "[t]") {
-        t.Error("expected [t] in shortcut bar")
-    }
-    if !strings.Contains(plain, "[a]") {
-        t.Error("expected [a] in shortcut bar")
-    }
-    if !strings.Contains(plain, "[!]") {
-        t.Error("expected [!] in shortcut bar at width 50")
-    }
+	initStyles(Theme{
+		ColorSession: lipgloss.Color("#89b4fa"),
+		ColorFgMuted: lipgloss.Color("#9399b2"),
+	}, config.ProcessesConfig{}, nil)
+	bar := filterShortcutBar(FilterTmux, 50)
+	plain := stripANSI(bar)
+	if !strings.Contains(plain, "[t]") {
+		t.Error("expected [t] in shortcut bar")
+	}
+	if !strings.Contains(plain, "[a]") {
+		t.Error("expected [a] in shortcut bar")
+	}
+	if !strings.Contains(plain, "[!]") {
+		t.Error("expected [!] in shortcut bar at width 50")
+	}
 }
 
 func TestFilterShortcutBar_TrimmedWhenNarrow(t *testing.T) {
-    initStyles(Theme{
-        ColorSession: lipgloss.Color("#89b4fa"),
-        ColorFgMuted: lipgloss.Color("#9399b2"),
-    }, config.ProcessesConfig{}, nil)
-    bar := filterShortcutBar(FilterTmux, 12)
-    plain := stripANSI(bar)
-    if !strings.Contains(plain, "[t]") {
-        t.Error("expected [t] to survive trimming")
-    }
-    if strings.Contains(plain, "[!]") {
-        t.Errorf("expected [!] to be trimmed at width 12, got: %q", plain)
-    }
+	initStyles(Theme{
+		ColorSession: lipgloss.Color("#89b4fa"),
+		ColorFgMuted: lipgloss.Color("#9399b2"),
+	}, config.ProcessesConfig{}, nil)
+	bar := filterShortcutBar(FilterTmux, 12)
+	plain := stripANSI(bar)
+	if !strings.Contains(plain, "[t]") {
+		t.Error("expected [t] to survive trimming")
+	}
+	if strings.Contains(plain, "[!]") {
+		t.Errorf("expected [!] to be trimmed at width 12, got: %q", plain)
+	}
 }
 
 // --- formatAge ---
 
 func TestFormatAge(t *testing.T) {
-    now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
-    cases := []struct {
-        desc string
-        ago  time.Duration
-        want string
-    }{
-        {"0 seconds",        0 * time.Second,                "now"},
-        {"5 seconds",        5 * time.Second,                "now"},
-        {"14 seconds",      14 * time.Second,               "now"},
-        {"15 seconds",      15 * time.Second,               "<1m"},
-        {"59 seconds",      59 * time.Second,               "<1m"},
-        {"1 minute",        1 * time.Minute,                " 1m"},
-        {"9 minutes",       9 * time.Minute,                " 9m"},
-        {"10 minutes",      10 * time.Minute,               "10m"},
-        {"59 minutes",      59 * time.Minute,               "59m"},
-        {"1 hour",          1 * time.Hour,                  " 1h"},
-        {"9 hours",         9 * time.Hour,                  " 9h"},
-        {"10 hours",        10 * time.Hour,                 "10h"},
-        {"23 hours",        23 * time.Hour,                 "23h"},
-        {"1 day",           24 * time.Hour,                 " 1d"},
-        {"9 days",          9 * 24 * time.Hour,             " 9d"},
-        {"10 days",         10 * 24 * time.Hour,            "10d"},
-        {"99 days",         99 * 24 * time.Hour,            "99d"},
-    }
-    for _, tc := range cases {
-        t.Run(tc.desc, func(t *testing.T) {
-            got := formatAge(now.Add(-tc.ago), now)
-            if got != tc.want {
-                t.Errorf("formatAge(%v ago): want %q, got %q", tc.ago, tc.want, got)
-            }
-        })
-    }
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		desc string
+		ago  time.Duration
+		want string
+	}{
+		{"0 seconds", 0 * time.Second, "now"},
+		{"5 seconds", 5 * time.Second, "now"},
+		{"14 seconds", 14 * time.Second, "now"},
+		{"15 seconds", 15 * time.Second, "<1m"},
+		{"59 seconds", 59 * time.Second, "<1m"},
+		{"1 minute", 1 * time.Minute, " 1m"},
+		{"9 minutes", 9 * time.Minute, " 9m"},
+		{"10 minutes", 10 * time.Minute, "10m"},
+		{"59 minutes", 59 * time.Minute, "59m"},
+		{"1 hour", 1 * time.Hour, " 1h"},
+		{"9 hours", 9 * time.Hour, " 9h"},
+		{"10 hours", 10 * time.Hour, "10h"},
+		{"23 hours", 23 * time.Hour, "23h"},
+		{"1 day", 24 * time.Hour, " 1d"},
+		{"9 days", 9 * 24 * time.Hour, " 9d"},
+		{"10 days", 10 * 24 * time.Hour, "10d"},
+		{"99 days", 99 * 24 * time.Hour, "99d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := formatAge(now.Add(-tc.ago), now)
+			if got != tc.want {
+				t.Errorf("formatAge(%v ago): want %q, got %q", tc.ago, tc.want, got)
+			}
+		})
+	}
 }
 
 func TestAlertSeverity(t *testing.T) {
-    tests := []struct {
-        level string
-        want  int
-    }{
-        {"defer", 0},
-        {"info", 1},
-        {"warn", 2},
-        {"error", 3},
-        {"unknown", 0},
-    }
-    for _, tt := range tests {
-        t.Run(tt.level, func(t *testing.T) {
-            if got := alertSeverity(tt.level); got != tt.want {
-                t.Errorf("alertSeverity(%q) = %d, want %d", tt.level, got, tt.want)
-            }
-        })
-    }
+	tests := []struct {
+		level string
+		want  int
+	}{
+		{"defer", 0},
+		{"info", 1},
+		{"warn", 2},
+		{"error", 3},
+		{"unknown", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			if got := alertSeverity(tt.level); got != tt.want {
+				t.Errorf("alertSeverity(%q) = %d, want %d", tt.level, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -1,8 +1,8 @@
 package tui
 
 import (
-    "github.com/charmbracelet/lipgloss"
-    "github.com/rtalexk/demux/internal/config"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 // activeTheme is set once at startup by initStyles.
@@ -10,160 +10,160 @@ var activeTheme Theme
 
 // Process-type name lists. Populated by initStyles from config.
 var (
-    activeProcEditors  []string
-    activeProcAgents   []string
-    activeProcServers  []string
-    activeProcShells   []string
-    activeIgnoredProcs []string
+	activeProcEditors  []string
+	activeProcAgents   []string
+	activeProcServers  []string
+	activeProcShells   []string
+	activeIgnoredProcs []string
 )
 
 // All package-level lipgloss styles. Populated by initStyles.
 var (
-    // Panel borders
-    borderActive   lipgloss.Style
-    borderInactive lipgloss.Style
-    detailBorder   lipgloss.Style
+	// Panel borders
+	borderActive   lipgloss.Style
+	borderInactive lipgloss.Style
+	detailBorder   lipgloss.Style
 
-    procBorderActive   lipgloss.Style
-    procBorderInactive lipgloss.Style
+	procBorderActive   lipgloss.Style
+	procBorderInactive lipgloss.Style
 
-    // Overlays
-    helpStyle     lipgloss.Style
-    helpDescStyle lipgloss.Style
-    yankStyle     lipgloss.Style
+	// Overlays
+	helpStyle     lipgloss.Style
+	helpDescStyle lipgloss.Style
+	yankStyle     lipgloss.Style
 
-    // Sidebar text
-    sessionStyle lipgloss.Style
+	// Sidebar text
+	sessionStyle lipgloss.Style
 
-    // Process list text
-    paneHeaderStyle   lipgloss.Style
-    windowHeaderStyle lipgloss.Style
-    panePathStyle     lipgloss.Style
-    paneSepStyle    lipgloss.Style
-    procLine1Style  lipgloss.Style
-    procLine2Style  lipgloss.Style
-    paneIdleStyle   lipgloss.Style
+	// Process list text
+	paneHeaderStyle   lipgloss.Style
+	windowHeaderStyle lipgloss.Style
+	panePathStyle     lipgloss.Style
+	paneSepStyle      lipgloss.Style
+	procLine1Style    lipgloss.Style
+	procLine2Style    lipgloss.Style
+	paneIdleStyle     lipgloss.Style
 
-    // Shared text
-    hintStyle        lipgloss.Style
-    detailLabelStyle lipgloss.Style
-    detailValueStyle lipgloss.Style
-    noSelectionStyle lipgloss.Style
-    spinnerStyle     lipgloss.Style
-    statLabelStyle   lipgloss.Style
-    statValueStyle   lipgloss.Style
+	// Shared text
+	hintStyle        lipgloss.Style
+	detailLabelStyle lipgloss.Style
+	detailValueStyle lipgloss.Style
+	noSelectionStyle lipgloss.Style
+	spinnerStyle     lipgloss.Style
+	statLabelStyle   lipgloss.Style
+	statValueStyle   lipgloss.Style
 
-    // Selection
-    selectedBG       lipgloss.Style
-    selectedInactive lipgloss.Style
+	// Selection
+	selectedBG       lipgloss.Style
+	selectedInactive lipgloss.Style
 
-    // Tree connectors
-    treeConnectorStyle lipgloss.Style
+	// Tree connectors
+	treeConnectorStyle lipgloss.Style
 
-    // Git indicators
-    gitAheadStyle  lipgloss.Style
-    gitBehindStyle lipgloss.Style
-    gitDirtyStyle  lipgloss.Style
+	// Git indicators
+	gitAheadStyle  lipgloss.Style
+	gitBehindStyle lipgloss.Style
+	gitDirtyStyle  lipgloss.Style
 
-    // Session icon
-    sessionIconStyle lipgloss.Style
+	// Session icon
+	sessionIconStyle lipgloss.Style
 )
 
 // initStyles rebuilds every style using the given theme and merges proc-type
 // name lists with any user-configured extras. Call once from New().
 func initStyles(t Theme, procs config.ProcessesConfig, ignoredProcs []string) {
-    activeTheme = t
+	activeTheme = t
 
-    activeProcEditors  = procs.Editors
-    activeProcAgents   = procs.Agents
-    activeProcServers  = procs.Servers
-    activeProcShells   = procs.Shells
-    activeIgnoredProcs = ignoredProcs
+	activeProcEditors = procs.Editors
+	activeProcAgents = procs.Agents
+	activeProcServers = procs.Servers
+	activeProcShells = procs.Shells
+	activeIgnoredProcs = ignoredProcs
 
-    borderActive   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession)
-    borderInactive = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorBorder)
-    detailBorder   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorBorder)
+	borderActive = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession)
+	borderInactive = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorBorder)
+	detailBorder = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorBorder)
 
-    procBorderActive   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession)
-    procBorderInactive = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorBorder)
+	procBorderActive = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession)
+	procBorderInactive = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorBorder)
 
-    helpStyle     = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession).Padding(1, 2)
-    helpDescStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
-    yankStyle     = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession).Padding(1, 2)
+	helpStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession).Padding(1, 2)
+	helpDescStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
+	yankStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession).Padding(1, 2)
 
-    sessionStyle    = lipgloss.NewStyle().Bold(true).Foreground(t.ColorSession)
-    paneHeaderStyle   = lipgloss.NewStyle().Bold(true).Foreground(t.ColorFgSubtext)
-    windowHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(t.ColorFgSubtext)
-    panePathStyle     = lipgloss.NewStyle().Foreground(t.ColorSession)
-    paneSepStyle    = lipgloss.NewStyle().Foreground(t.ColorFgGhost)
-    procLine1Style  = lipgloss.NewStyle().Foreground(t.ColorFgPrimary)
-    procLine2Style  = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
-    paneIdleStyle   = lipgloss.NewStyle().Foreground(t.ColorFgDim).Italic(true)
+	sessionStyle = lipgloss.NewStyle().Bold(true).Foreground(t.ColorSession)
+	paneHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(t.ColorFgSubtext)
+	windowHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(t.ColorFgSubtext)
+	panePathStyle = lipgloss.NewStyle().Foreground(t.ColorSession)
+	paneSepStyle = lipgloss.NewStyle().Foreground(t.ColorFgGhost)
+	procLine1Style = lipgloss.NewStyle().Foreground(t.ColorFgPrimary)
+	procLine2Style = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
+	paneIdleStyle = lipgloss.NewStyle().Foreground(t.ColorFgDim).Italic(true)
 
-    hintStyle        = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
-    detailLabelStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted).Width(10)
-    detailValueStyle = lipgloss.NewStyle().Foreground(t.ColorFgPrimary)
-    noSelectionStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted).Italic(true)
-    spinnerStyle     = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
-    statLabelStyle   = lipgloss.NewStyle().Foreground(t.ColorFgDim)
-    statValueStyle   = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
+	hintStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
+	detailLabelStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted).Width(10)
+	detailValueStyle = lipgloss.NewStyle().Foreground(t.ColorFgPrimary)
+	noSelectionStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted).Italic(true)
+	spinnerStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
+	statLabelStyle = lipgloss.NewStyle().Foreground(t.ColorFgDim)
+	statValueStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
 
-    selectedBG       = lipgloss.NewStyle().Background(t.ColorSelected).Foreground(t.ColorFgPrimary)
-    selectedInactive = lipgloss.NewStyle().Foreground(t.ColorSession)
+	selectedBG = lipgloss.NewStyle().Background(t.ColorSelected).Foreground(t.ColorFgPrimary)
+	selectedInactive = lipgloss.NewStyle().Foreground(t.ColorSession)
 
-    treeConnectorStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
+	treeConnectorStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
 
-    gitAheadStyle  = lipgloss.NewStyle().Foreground(t.ColorGitAhead)
-    gitBehindStyle = lipgloss.NewStyle().Foreground(t.ColorGitBehind)
-    gitDirtyStyle  = lipgloss.NewStyle().Foreground(t.ColorGitDirty)
+	gitAheadStyle = lipgloss.NewStyle().Foreground(t.ColorGitAhead)
+	gitBehindStyle = lipgloss.NewStyle().Foreground(t.ColorGitBehind)
+	gitDirtyStyle = lipgloss.NewStyle().Foreground(t.ColorGitDirty)
 
-    sessionIconStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
+	sessionIconStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
 }
 
 // alertIcon renders the configured icon for the given alert level, colored by theme.
 func alertIcon(level string) string {
-    switch level {
-    case "info":
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertInfo).Render(activeTheme.IconAlertInfo)
-    case "warn":
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertWarn).Render(activeTheme.IconAlertWarn)
-    case "error":
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertError).Bold(true).Render(activeTheme.IconAlertError)
-    case "defer":
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertDefer).Render(activeTheme.IconAlertDefer)
-    }
-    return ""
+	switch level {
+	case "info":
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertInfo).Render(activeTheme.IconAlertInfo)
+	case "warn":
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertWarn).Render(activeTheme.IconAlertWarn)
+	case "error":
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertError).Bold(true).Render(activeTheme.IconAlertError)
+	case "defer":
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertDefer).Render(activeTheme.IconAlertDefer)
+	}
+	return ""
 }
 
 // alertIconOnBG renders the configured icon with a background color applied.
 func alertIconOnBG(level string, bg lipgloss.Color) string {
-    switch level {
-    case "info":
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertInfo).Background(bg).Render(activeTheme.IconAlertInfo)
-    case "warn":
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertWarn).Background(bg).Render(activeTheme.IconAlertWarn)
-    case "error":
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertError).Bold(true).Background(bg).Render(activeTheme.IconAlertError)
-    case "defer":
-        return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertDefer).Background(bg).Render(activeTheme.IconAlertDefer)
-    }
-    return ""
+	switch level {
+	case "info":
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertInfo).Background(bg).Render(activeTheme.IconAlertInfo)
+	case "warn":
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertWarn).Background(bg).Render(activeTheme.IconAlertWarn)
+	case "error":
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertError).Bold(true).Background(bg).Render(activeTheme.IconAlertError)
+	case "defer":
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorAlertDefer).Background(bg).Render(activeTheme.IconAlertDefer)
+	}
+	return ""
 }
 
 // alertBadge renders the alert reason with a severity-based background color.
 func alertBadge(level, reason string) string {
-    var fg, bg lipgloss.Color
-    switch level {
-    case "info":
-        fg, bg = activeTheme.ColorAlertInfo, activeTheme.ColorAlertInfoBg
-    case "warn":
-        fg, bg = activeTheme.ColorAlertWarn, activeTheme.ColorAlertWarnBg
-    case "error":
-        fg, bg = activeTheme.ColorAlertError, activeTheme.ColorAlertErrorBg
-    case "defer":
-        fg, bg = activeTheme.ColorAlertDefer, activeTheme.ColorAlertDeferBg
-    default:
-        return reason
-    }
-    return lipgloss.NewStyle().Foreground(fg).Background(bg).Render(" " + reason + " ")
+	var fg, bg lipgloss.Color
+	switch level {
+	case "info":
+		fg, bg = activeTheme.ColorAlertInfo, activeTheme.ColorAlertInfoBg
+	case "warn":
+		fg, bg = activeTheme.ColorAlertWarn, activeTheme.ColorAlertWarnBg
+	case "error":
+		fg, bg = activeTheme.ColorAlertError, activeTheme.ColorAlertErrorBg
+	case "defer":
+		fg, bg = activeTheme.ColorAlertDefer, activeTheme.ColorAlertDeferBg
+	default:
+		return reason
+	}
+	return lipgloss.NewStyle().Foreground(fg).Background(bg).Render(" " + reason + " ")
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,117 +1,117 @@
 package tui
 
 import (
-    "github.com/charmbracelet/lipgloss"
-    "github.com/rtalexk/demux/internal/config"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rtalexk/demux/internal/config"
 )
 
 // Theme holds all colour values used across the TUI.
 type Theme struct {
-    // Structure & chrome
-    ColorBg       lipgloss.Color
-    ColorSurface  lipgloss.Color
-    ColorRaised   lipgloss.Color
-    ColorSelected lipgloss.Color
-    ColorBorder   lipgloss.Color
+	// Structure & chrome
+	ColorBg       lipgloss.Color
+	ColorSurface  lipgloss.Color
+	ColorRaised   lipgloss.Color
+	ColorSelected lipgloss.Color
+	ColorBorder   lipgloss.Color
 
-    // Text hierarchy
-    ColorFgPrimary lipgloss.Color
-    ColorFgSubtext lipgloss.Color
-    ColorFgMuted   lipgloss.Color
-    ColorFgDim     lipgloss.Color
-    ColorFgGhost   lipgloss.Color
+	// Text hierarchy
+	ColorFgPrimary lipgloss.Color
+	ColorFgSubtext lipgloss.Color
+	ColorFgMuted   lipgloss.Color
+	ColorFgDim     lipgloss.Color
+	ColorFgGhost   lipgloss.Color
 
-    // Process types
-    ColorSession    lipgloss.Color
-    ColorProcClaude lipgloss.Color
-    ColorProcServer lipgloss.Color
-    ColorProcEditor lipgloss.Color
-    ColorProcChild  lipgloss.Color
+	// Process types
+	ColorSession    lipgloss.Color
+	ColorProcClaude lipgloss.Color
+	ColorProcServer lipgloss.Color
+	ColorProcEditor lipgloss.Color
+	ColorProcChild  lipgloss.Color
 
-    // Git status
-    ColorGitDirty  lipgloss.Color
-    ColorGitBehind lipgloss.Color
-    ColorGitAhead  lipgloss.Color
+	// Git status
+	ColorGitDirty  lipgloss.Color
+	ColorGitBehind lipgloss.Color
+	ColorGitAhead  lipgloss.Color
 
-    // Alerts
-    ColorAlertInfo   lipgloss.Color
-    ColorAlertWarn   lipgloss.Color
-    ColorAlertError  lipgloss.Color
-    ColorAlertDefer  lipgloss.Color
-    ColorAlertInfoBg  lipgloss.Color
-    ColorAlertWarnBg  lipgloss.Color
-    ColorAlertErrorBg lipgloss.Color
-    ColorAlertDeferBg lipgloss.Color
+	// Alerts
+	ColorAlertInfo    lipgloss.Color
+	ColorAlertWarn    lipgloss.Color
+	ColorAlertError   lipgloss.Color
+	ColorAlertDefer   lipgloss.Color
+	ColorAlertInfoBg  lipgloss.Color
+	ColorAlertWarnBg  lipgloss.Color
+	ColorAlertErrorBg lipgloss.Color
+	ColorAlertDeferBg lipgloss.Color
 
-    IconAlertInfo  string
-    IconAlertWarn  string
-    IconAlertError string
-    IconAlertDefer string
+	IconAlertInfo  string
+	IconAlertWarn  string
+	IconAlertError string
+	IconAlertDefer string
 
-    IconTmuxSession string
-    IconCfgSession  string
+	IconTmuxSession string
+	IconCfgSession  string
 
-    // Semantic
-    ColorPort    lipgloss.Color
-    ColorPortBg  lipgloss.Color
-    ColorClean   lipgloss.Color
-    ColorCpuLow  lipgloss.Color
-    ColorCpuMed  lipgloss.Color
-    ColorCpuHigh lipgloss.Color
+	// Semantic
+	ColorPort    lipgloss.Color
+	ColorPortBg  lipgloss.Color
+	ColorClean   lipgloss.Color
+	ColorCpuLow  lipgloss.Color
+	ColorCpuMed  lipgloss.Color
+	ColorCpuHigh lipgloss.Color
 
-    // Search
-    ColorFgSearchHighlight lipgloss.Color
+	// Search
+	ColorFgSearchHighlight lipgloss.Color
 }
 
 // ThemeFromConfig builds a Theme directly from the config values.
 func ThemeFromConfig(tc config.ThemeConfig) Theme {
-    return Theme{
-        ColorBg:       lipgloss.Color(tc.ColorBg),
-        ColorSurface:  lipgloss.Color(tc.ColorSurface),
-        ColorRaised:   lipgloss.Color(tc.ColorRaised),
-        ColorSelected: lipgloss.Color(tc.ColorSelected),
-        ColorBorder:   lipgloss.Color(tc.ColorBorder),
+	return Theme{
+		ColorBg:       lipgloss.Color(tc.ColorBg),
+		ColorSurface:  lipgloss.Color(tc.ColorSurface),
+		ColorRaised:   lipgloss.Color(tc.ColorRaised),
+		ColorSelected: lipgloss.Color(tc.ColorSelected),
+		ColorBorder:   lipgloss.Color(tc.ColorBorder),
 
-        ColorFgPrimary: lipgloss.Color(tc.ColorFgPrimary),
-        ColorFgSubtext: lipgloss.Color(tc.ColorFgSubtext),
-        ColorFgMuted:   lipgloss.Color(tc.ColorFgMuted),
-        ColorFgDim:     lipgloss.Color(tc.ColorFgDim),
-        ColorFgGhost:   lipgloss.Color(tc.ColorFgGhost),
+		ColorFgPrimary: lipgloss.Color(tc.ColorFgPrimary),
+		ColorFgSubtext: lipgloss.Color(tc.ColorFgSubtext),
+		ColorFgMuted:   lipgloss.Color(tc.ColorFgMuted),
+		ColorFgDim:     lipgloss.Color(tc.ColorFgDim),
+		ColorFgGhost:   lipgloss.Color(tc.ColorFgGhost),
 
-        ColorSession:    lipgloss.Color(tc.ColorSession),
-        ColorProcClaude: lipgloss.Color(tc.ColorProcClaude),
-        ColorProcServer: lipgloss.Color(tc.ColorProcServer),
-        ColorProcEditor: lipgloss.Color(tc.ColorProcEditor),
-        ColorProcChild:  lipgloss.Color(tc.ColorProcChild),
+		ColorSession:    lipgloss.Color(tc.ColorSession),
+		ColorProcClaude: lipgloss.Color(tc.ColorProcClaude),
+		ColorProcServer: lipgloss.Color(tc.ColorProcServer),
+		ColorProcEditor: lipgloss.Color(tc.ColorProcEditor),
+		ColorProcChild:  lipgloss.Color(tc.ColorProcChild),
 
-        ColorGitDirty:  lipgloss.Color(tc.ColorGitDirty),
-        ColorGitBehind: lipgloss.Color(tc.ColorGitBehind),
-        ColorGitAhead:  lipgloss.Color(tc.ColorGitAhead),
+		ColorGitDirty:  lipgloss.Color(tc.ColorGitDirty),
+		ColorGitBehind: lipgloss.Color(tc.ColorGitBehind),
+		ColorGitAhead:  lipgloss.Color(tc.ColorGitAhead),
 
-        ColorAlertInfo:   lipgloss.Color(tc.ColorAlertInfo),
-        ColorAlertWarn:   lipgloss.Color(tc.ColorAlertWarn),
-        ColorAlertError:  lipgloss.Color(tc.ColorAlertError),
-        ColorAlertDefer:  lipgloss.Color(tc.ColorAlertDefer),
-        ColorAlertInfoBg:  lipgloss.Color(tc.ColorAlertInfoBg),
-        ColorAlertWarnBg:  lipgloss.Color(tc.ColorAlertWarnBg),
-        ColorAlertErrorBg: lipgloss.Color(tc.ColorAlertErrorBg),
-        ColorAlertDeferBg: lipgloss.Color(tc.ColorAlertDeferBg),
+		ColorAlertInfo:    lipgloss.Color(tc.ColorAlertInfo),
+		ColorAlertWarn:    lipgloss.Color(tc.ColorAlertWarn),
+		ColorAlertError:   lipgloss.Color(tc.ColorAlertError),
+		ColorAlertDefer:   lipgloss.Color(tc.ColorAlertDefer),
+		ColorAlertInfoBg:  lipgloss.Color(tc.ColorAlertInfoBg),
+		ColorAlertWarnBg:  lipgloss.Color(tc.ColorAlertWarnBg),
+		ColorAlertErrorBg: lipgloss.Color(tc.ColorAlertErrorBg),
+		ColorAlertDeferBg: lipgloss.Color(tc.ColorAlertDeferBg),
 
-        IconAlertInfo:  tc.IconAlertInfo,
-        IconAlertWarn:  tc.IconAlertWarn,
-        IconAlertError: tc.IconAlertError,
-        IconAlertDefer: tc.IconAlertDefer,
+		IconAlertInfo:  tc.IconAlertInfo,
+		IconAlertWarn:  tc.IconAlertWarn,
+		IconAlertError: tc.IconAlertError,
+		IconAlertDefer: tc.IconAlertDefer,
 
-        IconTmuxSession: tc.IconTmuxSession,
-        IconCfgSession:  tc.IconCfgSession,
+		IconTmuxSession: tc.IconTmuxSession,
+		IconCfgSession:  tc.IconCfgSession,
 
-        ColorPort:    lipgloss.Color(tc.ColorPort),
-        ColorPortBg:  lipgloss.Color(tc.ColorPortBg),
-        ColorClean:   lipgloss.Color(tc.ColorClean),
-        ColorCpuLow:  lipgloss.Color(tc.ColorCpuLow),
-        ColorCpuMed:  lipgloss.Color(tc.ColorCpuMed),
-        ColorCpuHigh: lipgloss.Color(tc.ColorCpuHigh),
+		ColorPort:    lipgloss.Color(tc.ColorPort),
+		ColorPortBg:  lipgloss.Color(tc.ColorPortBg),
+		ColorClean:   lipgloss.Color(tc.ColorClean),
+		ColorCpuLow:  lipgloss.Color(tc.ColorCpuLow),
+		ColorCpuMed:  lipgloss.Color(tc.ColorCpuMed),
+		ColorCpuHigh: lipgloss.Color(tc.ColorCpuHigh),
 
-        ColorFgSearchHighlight: lipgloss.Color(tc.ColorFgSearchHighlight),
-    }
+		ColorFgSearchHighlight: lipgloss.Color(tc.ColorFgSearchHighlight),
+	}
 }

--- a/internal/tui/yank.go
+++ b/internal/tui/yank.go
@@ -1,73 +1,71 @@
 package tui
 
 import (
-    "fmt"
-    "os/exec"
-    "runtime"
-    "strings"
-
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
 )
 
-
 type YankField struct {
-    Key   string
-    Label string
-    Value string
+	Key   string
+	Label string
+	Value string
 }
 
 type YankModel struct {
-    fields []YankField
-    cursor int
+	fields []YankField
+	cursor int
 }
 
 func (y *YankModel) SetFields(fields []YankField) {
-    y.fields = fields
-    y.cursor = 0
+	y.fields = fields
+	y.cursor = 0
 }
 
 func (y YankModel) Render() string {
-    var lines []string
-    for i, f := range y.fields {
-        line := fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, f.Value)
-        if i == y.cursor {
-            line = selectedBG.Render(line)
-        }
-        lines = append(lines, line)
-    }
-    return yankStyle.Render(strings.Join(lines, "\n"))
+	var lines []string
+	for i, f := range y.fields {
+		line := fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, f.Value)
+		if i == y.cursor {
+			line = selectedBG.Render(line)
+		}
+		lines = append(lines, line)
+	}
+	return yankStyle.Render(strings.Join(lines, "\n"))
 }
 
 func (y *YankModel) MoveUp() {
-    if y.cursor > 0 {
-        y.cursor--
-    }
+	if y.cursor > 0 {
+		y.cursor--
+	}
 }
 
 func (y *YankModel) MoveDown() {
-    if y.cursor < len(y.fields)-1 {
-        y.cursor++
-    }
+	if y.cursor < len(y.fields)-1 {
+		y.cursor++
+	}
 }
 
 func (y YankModel) SelectedValue() string {
-    if y.cursor < len(y.fields) {
-        return y.fields[y.cursor].Value
-    }
-    return ""
+	if y.cursor < len(y.fields) {
+		return y.fields[y.cursor].Value
+	}
+	return ""
 }
 
 func CopyToClipboard(text string) error {
-    var cmd *exec.Cmd
-    switch runtime.GOOS {
-    case "darwin":
-        cmd = exec.Command("pbcopy")
-    default:
-        if _, err := exec.LookPath("wl-copy"); err == nil {
-            cmd = exec.Command("wl-copy")
-        } else {
-            cmd = exec.Command("xclip", "-selection", "clipboard")
-        }
-    }
-    cmd.Stdin = strings.NewReader(text)
-    return cmd.Run()
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	default:
+		if _, err := exec.LookPath("wl-copy"); err == nil {
+			cmd = exec.Command("wl-copy")
+		} else {
+			cmd = exec.Command("xclip", "-selection", "clipboard")
+		}
+	}
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
 }

--- a/main.go
+++ b/main.go
@@ -3,5 +3,5 @@ package main
 import "github.com/rtalexk/demux/cmd"
 
 func main() {
-    cmd.Execute()
+	cmd.Execute()
 }


### PR DESCRIPTION
## Summary
- Ran `gofmt -s -w` across all 87 Go files to comply with standard Go formatting
- Switches indentation from 4-space spaces to tabs (gofmt standard)
- No logic changes — formatting only

## Test plan
- [ ] `go build ./...` passes
- [ ] `gofmt -s -l .` returns no files