### PR TITLE
fix(db): enable WAL mode and busy timeout to prevent SQLITE_BUSY

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -19,7 +19,11 @@ func Open(path string) (*DB, error) {
 			return nil, fmt.Errorf("db dir: %w", err)
 		}
 	}
-	sqldb, err := sql.Open("sqlite", path)
+	dsn := path
+	if path != ":memory:" {
+		dsn = path + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+	}
+	sqldb, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Appends `?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)` to the SQLite DSN on open
- WAL mode allows concurrent readers during writes, eliminating lock contention between the TUI and CLI subcommands
- 5-second busy timeout retries on the rare write-write race instead of immediately returning `SQLITE_BUSY`
- `:memory:` paths are excluded from pragma injection to avoid breaking in-memory DB usage (e.g. tests)

## Test plan

- [ ] Run `demux` TUI and simultaneously invoke `demuxrc event pane_focus --target <session>:<window>.<pane>` repeatedly — confirm no `SQLITE_BUSY` errors
- [ ] Run `demux status`, `demux sessions`, `demux windows` while TUI is open — confirm clean output
- [ ] Run `go build ./...` — confirm no compilation errors