### PR TITLE
feat(db/cmd): stable pane identity — pane_id column, GC, and kill-event cleanup

### DIFF
--- a/cmd/event.go
+++ b/cmd/event.go
@@ -109,6 +109,26 @@ func applyHookError() error {
 	return nil
 }
 
+var eventPaneClosedPaneID string
+
+var eventPaneClosedCmd = &cobra.Command{
+	Use:   "pane_closed",
+	Short: "Clear state for a closed tmux pane (called by after-kill-pane hook)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		d, err := openDB()
+		if err != nil {
+			return err
+		}
+		defer d.Close()
+		return applyPaneClosed(d, eventPaneClosedPaneID)
+	},
+}
+
+func applyPaneClosed(d *db.DB, paneID string) error {
+	demuxlog.Debug("pane_closed", "pane_id", paneID)
+	return d.StateClearByPaneID(paneID)
+}
+
 func init() {
 	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusTarget, "target", "", "Pane target: session:window.pane (auto-detected if omitted)")
 
@@ -119,6 +139,9 @@ func init() {
 	eventHookErrorCmd.Flags().BoolVar(&hookErrorSetStateError, "set-state-error", false, "Set the target state to error (requires --target)")
 	eventHookErrorCmd.MarkFlagRequired("hook")
 
-	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd)
+	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedPaneID, "pane", "", "Stable pane ID (%N format) of the closed pane (required)")
+	eventPaneClosedCmd.MarkFlagRequired("pane")
+
+	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneClosedCmd)
 	rootCmd.AddCommand(eventCmd)
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -101,7 +101,7 @@ func applyHookError() error {
 			return err
 		}
 		defer d.Close()
