### PR TITLE
fix(git): use --no-optional-locks to prevent index.lock conflicts

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -65,7 +65,7 @@ func Fetch(dir string, timeoutMs int) (Info, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
 	defer cancel()
 
-	out, err := exec.CommandContext(ctx, "git", "-C", dir, "status", "--porcelain=v1", "-b").Output()
+	out, err := exec.CommandContext(ctx, "git", "--no-optional-locks", "-C", dir, "status", "--porcelain=v1", "-b").Output()
 	if err != nil {
 		info := Info{Dir: dir}
 		if fi, statErr := os.Stat(filepath.Join(dir, ".bare")); statErr == nil && fi.IsDir() {


### PR DESCRIPTION
## Summary

- Concurrent `git status` calls from the sidebar (one per session, up to 8 goroutines) would race to update the index stat cache when two sessions share the same bare repo (e.g., two worktrees of the same project)
- This caused `fatal: Unable to create '...index.lock': File exists` errors
- Adding `--no-optional-locks` skips the optional cache write; the status output (branch, dirty state, ahead/behind) is identical

## Test plan

- All 416 existing tests pass
- Manual: open demux with two sessions pointing to different worktrees of the same bare repo and confirm no index.lock errors appear