### PR TITLE
fix(db): cap connection pool to 1 to prevent SQLITE_BUSY_RECOVERY

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,6 +27,7 @@ func Open(path string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	sqldb.SetMaxOpenConns(1)
 	d := &DB{sql: sqldb}
 	if err := d.migrate(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- `SQLITE_BUSY_RECOVERY` (261) is an extended subtype of `SQLITE_BUSY` for which the busy handler is **never invoked** — so `busy_timeout` cannot help
- The error is triggered by Go's `database/sql` default unlimited pool: connection 1 begins WAL recovery, connection 2 races to open the same file and gets error 261
- `SetMaxOpenConns(1)` serialises all DB access through one connection, eliminating the race; this has no practical downside for a single-user TUI app

## Test plan

- [ ] Run `demux` to confirm normal startup works
- [ ] Run `demux --compact` to confirm the original error is gone
- [ ] Run `demux alert list` while the TUI is open to confirm cross-process locking still works (busy_timeout handles this case)