### PR TITLE
feat(status): add configurable clean icon for empty status output

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,8 @@ icon_state_idle = "○"
 color_state_idle    = "#89dceb"
 color_state_idle_bg = "#0d2530"
 
+icon_status_clean = "🟢"  # shown by `demux status` when there are no active states
+
 # Session source icons (shown in sidebar)
 icon_tmux_session = "⊞"   # live tmux session
 icon_cfg_session  = "⚙︎"   # config-only (not currently running)
@@ -728,7 +730,7 @@ Add a live state summary to your tmux status bar:
 set -g status-right "#(demux status)"
 ```
 
-This outputs a colored summary of active pane states. When all panes are idle it shows a green indicator. Counts for `error`, `flagged`, `waiting`, `done`, and `idle` are shown when any are active.
+This outputs a colored summary of active pane states. When there are no active states it shows a configurable clean icon (default: `🟢`). Counts for `error`, `flagged`, `waiting`, `done`, and `idle` are shown when any are active. Configure the clean icon with `icon_status_clean` in the `[theme]` section.
 
 ### Claude Code
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -191,6 +191,9 @@ icon_state_idle  = "○"
 color_state_idle    = "#89dceb"
 color_state_idle_bg = "#0d2530"
 
+# Icon shown by "demux status" when there are no active states
+icon_status_clean = "🟢"
+
 # Session source icons
 icon_tmux_session = "⊞"
 icon_cfg_session  = "⚙︎"

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -44,7 +44,7 @@ func countStatesByValue(states []db.ToolState) (waiting, errs, flagged, done, id
 func tmuxStatusParts(waiting, errs, flagged, done, idle int, cfg config.Config) string {
 	th := cfg.Theme
 	if waiting == 0 && errs == 0 && flagged == 0 && done == 0 && idle == 0 {
-		return fmt.Sprintf("#[fg=%s]%s#[default]", th.ColorStateDone, th.IconStateDone)
+		return fmt.Sprintf("#[fg=%s]%s#[default]", th.ColorStateDone, th.IconStatusClean)
 	}
 	var parts []string
 	if errs > 0 {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -42,8 +42,8 @@ func TestCountStatesByValue(t *testing.T) {
 func TestTmuxStatusParts_NoStates(t *testing.T) {
 	cfg := config.Default()
 	out := tmuxStatusParts(0, 0, 0, 0, 0, cfg)
-	if !strings.Contains(out, cfg.Theme.IconStateDone) {
-		t.Errorf("expected done icon %q, got: %q", cfg.Theme.IconStateDone, out)
+	if !strings.Contains(out, cfg.Theme.IconStatusClean) {
+		t.Errorf("expected clean icon %q, got: %q", cfg.Theme.IconStatusClean, out)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,6 +95,7 @@ type ThemeConfig struct {
 	IconStateError   string `toml:"icon_state_error"`
 	IconStateFlagged string `toml:"icon_state_flagged"`
 	IconStateIdle    string `toml:"icon_state_idle"`
+	IconStatusClean  string `toml:"icon_status_clean"`
 
 	IconWatch  string `toml:"icon_watch"`
 	ColorWatch string `toml:"color_watch"`
@@ -246,6 +247,7 @@ func Default() Config {
 			IconStateError:   "✗",
 			IconStateFlagged: "🔖",
 			IconStateIdle:    "○",
+			IconStatusClean:  "🟢",
 
 			IconWatch:  "·",
 			ColorWatch: "#89b4fa",


### PR DESCRIPTION
## Summary

- Adds `icon_status_clean` to `ThemeConfig` (default: `🟢`) for the icon shown by `demux status` when there are no active states
- Previously the clean state re-used `icon_state_done`; now it has its own dedicated, configurable field
- Documented in config init template and README

## Test plan

- Run `demux status` with no active states — should output `🟢`
- Set a custom `icon_status_clean` in `~/.config/demux/demux.toml` and verify it's reflected
- Run `demux config init` and confirm `icon_status_clean = "🟢"` appears in the `[theme]` section
- Verify `demux status` still shows state counts when states are active