-		if err := d.StateSet(hookErrorTarget, hookErrorTool, db.StateError, hookErrorMessage, db.SourceTool, true, nil); err != nil {
+		if err := d.StateSet(hookErrorTarget, hookErrorTool, db.StateError, hookErrorMessage, db.SourceTool, true, nil, ""); err != nil {
 			demuxlog.Error("hook_error: set state error failed", "target", hookErrorTarget, "err", err)
 			return err
 		}

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -30,7 +30,7 @@ var eventPaneFocusCmd = &cobra.Command{
 		target := eventPaneFocusTarget
 		if target == "" {
 			var err error
-			target, err = tmuxPaneTarget()
+			target, _, err = tmuxPaneTarget()
 			if err != nil {
 				return err
 			}

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -101,3 +101,26 @@ func TestPaneFocusClearsIdleStates(t *testing.T) {
 		t.Error("idle pane state should be cleared on focus")
 	}
 }
+
+func TestApplyPaneClosed_DeletesByPaneID(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", db.StateWorking, "", db.SourceTool, false, nil, "%7")
+	if err := applyPaneClosed(d, "%7"); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := d.StateByTarget("s:0.0")
+	if st != nil {
+		t.Errorf("state should be deleted after pane_closed, got: %+v", st)
+	}
+}
+
+func TestApplyPaneClosed_NoopUnknownPane(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	if err := applyPaneClosed(d, "%99"); err != nil {
+		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
+	}
+}

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -34,8 +34,8 @@ func TestPaneFocusClearsDoneStates(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("myses:0.1", "claude", db.StateDone, "finished", db.SourceTool, false, nil)
-	d.StateSet("myses:0", "claude", db.StateDone, "finished", db.SourceTool, false, nil)
+	d.StateSet("myses:0.1", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
+	d.StateSet("myses:0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
 
 	if err := applyPaneFocus(d, "myses:0.1"); err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestPaneFocusDoesNotClearNonDone(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("myses:0.1", "claude", db.StateError, "boom", db.SourceTool, false, nil)
+	d.StateSet("myses:0.1", "claude", db.StateError, "boom", db.SourceTool, false, nil, "")
 	applyPaneFocus(d, "myses:0.1")
 
 	st, _ := d.StateByTarget("myses:0.1")
@@ -68,7 +68,7 @@ func TestPaneFocusDoesNotClearFlagged(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("myses:0.1", "", db.StateFlagged, "come back", db.SourceUser, false, nil)
+	d.StateSet("myses:0.1", "", db.StateFlagged, "come back", db.SourceUser, false, nil, "")
 	applyPaneFocus(d, "myses:0.1")
 
 	st, _ := d.StateByTarget("myses:0.1")
@@ -90,7 +90,7 @@ func TestPaneFocusClearsIdleStates(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("myses:0.1", "claude", db.StateIdle, "available", db.SourceTool, false, nil)
+	d.StateSet("myses:0.1", "claude", db.StateIdle, "available", db.SourceTool, false, nil, "")
 
 	if err := applyPaneFocus(d, "myses:0.1"); err != nil {
 		t.Fatal(err)

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rtalexk/demux/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+var gcCmd = &cobra.Command{
+	Use:   "gc",
+	Short: "Garbage collect stale records",
+}
+
+var gcStatesCmd = &cobra.Command{
+	Use:   "states",
+	Short: "Remove orphaned state records for closed tmux panes",
+	RunE:  runGCStates,
+}
+
+func runGCStates(_ *cobra.Command, _ []string) error {
+	panes, err := tmux.ListPanes()
+	if err != nil {
+		return fmt.Errorf("tmux not available: %w", err)
+	}
+
+	livePaneIDs := make(map[string]bool, len(panes))
+	livePaneTargets := make(map[string]bool, len(panes))
+	for _, p := range panes {
+		if p.PaneID != "" {
+			livePaneIDs[p.PaneID] = true
+		}
+		target := fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)
+		livePaneTargets[target] = true
+	}
+
+	d, err := openDB()
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	n, err := d.StateGCOrphaned(livePaneIDs, livePaneTargets)
+	if err != nil {
+		return fmt.Errorf("gc states: %w", err)
+	}
+	if n > 0 {
+		fmt.Printf("Removed %d orphaned state record(s).\n", n)
+	} else {
+		fmt.Println("No orphaned state records found.")
+	}
+	return nil
+}
+
+func init() {
+	gcCmd.AddCommand(gcStatesCmd)
+	rootCmd.AddCommand(gcCmd)
+}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -30,7 +30,7 @@ func runGCStates(_ *cobra.Command, _ []string) error {
 		if p.PaneID != "" {
 			livePaneIDs[p.PaneID] = true
 		}
-		target := fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)
+		target := p.Target()
 		livePaneTargets[target] = true
 	}
 

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -1,27 +1,24 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func TestBuildLivePaneMaps(t *testing.T) {
-	panes := []struct {
-		paneID  string
-		session string
-		winIdx  int
-		paneIdx int
-	}{
-		{"%1", "work", 0, 0},
-		{"%2", "work", 1, 0},
+	panes := []tmux.Pane{
+		{PaneID: "%1", Session: "work", WindowIndex: 0, PaneIndex: 0},
+		{PaneID: "%2", Session: "work", WindowIndex: 1, PaneIndex: 0},
 	}
 
 	liveIDs := map[string]bool{}
 	liveTargets := map[string]bool{}
 	for _, p := range panes {
-		liveIDs[p.paneID] = true
-		target := fmt.Sprintf("%s:%d.%d", p.session, p.winIdx, p.paneIdx)
-		liveTargets[target] = true
+		if p.PaneID != "" {
+			liveIDs[p.PaneID] = true
+		}
+		liveTargets[p.Target()] = true
 	}
 
 	if !liveIDs["%1"] || !liveIDs["%2"] {

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBuildLivePaneMaps(t *testing.T) {
+	panes := []struct {
+		paneID  string
+		session string
+		winIdx  int
+		paneIdx int
+	}{
+		{"%1", "work", 0, 0},
+		{"%2", "work", 1, 0},
+	}
+
+	liveIDs := map[string]bool{}
+	liveTargets := map[string]bool{}
+	for _, p := range panes {
+		liveIDs[p.paneID] = true
+		target := fmt.Sprintf("%s:%d.%d", p.session, p.winIdx, p.paneIdx)
+		liveTargets[target] = true
+	}
+
+	if !liveIDs["%1"] || !liveIDs["%2"] {
+		t.Error("pane_ids not in live map")
+	}
+	if !liveTargets["work:0.0"] || !liveTargets["work:1.0"] {
+		t.Error("pane targets not in live map")
+	}
+}

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -84,6 +84,7 @@ const tmuxHooksSnippet = `# demux tmux hooks
 #   Together they cover every way a pane can receive focus.
 #   Each hook targets the now-active pane and clears any done states on it and its
 #   parent window.
+#   after-kill-pane     — fires when a pane is closed; removes its state record.
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Clears Demux done states when switching between panes within the same window.
@@ -97,6 +98,9 @@ set-hook -g client-session-changed "run-shell 'demux event pane_focus --target #
 
 # Clears Demux done states when switching back from another application.
 set-hook -g client-focus-in "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+
+# Removes Demux state when a pane is closed (prevents stale state accumulation).
+set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane #{pane_id} 2>/dev/null; true'"
 # ──────────────────────────────────────────────────────────────────────────────
 `
 

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -55,19 +55,20 @@ func resolveAgent(name string) (agentDef, error) {
 	return agentDef{}, fmt.Errorf("unknown tool %q: supported tools: %s", name, strings.Join(supported, ", "))
 }
 
-// tmuxPaneTarget returns the current tmux target as "session:windowIndex.paneIndex".
-// It uses $TMUX_PANE (set by tmux at process start) so the result always refers
-// to the pane where the agent was launched, not the currently focused pane.
-func tmuxPaneTarget() (string, error) {
+// tmuxPaneTarget returns the current tmux target as "session:windowIndex.paneIndex"
+// and the stable pane ID (%N) from $TMUX_PANE.
+func tmuxPaneTarget() (target string, paneID string, err error) {
+	paneID = os.Getenv("TMUX_PANE") // already %N — set by tmux at process start
 	args := []string{"display-message", "-p", "#S:#I.#P"}
-	if pane := os.Getenv("TMUX_PANE"); pane != "" {
-		args = []string{"display-message", "-t", pane, "-p", "#S:#I.#P"}
+	if paneID != "" {
+		args = []string{"display-message", "-t", paneID, "-p", "#S:#I.#P"}
 	}
-	out, err := exec.Command("tmux", args...).Output()
-	if err != nil {
-		return "", fmt.Errorf("get tmux pane target: %w", err)
+	out, execErr := exec.Command("tmux", args...).Output()
+	if execErr != nil {
+		return "", paneID, fmt.Errorf("get tmux pane target: %w", execErr)
 	}
-	return strings.TrimSpace(string(out)), nil
+	target = strings.TrimSpace(string(out))
+	return target, paneID, nil
 }
 
 const tmuxHooksSnippet = `# demux tmux hooks

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -37,3 +37,12 @@ func TestTmuxHooksSnippet_ContainsAfterSelectPane(t *testing.T) {
 		t.Error("tmuxHooksSnippet should call demux event pane_focus")
 	}
 }
+
+func TestTmuxHooksSnippet_ContainsAfterKillPane(t *testing.T) {
+	if !strings.Contains(tmuxHooksSnippet, "after-kill-pane") {
+		t.Error("hooks snippet should include after-kill-pane hook for GC")
+	}
+	if !strings.Contains(tmuxHooksSnippet, "pane_closed") {
+		t.Error("hooks snippet after-kill-pane hook should call demux event pane_closed")
+	}
+}

--- a/cmd/sessions_test.go
+++ b/cmd/sessions_test.go
@@ -57,9 +57,9 @@ func TestClearSessionStates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.StateSet("myapp:0", "claude", db.StateWorking, "", db.SourceTool, false, nil)
-	d.StateSet("myapp:1", "make", db.StateError, "fail", db.SourceTool, false, nil)
-	d.StateSet("other:0", "claude", db.StateDone, "ok", db.SourceTool, false, nil)
+	d.StateSet("myapp:0", "claude", db.StateWorking, "", db.SourceTool, false, nil, "")
+	d.StateSet("myapp:1", "make", db.StateError, "fail", db.SourceTool, false, nil, "")
+	d.StateSet("other:0", "claude", db.StateDone, "ok", db.SourceTool, false, nil, "")
 	d.Close()
 
 	// Each clearSessionStates call opens and closes its own handle.

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -19,6 +19,7 @@ var (
 	stateSource  string
 	stateForce   bool
 	stateIfState string
+	statePaneID  string
 
 	clearTarget string
 	clearYes    bool
@@ -55,6 +56,7 @@ func init() {
 	stateSetCmd.Flags().StringVar(&stateSource, "source", "tool", "Source: tool|user")
 	stateSetCmd.Flags().BoolVar(&stateForce, "force", false, "Override write-lock (allow overwriting another tool's active state)")
 	stateSetCmd.Flags().StringVar(&stateIfState, "if-state", "", "Only write if current state matches this value")
+	stateSetCmd.Flags().StringVar(&statePaneID, "pane-id", "", "Stable tmux pane ID (%N format, e.g. %12); stored alongside target for GC")
 	stateSetCmd.MarkFlagRequired("target")
 	stateSetCmd.MarkFlagRequired("state")
 
@@ -115,7 +117,7 @@ func applyStateSet(d *db.DB) error {
 		ifState = &sv
 	}
 
-	if err := d.StateSet(stateTarget, stateTool, val, stateMessage, src, stateForce, ifState); err != nil {
+	if err := d.StateSet(stateTarget, stateTool, val, stateMessage, src, stateForce, ifState, statePaneID); err != nil {
 		if errors.Is(err, db.ErrStateLocked) {
 			demuxlog.Warn("state set rejected: lock", "target", stateTarget, "tool", stateTool, "state", stateValue, "err", err)
 			fmt.Fprintln(os.Stderr, "error:", err)

--- a/cmd/state_test.go
+++ b/cmd/state_test.go
@@ -166,3 +166,28 @@ func TestStateSet_IfState_InvalidValue(t *testing.T) {
 		t.Errorf("error should mention --if-state, got: %v", err)
 	}
 }
+
+func TestStateSet_PaneIDFlag(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	stateTarget = "s:0.0"
+	stateValue = "working"
+	stateTool = "claude"
+	stateMessage = "running"
+	stateSource = "tool"
+	stateForce = false
+	stateIfState = ""
+	statePaneID = "%42"
+
+	if err := applyStateSet(d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	st, _ := d.StateByTarget("s:0.0")
+	if st == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if st.PaneID != "%42" {
+		t.Errorf("expected PaneID %%42, got %q", st.PaneID)
+	}
+}

--- a/cmd/state_test.go
+++ b/cmd/state_test.go
@@ -46,7 +46,7 @@ func TestStateClear_FlaggedRequiresYes(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "", db.StateFlagged, "note", db.SourceUser, false, nil)
+	d.StateSet("s:0.0", "", db.StateFlagged, "note", db.SourceUser, false, nil, "")
 
 	clearTarget = "s:0.0"
 	clearYes = false
@@ -69,7 +69,7 @@ func TestStateClear_NonFlagged_NoYesRequired(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "claude", db.StateError, "boom", db.SourceTool, false, nil)
+	d.StateSet("s:0.0", "claude", db.StateError, "boom", db.SourceTool, false, nil, "")
 
 	clearTarget = "s:0.0"
 	clearYes = false
@@ -105,7 +105,7 @@ func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
 	defer d.Close()
 
 	// Pre-set state to done.
-	d.StateSet("s:0.0", "claude", db.StateDone, "finished", db.SourceTool, false, nil)
+	d.StateSet("s:0.0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
 
 	stateTarget = "s:0.0"
 	stateValue = "waiting"
@@ -128,7 +128,7 @@ func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "claude", db.StateWorking, "running", db.SourceTool, false, nil)
+	d.StateSet("s:0.0", "claude", db.StateWorking, "running", db.SourceTool, false, nil, "")
 
 	stateTarget = "s:0.0"
 	stateValue = "done"

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -99,6 +99,31 @@ func (d *DB) migrate() error {
 	return nil
 }
 
+// tableHasColumn reports whether table contains a column named column.
+// It accepts both *sql.DB and *sql.Tx via the querier interface, so it works
+// inside and outside transactions. Table name is interpolated — callers must
+// use hardcoded literals (PRAGMA does not support bind parameters).
+type querier interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+func tableHasColumn(q querier, table, column string) (bool, error) {
+	rows, err := q.Query(`PRAGMA table_info(` + table + `)`)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, typ string
+		var dfltVal sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltVal, &pk); err == nil && name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
 func (d *DB) migrateV1() error {
 	tx, err := d.sql.Begin()
 	if err != nil {
@@ -132,24 +157,11 @@ func (d *DB) migrateV2() error {
 		return fmt.Errorf("begin v2: %w", err)
 	}
 
-	// Check if sticky column already exists (handles partial migrations).
-	rows, err := tx.Query(`PRAGMA table_info(alerts)`)
+	hasSticky, err := tableHasColumn(tx, "alerts", "sticky")
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("table info v2: %w", err)
 	}
-	var hasSticky bool
-	for rows.Next() {
-		var cid int
-		var name, typ string
-		var notNull int
-		var dfltVal sql.NullString
-		var pk int
-		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltVal, &pk); err == nil && name == "sticky" {
-			hasSticky = true
-		}
-	}
-	rows.Close()
 
 	if !hasSticky {
 		if _, err := tx.Exec(`ALTER TABLE alerts ADD COLUMN sticky BOOLEAN NOT NULL DEFAULT 0`); err != nil {
@@ -261,24 +273,11 @@ func (d *DB) migrateV6() error {
 	if err != nil {
 		return fmt.Errorf("begin v6: %w", err)
 	}
-	// Idempotency check — handles partial migrations.
-	rows, err := tx.Query(`PRAGMA table_info(tool_states)`)
+	hasPaneID, err := tableHasColumn(tx, "tool_states", "pane_id")
 	if err != nil {
 		tx.Rollback()
 		return fmt.Errorf("table info v6: %w", err)
 	}
-	var hasPaneID bool
-	for rows.Next() {
-		var cid int
-		var name, typ string
-		var notNull int
-		var dfltVal sql.NullString
-		var pk int
-		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltVal, &pk); err == nil && name == "pane_id" {
-			hasPaneID = true
-		}
-	}
-	rows.Close()
 	if !hasPaneID {
 		if _, err := tx.Exec(`ALTER TABLE tool_states ADD COLUMN pane_id TEXT`); err != nil {
 			tx.Rollback()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -90,6 +90,12 @@ func (d *DB) migrate() error {
 		}
 		version = 5
 	}
+	if version < 6 {
+		if err := d.migrateV6(); err != nil {
+			return err
+		}
+		version = 6
+	}
 	return nil
 }
 
@@ -246,6 +252,46 @@ func (d *DB) migrateV5() error {
 	if _, err := tx.Exec(`PRAGMA user_version = 5`); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("set version 5: %w", err)
+	}
+	return tx.Commit()
+}
+
+func (d *DB) migrateV6() error {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin v6: %w", err)
+	}
+	// Idempotency check — handles partial migrations.
+	rows, err := tx.Query(`PRAGMA table_info(tool_states)`)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("table info v6: %w", err)
+	}
+	var hasPaneID bool
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var dfltVal sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltVal, &pk); err == nil && name == "pane_id" {
+			hasPaneID = true
+		}
+	}
+	rows.Close()
+	if !hasPaneID {
+		if _, err := tx.Exec(`ALTER TABLE tool_states ADD COLUMN pane_id TEXT`); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("migrate v6 add pane_id: %w", err)
+		}
+		if _, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_tool_states_pane_id ON tool_states(pane_id) WHERE pane_id IS NOT NULL`); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("migrate v6 index pane_id: %w", err)
+		}
+	}
+	if _, err := tx.Exec(`PRAGMA user_version = 6`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("set version 6: %w", err)
 	}
 	return tx.Commit()
 }

--- a/internal/db/db_migrate_test.go
+++ b/internal/db/db_migrate_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"database/sql"
 	"testing"
 )
 
@@ -38,23 +37,11 @@ func TestMigrateV6_AddsPaneIDColumn(t *testing.T) {
 	}
 	defer d.Close()
 
-	rows, err := d.sql.Query(`PRAGMA table_info(tool_states)`)
+	ok, err := tableHasColumn(d.sql, "tool_states", "pane_id")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rows.Close()
-	var hasPaneID bool
-	for rows.Next() {
-		var cid int
-		var name, typ string
-		var notNull int
-		var dfltVal sql.NullString
-		var pk int
-		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltVal, &pk); err == nil && name == "pane_id" {
-			hasPaneID = true
-		}
-	}
-	if !hasPaneID {
+	if !ok {
 		t.Error("pane_id column not found in tool_states after migration")
 	}
 }

--- a/internal/db/db_migrate_test.go
+++ b/internal/db/db_migrate_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"testing"
 )
 
@@ -30,6 +31,34 @@ func TestMigrateV3_AlertsTableGone(t *testing.T) {
 	}
 }
 
+func TestMigrateV6_AddsPaneIDColumn(t *testing.T) {
+	d, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	rows, err := d.sql.Query(`PRAGMA table_info(tool_states)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var hasPaneID bool
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var dfltVal sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltVal, &pk); err == nil && name == "pane_id" {
+			hasPaneID = true
+		}
+	}
+	if !hasPaneID {
+		t.Error("pane_id column not found in tool_states after migration")
+	}
+}
+
 func TestMigrateV3_UserVersion(t *testing.T) {
 	d, err := Open(":memory:")
 	if err != nil {
@@ -41,7 +70,7 @@ func TestMigrateV3_UserVersion(t *testing.T) {
 	if err := d.sql.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
 		t.Fatalf("read user_version: %v", err)
 	}
-	if version != 5 {
-		t.Fatalf("expected user_version=5, got %d", version)
+	if version != 6 {
+		t.Fatalf("expected user_version=6, got %d", version)
 	}
 }

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	demuxlog "github.com/rtalexk/demux/internal/log"
@@ -227,6 +228,41 @@ func (d *DB) StateDeleteIfResting(target string) error {
 func (d *DB) StateClearByPaneID(paneID string) error {
 	_, err := d.sql.Exec(`DELETE FROM tool_states WHERE pane_id = ?`, paneID)
 	return err
+}
+
+// looksLikePaneTarget reports whether target is in "session:window.pane" format.
+// Used by StateGCOrphaned to skip session-level and window-level targets.
+func looksLikePaneTarget(target string) bool {
+	return strings.Contains(target, ":") && strings.Contains(target, ".")
+}
+
+// StateGCOrphaned deletes state records whose pane is no longer live.
+// For records with a pane_id: orphaned when pane_id is not in livePaneIDs.
+// For legacy records (pane_id empty) that look like "session:window.pane":
+// orphaned when target is not in livePaneTargets.
+// Session-level and window-level targets (no ".") are never deleted.
+// Returns the number of records deleted.
+func (d *DB) StateGCOrphaned(livePaneIDs map[string]bool, livePaneTargets map[string]bool) (int64, error) {
+	states, err := d.StateList(0, "")
+	if err != nil {
+		return 0, err
+	}
+	var deleted int64
+	for _, st := range states {
+		orphaned := false
+		if st.PaneID != "" {
+			orphaned = !livePaneIDs[st.PaneID]
+		} else if looksLikePaneTarget(st.Target) {
+			orphaned = !livePaneTargets[st.Target]
+		}
+		if orphaned {
+			if err := d.StateClear(st.Target); err != nil {
+				return deleted, fmt.Errorf("gc: clear %q: %w", st.Target, err)
+			}
+			deleted++
+		}
+	}
+	return deleted, nil
 }
 
 // StateDeleteBySession removes all state records for the given session.

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -122,13 +122,14 @@ type ToolState struct {
 	Tool      string
 	Value     StateValue
 	Message   string
+	PaneID    string
 	Source    StateSource
 	UpdatedAt time.Time
 }
 
 // StateSet writes a state record for target, applying write-lock rules.
 // Returns ErrStateLocked (wrapped) if the write is rejected.
-func (d *DB) StateSet(target, tool string, value StateValue, message string, source StateSource, force bool, ifState *StateValue) error {
+func (d *DB) StateSet(target, tool string, value StateValue, message string, source StateSource, force bool, ifState *StateValue, paneID string) error {
 	tx, err := d.sql.Begin()
 	if err != nil {
 		return fmt.Errorf("begin StateSet: %w", err)
@@ -180,15 +181,16 @@ func (d *DB) StateSet(target, tool string, value StateValue, message string, sou
 	}
 
 	_, err = tx.Exec(`
-		INSERT INTO tool_states (target, tool, value, message, source, updated_at)
-		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		INSERT INTO tool_states (target, tool, value, message, source, pane_id, updated_at)
+		VALUES (?, ?, ?, ?, ?, NULLIF(?, ''), CURRENT_TIMESTAMP)
 		ON CONFLICT(target) DO UPDATE SET
 			tool       = excluded.tool,
 			value      = excluded.value,
 			message    = excluded.message,
 			source     = excluded.source,
+			pane_id    = COALESCE(excluded.pane_id, tool_states.pane_id),
 			updated_at = excluded.updated_at
-	`, target, tool, int(value), message, int(source))
+	`, target, tool, int(value), message, int(source), paneID)
 	if err != nil {
 		return fmt.Errorf("upsert state: %w", err)
 	}
@@ -237,12 +239,14 @@ func (d *DB) StateDeleteBySession(name string) (int64, error) {
 // StateByTarget returns the ToolState for target, or nil if no record exists (idle).
 func (d *DB) StateByTarget(target string) (*ToolState, error) {
 	row := d.sql.QueryRow(`
-		SELECT id, target, tool, value, message, source, updated_at
+		SELECT id, target, tool, value, message, pane_id, source, updated_at
 		FROM tool_states WHERE target = ?
 	`, target)
 	var st ToolState
 	var updatedAt string
-	err := row.Scan(&st.ID, &st.Target, &st.Tool, &st.Value, &st.Message, &st.Source, &updatedAt)
+	var paneID sql.NullString
+	err := row.Scan(&st.ID, &st.Target, &st.Tool, &st.Value, &st.Message, &paneID, &st.Source, &updatedAt)
+	st.PaneID = paneID.String
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -255,7 +259,7 @@ func (d *DB) StateByTarget(target string) (*ToolState, error) {
 
 // StateList returns all non-idle state records. Pass value=0 or tool="" to skip that filter.
 func (d *DB) StateList(value StateValue, tool string) ([]ToolState, error) {
-	q := `SELECT id, target, tool, value, message, source, updated_at FROM tool_states WHERE 1=1`
+	q := `SELECT id, target, tool, value, message, pane_id, source, updated_at FROM tool_states WHERE 1=1`
 	var args []any
 	if value != 0 {
 		q += ` AND value = ?`
@@ -277,9 +281,11 @@ func (d *DB) StateList(value StateValue, tool string) ([]ToolState, error) {
 	for rows.Next() {
 		var st ToolState
 		var updatedAt string
-		if err := rows.Scan(&st.ID, &st.Target, &st.Tool, &st.Value, &st.Message, &st.Source, &updatedAt); err != nil {
+		var paneID sql.NullString
+		if err := rows.Scan(&st.ID, &st.Target, &st.Tool, &st.Value, &st.Message, &paneID, &st.Source, &updatedAt); err != nil {
 			return nil, err
 		}
+		st.PaneID = paneID.String
 		st.UpdatedAt = parseTS(updatedAt)
 		states = append(states, st)
 	}

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -222,6 +222,13 @@ func (d *DB) StateDeleteIfResting(target string) error {
 	return err
 }
 
+// StateClearByPaneID removes the state record whose pane_id matches.
+// No-op if no record has that pane_id.
+func (d *DB) StateClearByPaneID(paneID string) error {
+	_, err := d.sql.Exec(`DELETE FROM tool_states WHERE pane_id = ?`, paneID)
+	return err
+}
+
 // StateDeleteBySession removes all state records for the given session.
 // It matches targets equal to name (bare) or prefixed with "name:" (session:window).
 // Returns the number of rows deleted.

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -349,6 +349,43 @@ func TestStateSet_IfState_NoopWhenNoRow(t *testing.T) {
 	}
 }
 
+func TestStateClearByPaneID_DeletesRecord(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%12")
+	if err := d.StateClearByPaneID("%12"); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := d.StateByTarget("s:0.0")
+	if st != nil {
+		t.Errorf("expected state deleted by pane_id, got: %+v", st)
+	}
+}
+
+func TestStateClearByPaneID_NoopWhenNotFound(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	if err := d.StateClearByPaneID("%99"); err != nil {
+		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
+	}
+}
+
+func TestStateClearByPaneID_DoesNotDeleteOtherRecords(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%12")
+	d.StateSet("s:1.0", "claude", StateWorking, "running", SourceTool, false, nil, "%13")
+	d.StateClearByPaneID("%12")
+
+	st, _ := d.StateByTarget("s:1.0")
+	if st == nil {
+		t.Error("unrelated pane state should not be deleted")
+	}
+}
+
 func TestStateSet_StoresPaneID(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -386,6 +386,70 @@ func TestStateClearByPaneID_DoesNotDeleteOtherRecords(t *testing.T) {
 	}
 }
 
+func TestStateGCOrphaned_DeletesByPaneID(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", StateWorking, "", SourceTool, false, nil, "%12")
+	d.StateSet("s:1.0", "claude", StateWorking, "", SourceTool, false, nil, "%13")
+
+	// %12 is live; %13 is gone.
+	n, err := d.StateGCOrphaned(map[string]bool{"%12": true}, map[string]bool{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 deleted, got %d", n)
+	}
+	if st, _ := d.StateByTarget("s:0.0"); st == nil {
+		t.Error("live pane state should survive GC")
+	}
+	if st, _ := d.StateByTarget("s:1.0"); st != nil {
+		t.Error("orphaned pane state should be deleted")
+	}
+}
+
+func TestStateGCOrphaned_LegacyFallback(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	// Legacy record: no pane_id, target is session:window.pane format.
+	d.StateSet("s:0.0", "claude", StateWorking, "", SourceTool, false, nil, "")
+	d.StateSet("s:1.0", "claude", StateWorking, "", SourceTool, false, nil, "")
+
+	// s:0.0 is live; s:1.0 is not.
+	n, err := d.StateGCOrphaned(map[string]bool{}, map[string]bool{"s:0.0": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 deleted, got %d", n)
+	}
+	if st, _ := d.StateByTarget("s:0.0"); st == nil {
+		t.Error("live legacy target should survive")
+	}
+	if st, _ := d.StateByTarget("s:1.0"); st != nil {
+		t.Error("orphaned legacy target should be deleted")
+	}
+}
+
+func TestStateGCOrphaned_SkipsSessionAndWindowTargets(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	// Bare session target and window target have no pane_id and no dot — skip GC.
+	d.StateSet("myapp", "claude", StateWorking, "", SourceTool, false, nil, "")
+	d.StateSet("myapp:1", "claude", StateWorking, "", SourceTool, false, nil, "")
+
+	n, err := d.StateGCOrphaned(map[string]bool{}, map[string]bool{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("session/window targets should not be GC'd, deleted %d", n)
+	}
+}
+
 func TestStateSet_StoresPaneID(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -30,7 +30,7 @@ func TestStateSet_BasicUpsert(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	if err := d.StateSet("s:0:0", "claude", StateWorking, "running tests", SourceTool, false, nil); err != nil {
+	if err := d.StateSet("s:0:0", "claude", StateWorking, "running tests", SourceTool, false, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	st, err := d.StateByTarget("s:0:0")
@@ -49,8 +49,8 @@ func TestStateSet_LockWorking_DifferentTool(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil)
-	err := d.StateSet("s:0:0", "make", StateWorking, "", SourceTool, false, nil)
+	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, "")
+	err := d.StateSet("s:0:0", "make", StateWorking, "", SourceTool, false, nil, "")
 	if err == nil {
 		t.Fatal("expected locked error, got nil")
 	}
@@ -65,8 +65,8 @@ func TestStateSet_LockWorking_SameTool(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "step 1", SourceTool, false, nil)
-	if err := d.StateSet("s:0:0", "claude", StateWorking, "step 2", SourceTool, false, nil); err != nil {
+	d.StateSet("s:0:0", "claude", StateWorking, "step 1", SourceTool, false, nil, "")
+	if err := d.StateSet("s:0:0", "claude", StateWorking, "step 2", SourceTool, false, nil, ""); err != nil {
 		t.Errorf("same tool should not be locked: %v", err)
 	}
 }
@@ -75,9 +75,9 @@ func TestStateSet_LockFlagged_BlocksAllTools(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "", StateFlagged, "come back", SourceUser, false, nil)
+	d.StateSet("s:0:0", "", StateFlagged, "come back", SourceUser, false, nil, "")
 	// same tool name should still be blocked
-	if err := d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil); err == nil {
+	if err := d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, ""); err == nil {
 		t.Fatal("flagged should block all tool writes")
 	}
 }
@@ -87,14 +87,14 @@ func TestStateSet_ForceOverridesLock(t *testing.T) {
 	defer d.Close()
 
 	// Flagged blocks tool writes normally.
-	d.StateSet("s:0:0", "", StateFlagged, "come back", SourceUser, false, nil)
-	if err := d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, true, nil); err != nil {
+	d.StateSet("s:0:0", "", StateFlagged, "come back", SourceUser, false, nil, "")
+	if err := d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, true, nil, ""); err != nil {
 		t.Fatalf("force should override flagged lock: %v", err)
 	}
 
 	// Different-tool lock overridden by force.
-	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil)
-	if err := d.StateSet("s:0:0", "make", StateWorking, "", SourceTool, true, nil); err != nil {
+	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, "")
+	if err := d.StateSet("s:0:0", "make", StateWorking, "", SourceTool, true, nil, ""); err != nil {
 		t.Fatalf("force should override different-tool lock: %v", err)
 	}
 }
@@ -103,8 +103,8 @@ func TestStateSet_UserWriteAlwaysSucceeds(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil)
-	if err := d.StateSet("s:0:0", "", StateFlagged, "note", SourceUser, false, nil); err != nil {
+	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, "")
+	if err := d.StateSet("s:0:0", "", StateFlagged, "note", SourceUser, false, nil, ""); err != nil {
 		t.Errorf("user write should always succeed: %v", err)
 	}
 }
@@ -113,7 +113,7 @@ func TestStateClear(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateError, "boom", SourceTool, false, nil)
+	d.StateSet("s:0:0", "claude", StateError, "boom", SourceTool, false, nil, "")
 	if err := d.StateClear("s:0:0"); err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestStateDeleteIfDone(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil)
+	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil, "")
 	if err := d.StateDeleteIfDone("s:0:0"); err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestStateDeleteIfDone(t *testing.T) {
 	}
 
 	// non-done states must not be deleted
-	d.StateSet("s:1:0", "claude", StateError, "boom", SourceTool, false, nil)
+	d.StateSet("s:1:0", "claude", StateError, "boom", SourceTool, false, nil, "")
 	d.StateDeleteIfDone("s:1:0")
 	st2, _ := d.StateByTarget("s:1:0")
 	if st2 == nil {
@@ -150,7 +150,7 @@ func TestStateDeleteIfResting(t *testing.T) {
 	defer d.Close()
 
 	// done is cleared
-	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil)
+	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil, "")
 	d.StateDeleteIfResting("s:0:0")
 	st, _ := d.StateByTarget("s:0:0")
 	if st != nil {
@@ -158,7 +158,7 @@ func TestStateDeleteIfResting(t *testing.T) {
 	}
 
 	// idle is cleared
-	d.StateSet("s:1:0", "claude", StateIdle, "available", SourceTool, false, nil)
+	d.StateSet("s:1:0", "claude", StateIdle, "available", SourceTool, false, nil, "")
 	d.StateDeleteIfResting("s:1:0")
 	st2, _ := d.StateByTarget("s:1:0")
 	if st2 != nil {
@@ -166,7 +166,7 @@ func TestStateDeleteIfResting(t *testing.T) {
 	}
 
 	// working is not cleared
-	d.StateSet("s:2:0", "claude", StateWorking, "running", SourceTool, false, nil)
+	d.StateSet("s:2:0", "claude", StateWorking, "running", SourceTool, false, nil, "")
 	d.StateDeleteIfResting("s:2:0")
 	st3, _ := d.StateByTarget("s:2:0")
 	if st3 == nil {
@@ -174,7 +174,7 @@ func TestStateDeleteIfResting(t *testing.T) {
 	}
 
 	// error is not cleared
-	d.StateSet("s:3:0", "claude", StateError, "boom", SourceTool, false, nil)
+	d.StateSet("s:3:0", "claude", StateError, "boom", SourceTool, false, nil, "")
 	d.StateDeleteIfResting("s:3:0")
 	st4, _ := d.StateByTarget("s:3:0")
 	if st4 == nil {
@@ -186,8 +186,8 @@ func TestStateList(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil)
-	d.StateSet("s:1:0", "make", StateError, "fail", SourceTool, false, nil)
+	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, "")
+	d.StateSet("s:1:0", "make", StateError, "fail", SourceTool, false, nil, "")
 
 	all, err := d.StateList(0, "")
 	if err != nil {
@@ -208,9 +208,9 @@ func TestStateDeleteBySession(t *testing.T) {
 	defer d.Close()
 
 	// populate: two targets for session "myapp", one for another session
-	d.StateSet("myapp:0", "claude", StateWorking, "", SourceTool, false, nil)
-	d.StateSet("myapp:1", "make", StateError, "fail", SourceTool, false, nil)
-	d.StateSet("other:0", "claude", StateDone, "ok", SourceTool, false, nil)
+	d.StateSet("myapp:0", "claude", StateWorking, "", SourceTool, false, nil, "")
+	d.StateSet("myapp:1", "make", StateError, "fail", SourceTool, false, nil, "")
+	d.StateSet("other:0", "claude", StateDone, "ok", SourceTool, false, nil, "")
 
 	n, err := d.StateDeleteBySession("myapp")
 	if err != nil {
@@ -242,7 +242,7 @@ func TestStateDeleteBySession_BareTarget(t *testing.T) {
 	defer d.Close()
 
 	// target that is exactly the session name (no colon suffix)
-	d.StateSet("myapp", "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet("myapp", "claude", StateWorking, "", SourceTool, false, nil, "")
 
 	n, err := d.StateDeleteBySession("myapp")
 	if err != nil {
@@ -287,7 +287,7 @@ func TestStateIdle_SetAndRetrieve(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	if err := d.StateSet("s:0:0", "claude", StateIdle, "available", SourceTool, false, nil); err != nil {
+	if err := d.StateSet("s:0:0", "claude", StateIdle, "available", SourceTool, false, nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	st, _ := d.StateByTarget("s:0:0")
@@ -301,11 +301,11 @@ func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
 	defer d.Close()
 
 	// Set to done.
-	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil)
+	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil, "")
 
 	// Try to overwrite with working, but guard says "only if currently working".
 	ifWorking := StateWorking
-	err := d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, &ifWorking)
+	err := d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, &ifWorking, "")
 	if err != nil {
 		t.Fatalf("ifState mismatch should be a silent no-op, got: %v", err)
 	}
@@ -320,10 +320,10 @@ func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, nil)
+	d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, nil, "")
 
 	ifWorking := StateWorking
-	if err := d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, &ifWorking); err != nil {
+	if err := d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, &ifWorking, ""); err != nil {
 		t.Fatalf("ifState match should write: %v", err)
 	}
 	st, _ := d.StateByTarget("s:0:0")
@@ -339,12 +339,61 @@ func TestStateSet_IfState_NoopWhenNoRow(t *testing.T) {
 	// No row exists. Passing ifState=StateIdle (6) should be a no-op because
 	// a missing row is treated as StateValue(0), not StateIdle.
 	ifIdle := StateIdle
-	err := d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, &ifIdle)
+	err := d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, &ifIdle, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	st, _ := d.StateByTarget("s:0:0")
 	if st != nil {
 		t.Errorf("no row should exist: missing row != StateIdle, got: %+v", st)
+	}
+}
+
+func TestStateSet_StoresPaneID(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	if err := d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%12"); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := d.StateByTarget("s:0.0")
+	if st == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if st.PaneID != "%12" {
+		t.Errorf("expected PaneID %%12, got %q", st.PaneID)
+	}
+}
+
+func TestStateSet_PaneIDPreservedOnUpdate(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%12")
+	// Update with empty pane_id — existing value must be kept.
+	d.StateSet("s:0.0", "claude", StateDone, "done", SourceTool, true, nil, "")
+
+	st, _ := d.StateByTarget("s:0.0")
+	if st == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if st.PaneID != "%12" {
+		t.Errorf("pane_id should be preserved when update passes empty string, got %q", st.PaneID)
+	}
+}
+
+func TestStateSet_EmptyPaneID(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	if err := d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := d.StateByTarget("s:0.0")
+	if st == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if st.PaneID != "" {
+		t.Errorf("expected empty PaneID, got %q", st.PaneID)
 	}
 }

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -19,6 +19,11 @@ type Pane struct {
 	SessionActivity int64 // Unix timestamp from #{session_activity}
 }
 
+// Target returns the "session:windowIndex.paneIndex" target string used as a demux state key.
+func (p Pane) Target() string {
+	return fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)
+}
+
 // ListPanes runs tmux list-panes and returns all panes across all sessions.
 func ListPanes() ([]Pane, error) {
 	out, err := exec.Command("tmux", "list-panes", "-a",

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -519,7 +519,7 @@ func (m Model) flagCurrentState(target string) tea.Cmd {
 	d := m.db
 	msg := m.cfg.Tui.FlagDefaultMessage
 	return func() tea.Msg {
-		_ = d.StateSet(target, "", db.StateFlagged, msg, db.SourceUser, false, nil)
+		_ = d.StateSet(target, "", db.StateFlagged, msg, db.SourceUser, false, nil, "")
 		states, _ := d.StateList(0, "")
 		return statesMsg{states: states}
 	}

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -439,7 +439,7 @@ func (m Model) handleProcListCollapse(msg tea.KeyMsg, procH int) (Model, tea.Cmd
 func (m Model) handleProcListOpen() (Model, tea.Cmd) {
 	var target string
 	if pane := m.procList.SelectedPane(); pane != nil {
-		target = fmt.Sprintf("%s:%d.%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
+		target = pane.Target()
 	} else if node := m.sidebar.Selected(); node != nil {
 		target = node.Session
 	}
@@ -544,7 +544,7 @@ func (m Model) procListStateTarget() string {
 	if node.IsWindowHeader {
 		return fmt.Sprintf("%s:%d", node.Pane.Session, node.Pane.WindowIndex)
 	}
-	return fmt.Sprintf("%s:%d.%d", node.Pane.Session, node.Pane.WindowIndex, node.Pane.PaneIndex)
+	return node.Pane.Target()
 }
 
 // clearCurrentState clears the state for the given target.

--- a/internal/tui/proclist.go
+++ b/internal/tui/proclist.go
@@ -56,7 +56,7 @@ func (p *ProcListModel) SetStates(states []db.ToolState) {
 
 // stateForPane returns the state for the given pane, or nil.
 func (p ProcListModel) stateForPane(pane tmux.Pane) *db.ToolState {
-	key := fmt.Sprintf("%s:%d.%d", pane.Session, pane.WindowIndex, pane.PaneIndex)
+	key := pane.Target()
 	return activeStateFor(p.states, key)
 }
 


### PR DESCRIPTION
## Summary

- Adds nullable `pane_id TEXT` column to `tool_states` (migrateV6) with a sparse index, capturing the stable tmux `%N` ID at write time via `--pane-id` flag and `$TMUX_PANE`
- Adds `demux event pane_closed --pane %N` command called by a new `after-kill-pane` tmux hook for immediate GC when a pane is killed
- Adds `demux gc states` reconciliation command that compares live tmux panes against DB records and deletes orphans, with fallback for legacy records that predate `pane_id`

Partially addresses #17.

## Test Plan

- [x] `go test ./...` — 457 tests pass
- [x] `demux state set --target "..." --pane-id "$TMUX_PANE" --state working --tool test` stores pane_id
- [x] `demux state set --target "ghost:9.9" --state working --tool test && demux gc states` removes the orphan
- [x] `demux state set --target "test:0.0" --pane-id "%999" --state working --tool test && demux event pane_closed --pane "%999"` clears the record
- [x] `tmux source ~/.tmux.conf && tmux show-hooks -g | grep after-kill-pane` confirms hook is registered