### PR TITLE
feat(status): output alert counts in severity order, include defer level

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -23,7 +23,7 @@ func tmuxCounter(style, icon string, count int) string {
 	return fmt.Sprintf("%s%s %d", style, icon, count)
 }
 
-func countAlertsByLevel(alerts []db.Alert) (infos, warns, errors int) {
+func countAlertsByLevel(alerts []db.Alert) (infos, warns, errors, defers int) {
 	for _, a := range alerts {
 		switch a.Level {
 		case "info":
@@ -32,39 +32,58 @@ func countAlertsByLevel(alerts []db.Alert) (infos, warns, errors int) {
 			warns++
 		case "error":
 			errors++
+		case "defer":
+			defers++
 		}
 	}
 	return
 }
 
-func tmuxStatusParts(infos, warns, errors int, cfg config.Config) string {
-	if infos == 0 && warns == 0 && errors == 0 {
+func tmuxStatusParts(infos, warns, errors, defers int, cfg config.Config) string {
+	if infos == 0 && warns == 0 && errors == 0 && defers == 0 {
 		return "#[fg=green]#[default]"
 	}
 	var parts []string
-	if infos > 0 {
-		parts = append(parts, tmuxCounter("#[fg=cyan]", cfg.Theme.IconAlertInfo, infos))
+	if errors > 0 {
+		parts = append(parts, tmuxCounter("#[fg=red,bold]", cfg.Theme.IconAlertError, errors))
 	}
 	if warns > 0 {
 		parts = append(parts, tmuxCounter("#[fg=yellow]", cfg.Theme.IconAlertWarn, warns))
 	}
-	if errors > 0 {
-		parts = append(parts, tmuxCounter("#[fg=red,bold]", cfg.Theme.IconAlertError, errors))
+	if infos > 0 {
+		parts = append(parts, tmuxCounter("#[fg=cyan]", cfg.Theme.IconAlertInfo, infos))
+	}
+	if defers > 0 {
+		parts = append(parts, tmuxCounter("#[fg=#b4befe]", cfg.Theme.IconAlertDefer, defers))
 	}
 	return strings.Join(parts, " ") + "#[default]"
 }
 
-func formatStatusOutput(fmtName string, infos, warns, errors int, cfg config.Config) string {
+func formatStatusOutput(fmtName string, infos, warns, errors, defers int, cfg config.Config) string {
 	switch fmtName {
 	case "tmux":
-		return tmuxStatusParts(infos, warns, errors, cfg)
+		return tmuxStatusParts(infos, warns, errors, defers, cfg)
 	case "json":
+		// defers intentionally omitted; JSON schema is stable and order is not meaningful.
 		return fmt.Sprintf(`{"infos":%d,"warns":%d,"errors":%d}`, infos, warns, errors)
 	default:
-		if infos == 0 && warns == 0 && errors == 0 {
+		if infos == 0 && warns == 0 && errors == 0 && defers == 0 {
 			return "ok"
 		}
-		return fmt.Sprintf("infos=%d warns=%d errors=%d", infos, warns, errors)
+		var parts []string
+		if errors > 0 {
+			parts = append(parts, fmt.Sprintf("errors=%d", errors))
+		}
+		if warns > 0 {
+			parts = append(parts, fmt.Sprintf("warns=%d", warns))
+		}
+		if infos > 0 {
+			parts = append(parts, fmt.Sprintf("infos=%d", infos))
+		}
+		if defers > 0 {
+			parts = append(parts, fmt.Sprintf("defers=%d", defers))
+		}
+		return strings.Join(parts, " ")
 	}
 }
 
@@ -80,7 +99,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	infos, warns, errors := countAlertsByLevel(alerts)
+	infos, warns, errors, defers := countAlertsByLevel(alerts)
 
 	cfg := loadConfig()
 
@@ -89,7 +108,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		fmtName = "tmux"
 	}
 
-	out := formatStatusOutput(fmtName, infos, warns, errors, cfg)
+	out := formatStatusOutput(fmtName, infos, warns, errors, defers, cfg)
 	if fmtName == "tmux" {
 		fmt.Print(out)
 	} else {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
+)
+
+func TestCountAlertsByLevel(t *testing.T) {
+	alerts := []db.Alert{
+		{Level: "info"},
+		{Level: "info"},
+		{Level: "warn"},
+		{Level: "error"},
+		{Level: "error"},
+		{Level: "error"},
+		{Level: "defer"},
+	}
+	infos, warns, errors, defers := countAlertsByLevel(alerts)
+	if infos != 2 {
+		t.Errorf("infos: want 2, got %d", infos)
+	}
+	if warns != 1 {
+		t.Errorf("warns: want 1, got %d", warns)
+	}
+	if errors != 3 {
+		t.Errorf("errors: want 3, got %d", errors)
+	}
+	if defers != 1 {
+		t.Errorf("defers: want 1, got %d", defers)
+	}
+}
+
+func TestTmuxStatusParts_SeverityOrder(t *testing.T) {
+	cfg := config.Default()
+	out := tmuxStatusParts(1, 1, 1, 1, cfg)
+	errIdx := strings.Index(out, cfg.Theme.IconAlertError)
+	warnIdx := strings.Index(out, cfg.Theme.IconAlertWarn)
+	infoIdx := strings.Index(out, cfg.Theme.IconAlertInfo)
+	deferIdx := strings.Index(out, cfg.Theme.IconAlertDefer)
+	if errIdx == -1 || warnIdx == -1 || infoIdx == -1 || deferIdx == -1 {
+		t.Fatalf("missing icon in output: %q", out)
+	}
+	if !(errIdx < warnIdx && warnIdx < infoIdx && infoIdx < deferIdx) {
+		t.Errorf("wrong severity order in output: %q", out)
+	}
+}
+
+func TestTmuxStatusParts_ZeroDefer(t *testing.T) {
+	cfg := config.Default()
+	out := tmuxStatusParts(0, 0, 1, 0, cfg)
+	if strings.Contains(out, cfg.Theme.IconAlertDefer) {
+		t.Errorf("defer icon should not appear when defers=0: %q", out)
+	}
+}
+
+func TestFormatStatusOutput_PlainOrder(t *testing.T) {
+	cfg := config.Default()
+	out := formatStatusOutput("plain", 1, 1, 1, 1, cfg)
+	errIdx := strings.Index(out, "errors=")
+	warnIdx := strings.Index(out, "warns=")
+	infoIdx := strings.Index(out, "infos=")
+	deferIdx := strings.Index(out, "defers=")
+	if !(errIdx < warnIdx && warnIdx < infoIdx && infoIdx < deferIdx) {
+		t.Errorf("wrong severity order in plain output: %q", out)
+	}
+}
+
+func TestFormatStatusOutput_PlainSkipsZeros(t *testing.T) {
+	cfg := config.Default()
+	out := formatStatusOutput("plain", 1, 0, 0, 0, cfg)
+	if strings.Contains(out, "errors=") || strings.Contains(out, "warns=") || strings.Contains(out, "defers=") {
+		t.Errorf("plain output should skip zero counts: %q", out)
+	}
+	if !strings.Contains(out, "infos=1") {
+		t.Errorf("plain output missing infos=1: %q", out)
+	}
+}
+
+func TestFormatStatusOutput_JSON(t *testing.T) {
+	cfg := config.Default()
+	out := formatStatusOutput("json", 1, 2, 3, 4, cfg)
+	// defers is intentionally omitted from JSON output; schema is stable
+	want := `{"infos":1,"warns":2,"errors":3}`
+	if out != want {
+		t.Errorf("json output: want %q, got %q", want, out)
+	}
+}


### PR DESCRIPTION
## Summary

- Alert counts in `demux status` now output in descending severity order: errors, warns, infos, defers (left to right)
- The `defer` alert level was previously omitted from status output; it is now included
- Plain text format follows the same severity order and skips zero-count levels
- JSON format intentionally unchanged

## Test Plan

- [ ] Run `go test ./cmd/ -run 'TestCountAlertsByLevel|TestTmuxStatusParts|TestFormatStatusOutput' -v` — all 6 tests pass
- [ ] Run `go test ./...` — 416 tests pass, no regressions
- [ ] Manually: set alerts of mixed levels and run `demux status` — verify errors appear leftmost in tmux status bar