### PR TITLE
refactor(db): extract migrateV1/V2 to reduce cyclomatic complexity

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -44,13 +44,26 @@ func (d *DB) migrate() error {
 	if err := d.sql.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
 		return fmt.Errorf("read schema version: %w", err)
 	}
-
 	if version < 1 {
-		tx, err := d.sql.Begin()
-		if err != nil {
-			return fmt.Errorf("begin v1: %w", err)
+		if err := d.migrateV1(); err != nil {
+			return err
 		}
-		if _, err := tx.Exec(`
+		version = 1
+	}
+	if version < 2 {
+		if err := d.migrateV2(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *DB) migrateV1() error {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin v1: %w", err)
+	}
+	if _, err := tx.Exec(`
             CREATE TABLE IF NOT EXISTS alerts (
                 id         INTEGER PRIMARY KEY AUTOINCREMENT,
                 target     TEXT NOT NULL UNIQUE,
@@ -59,60 +72,57 @@ func (d *DB) migrate() error {
                 created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
         `); err != nil {
-			tx.Rollback()
-			return fmt.Errorf("migrate v1: %w", err)
-		}
-		if _, err := tx.Exec(`PRAGMA user_version = 1`); err != nil {
-			tx.Rollback()
-			return fmt.Errorf("set version 1: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit v1: %w", err)
-		}
-		version = 1
+		tx.Rollback()
+		return fmt.Errorf("migrate v1: %w", err)
+	}
+	if _, err := tx.Exec(`PRAGMA user_version = 1`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("set version 1: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit v1: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) migrateV2() error {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin v2: %w", err)
 	}
 
-	if version < 2 {
-		tx, err := d.sql.Begin()
-		if err != nil {
-			return fmt.Errorf("begin v2: %w", err)
-		}
-
-		// Check if sticky column already exists (handles partial migrations).
-		rows, err := tx.Query(`PRAGMA table_info(alerts)`)
-		if err != nil {
-			tx.Rollback()
-			return fmt.Errorf("table info v2: %w", err)
-		}
-		var hasSticky bool
-		for rows.Next() {
-			var cid int
-			var name, typ string
-			var notNull int
-			var dfltVal sql.NullString
-			var pk int
-			if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltVal, &pk); err == nil && name == "sticky" {
-				hasSticky = true
-			}
-		}
-		rows.Close()
-
-		if !hasSticky {
-			if _, err := tx.Exec(`ALTER TABLE alerts ADD COLUMN sticky BOOLEAN NOT NULL DEFAULT 0`); err != nil {
-				tx.Rollback()
-				return fmt.Errorf("migrate v2: %w", err)
-			}
-		}
-
-		if _, err := tx.Exec(`PRAGMA user_version = 2`); err != nil {
-			tx.Rollback()
-			return fmt.Errorf("set version 2: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit v2: %w", err)
+	// Check if sticky column already exists (handles partial migrations).
+	rows, err := tx.Query(`PRAGMA table_info(alerts)`)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("table info v2: %w", err)
+	}
+	var hasSticky bool
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var dfltVal sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltVal, &pk); err == nil && name == "sticky" {
+			hasSticky = true
 		}
 	}
+	rows.Close()
 
+	if !hasSticky {
+		if _, err := tx.Exec(`ALTER TABLE alerts ADD COLUMN sticky BOOLEAN NOT NULL DEFAULT 0`); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("migrate v2: %w", err)
+		}
+	}
+	if _, err := tx.Exec(`PRAGMA user_version = 2`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("set version 2: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit v2: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Extracted the v1 and v2 migration blocks from \`(*DB).migrate()\` into dedicated \`migrateV1()\` and \`migrateV2()\` methods
- Reduces \`migrate()\` cyclomatic complexity from 17 to ~4, resolving the \`gocyclo\` warning
- No behaviour change; all 14 existing migration tests pass

## Test Plan

- [x] \`go test ./internal/db/...\` — 14 tests pass
- [ ] Manual: start demux fresh (no existing DB) — verify alerts table is created and usable
- [ ] Manual: start demux with a v1 DB — verify \`sticky\` column is added on upgrade