### PR TITLE
fix(help): remove incorrect 'expand session' from Enter keybinding

### DIFF
--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -77,7 +77,7 @@ func (h HelpModel) buildLines() []string {
 		helpNavLine("Tab/Shift+Tab", " cycles (wraps).  ", "g/G", " jumps."),
 		"",
 		helpSection("Sidebar"),
-		helpKV(7, "Enter", "expand session / select window"),
+		helpKV(7, "Enter", "select window"),
 		helpKV(7, "o", "attach to session / window"),
 		helpKV(7, "Esc", "back to session level"),
 		helpKV(7, keys.Defer.Help().Key, keys.Defer.Help().Desc),


### PR DESCRIPTION
## Summary

- Removes the incorrect "expand session" label from the Enter keybinding in the help menu
- Enter selects a window; it does not expand sessions

## Test plan

- Run demux, open the help menu with `?`, verify the Enter keybinding under Sidebar reads "select window"