### PR TITLE
feat: add version command and --version/-v flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,8 @@ builds:
     binary: demux
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/rtalexk/demux/cmd.Version={{.Version}}
     goos:
       - linux
       - windows
@@ -23,6 +25,8 @@ builds:
     binary: demux
     env:
       - CGO_ENABLED=1
+    ldflags:
+      - -X github.com/rtalexk/demux/cmd.Version={{.Version}}
     goos:
       - darwin
     goarch:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.Version = Version
 	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "", "Output format: text|table|json")
 	rootCmd.PersistentFlags().StringVar(&logLevelFlag, "log-level", "", "Log level: off|error|warn|info|debug (overrides config)")
 	rootCmd.PersistentFlags().BoolVar(&compactFlag, "compact", false, "Launch in compact mode (sidebar + search only)")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+var Version = "dev"
+
+func printVersion(w io.Writer) {
+	fmt.Fprintln(w, Version)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version",
+	Run: func(cmd *cobra.Command, args []string) {
+		printVersion(cmd.OutOrStdout())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionDefault(t *testing.T) {
+	if Version != "dev" {
+		t.Errorf("default version: want %q, got %q", "dev", Version)
+	}
+}
+
+func TestPrintVersion_OutputsVersion(t *testing.T) {
+	orig := Version
+	Version = "1.2.3"
+	defer func() { Version = orig }()
+
+	var buf bytes.Buffer
+	printVersion(&buf)
+
+	if got := strings.TrimSpace(buf.String()); got != "1.2.3" {
+		t.Errorf("want %q, got %q", "1.2.3", got)
+	}
+}


### PR DESCRIPTION
closes #26 

## Summary

- Adds `demux version` subcommand that prints the version string
- Adds `--version` / `-v` flags via cobra's built-in version support
- Wires GoReleaser ldflags to inject the git tag at release time; defaults to `dev` for local builds

## Test Plan

- [ ] `go test ./cmd/ -run "TestVersion|TestPrintVersion"` passes
- [ ] `demux version` prints `dev` locally
- [ ] `demux --version` and `demux -v` print `demux version dev` locally
- [ ] On release, verify `demux --version` prints the correct tag version (already exercised by the Homebrew tap test)