### PR TITLE
feat: stable pane identity phases 3 & 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,16 +708,16 @@ tmux source ~/.tmux.conf
 
 ```tmux
 # Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+set-hook -g after-select-pane   "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+set-hook -g after-select-window "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+set-hook -g client-session-changed "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+set-hook -g client-focus-in "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
 ```
 
 </details>
@@ -904,7 +904,7 @@ demux state ls --tool <name>       # filter by tool
 
 demux state set   --target <session:window[.pane]> --state working|waiting|done|error|flagged
                   [--tool <name>] [--message <text>] [--source tool|user]
-                  [--force] [--if-state <value>]
+                  [--force] [--if-state <value>] [--pane-id <%N>]
 
 demux state clear --target <session:window[.pane]> [--yes]
 
@@ -918,7 +918,7 @@ demux status --format text         # plain text summary
 
 # Hooks
 demux event pane_focus             # clear done states for the focused pane (used by tmux hooks)
-demux event pane_focus --target <session:window.pane>
+demux event pane_focus --target <session:window.pane> [--pane-id <%N>]
 
 # Config
 demux config init                  # print default config to stdout

--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state working --tool claude --message \"on it\" --force || demux event hook_error --hook PreToolUse --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" --force || demux event hook_error --hook PreToolUse --tool claude --target \"$T\" --message \"state set failed\"",
           },
         ],
       },
@@ -759,7 +759,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state waiting --tool claude --message \"awaiting permission\" || demux event hook_error --hook Notification.permission_prompt --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state waiting --tool claude --message \"awaiting permission\" || demux event hook_error --hook Notification.permission_prompt --tool claude --target \"$T\" --message \"state set failed\"",
           },
         ],
       },
@@ -768,7 +768,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state waiting --tool claude --message \"mcp input needed\" || demux event hook_error --hook Notification.elicitation_dialog --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state waiting --tool claude --message \"mcp input needed\" || demux event hook_error --hook Notification.elicitation_dialog --tool claude --target \"$T\" --message \"state set failed\"",
           },
         ],
       },
@@ -779,7 +779,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state working --tool claude --message \"on it\" || demux event hook_error --hook SessionStart.resume --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" || demux event hook_error --hook SessionStart.resume --tool claude --target \"$T\" --message \"state set failed\"",
           },
         ],
       },
@@ -789,7 +789,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state working --tool claude --message \"on it\" || demux event hook_error --hook UserPromptSubmit --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" || demux event hook_error --hook UserPromptSubmit --tool claude --target \"$T\" --message \"state set failed\"",
           },
         ],
       },
@@ -799,7 +799,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state working --tool claude --message \"spawning agent\" || demux event hook_error --hook SubagentStart --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"spawning agent\" || demux event hook_error --hook SubagentStart --tool claude --target \"$T\" --message \"state set failed\"",
           },
         ],
       },
@@ -809,7 +809,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state working --tool claude --message \"subagent complete\" || demux event hook_error --hook SubagentStop --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"subagent complete\" || demux event hook_error --hook SubagentStop --tool claude --target \"$T\" --message \"state set failed\"",
           },
         ],
       },
@@ -819,7 +819,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state done --tool claude --message \"task complete\" || demux event hook_error --hook Stop --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state done --tool claude --message \"task complete\" || demux event hook_error --hook Stop --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
           },
         ],
       },
@@ -830,7 +830,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state error --tool claude --message \"rate limited\" || demux event hook_error --hook StopFailure.rate_limit --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state error --tool claude --message \"rate limited\" || demux event hook_error --hook StopFailure.rate_limit --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
           },
         ],
       },
@@ -839,7 +839,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state error --tool claude --message \"auth failed\" || demux event hook_error --hook StopFailure.authentication_failed --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state error --tool claude --message \"auth failed\" || demux event hook_error --hook StopFailure.authentication_failed --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
           },
         ],
       },
@@ -847,7 +847,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --state error --tool claude --message \"task failed\" || demux event hook_error --hook StopFailure --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
+            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state error --tool claude --message \"task failed\" || demux event hook_error --hook StopFailure --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
           },
         ],
       },

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -17,6 +17,7 @@ var (
 )
 
 var eventPaneFocusTarget string
+var eventPaneFocusPaneID string
 
 var eventCmd = &cobra.Command{
 	Use:   "event",
@@ -28,9 +29,10 @@ var eventPaneFocusCmd = &cobra.Command{
 	Short: "Clear done states for the focused pane, its window, and its session",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		target := eventPaneFocusTarget
+		paneID := eventPaneFocusPaneID
 		if target == "" {
 			var err error
-			target, _, err = tmuxPaneTarget()
+			target, paneID, err = tmuxPaneTarget()
 			if err != nil {
 				return err
 			}
@@ -42,12 +44,12 @@ var eventPaneFocusCmd = &cobra.Command{
 		}
 		defer d.Close()
 
-		return applyPaneFocus(d, target)
+		return applyPaneFocus(d, target, paneID)
 	},
 }
 
-func applyPaneFocus(d *db.DB, paneTarget string) error {
-	demuxlog.Debug("pane_focus", "target", paneTarget)
+func applyPaneFocus(d *db.DB, paneTarget string, paneID string) error {
+	demuxlog.Debug("pane_focus", "target", paneTarget, "pane_id", paneID)
 	for _, target := range []string{
 		paneTarget,
 		windowTargetFromPane(paneTarget),
@@ -55,6 +57,13 @@ func applyPaneFocus(d *db.DB, paneTarget string) error {
 	} {
 		if err := d.StateDeleteIfResting(target); err != nil {
 			demuxlog.Error("pane_focus: delete resting state failed", "target", target, "err", err)
+			return err
+		}
+	}
+	// Also clear by pane_id: handles panes that moved since the state was written.
+	if paneID != "" {
+		if err := d.StateDeleteIfRestingByPaneID(paneID); err != nil {
+			demuxlog.Error("pane_focus: delete resting by pane_id failed", "pane_id", paneID, "err", err)
 			return err
 		}
 	}
@@ -131,6 +140,7 @@ func applyPaneClosed(d *db.DB, paneID string) error {
 
 func init() {
 	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusTarget, "target", "", "Pane target: session:window.pane (auto-detected if omitted)")
+	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusPaneID, "pane-id", "", "Stable pane ID (%N format) for clearing moved panes (optional, auto-detected if omitted)")
 
 	eventHookErrorCmd.Flags().StringVar(&hookErrorTarget, "target", "", "Pane target: session:window.pane (optional)")
 	eventHookErrorCmd.Flags().StringVar(&hookErrorHook, "hook", "", "Hook name that failed (e.g. Stop, PreToolUse)")

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -37,7 +37,7 @@ func TestPaneFocusClearsDoneStates(t *testing.T) {
 	d.StateSet("myses:0.1", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
 	d.StateSet("myses:0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
 
-	if err := applyPaneFocus(d, "myses:0.1"); err != nil {
+	if err := applyPaneFocus(d, "myses:0.1", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,7 +56,7 @@ func TestPaneFocusDoesNotClearNonDone(t *testing.T) {
 	defer d.Close()
 
 	d.StateSet("myses:0.1", "claude", db.StateError, "boom", db.SourceTool, false, nil, "")
-	applyPaneFocus(d, "myses:0.1")
+	applyPaneFocus(d, "myses:0.1", "")
 
 	st, _ := d.StateByTarget("myses:0.1")
 	if st == nil {
@@ -69,7 +69,7 @@ func TestPaneFocusDoesNotClearFlagged(t *testing.T) {
 	defer d.Close()
 
 	d.StateSet("myses:0.1", "", db.StateFlagged, "come back", db.SourceUser, false, nil, "")
-	applyPaneFocus(d, "myses:0.1")
+	applyPaneFocus(d, "myses:0.1", "")
 
 	st, _ := d.StateByTarget("myses:0.1")
 	if st == nil {
@@ -81,7 +81,7 @@ func TestPaneFocusNoStatesIsNoop(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	if err := applyPaneFocus(d, "work:2.3"); err != nil {
+	if err := applyPaneFocus(d, "work:2.3", ""); err != nil {
 		t.Fatalf("unexpected error on empty db: %v", err)
 	}
 }
@@ -92,13 +92,48 @@ func TestPaneFocusClearsIdleStates(t *testing.T) {
 
 	d.StateSet("myses:0.1", "claude", db.StateIdle, "available", db.SourceTool, false, nil, "")
 
-	if err := applyPaneFocus(d, "myses:0.1"); err != nil {
+	if err := applyPaneFocus(d, "myses:0.1", ""); err != nil {
 		t.Fatal(err)
 	}
 
 	st, _ := d.StateByTarget("myses:0.1")
 	if st != nil {
 		t.Error("idle pane state should be cleared on focus")
+	}
+}
+
+func TestApplyPaneFocus_ClearsByPaneID(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	// Pane %5 was at s:0.0 (stored target), but is now at s:1.0 (new target).
+	// The done state was written when pane was at s:0.0.
+	d.StateSet("s:0.0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "%5")
+
+	// pane_focus fires with new target s:1.0 and pane_id %5.
+	if err := applyPaneFocus(d, "s:1.0", "%5"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The state should be cleared via pane_id even though the target string didn't match.
+	st, _ := d.StateByTarget("s:0.0")
+	if st != nil {
+		t.Errorf("state should be cleared by pane_id after pane moved, got: %+v", st)
+	}
+}
+
+func TestApplyPaneFocus_EmptyPaneIDFallsBackToTarget(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
+
+	if err := applyPaneFocus(d, "s:0.0", ""); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := d.StateByTarget("s:0.0")
+	if st != nil {
+		t.Errorf("legacy target should still be cleared when pane_id is empty, got: %+v", st)
 	}
 }
 

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -88,16 +88,16 @@ const tmuxHooksSnippet = `# demux tmux hooks
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+set-hook -g after-select-pane   "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+set-hook -g after-select-window "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+set-hook -g client-session-changed "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} 2>/dev/null; true'"
+set-hook -g client-focus-in "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Removes Demux state when a pane is closed (prevents stale state accumulation).
 set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane #{pane_id} 2>/dev/null; true'"

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -46,3 +46,9 @@ func TestTmuxHooksSnippet_ContainsAfterKillPane(t *testing.T) {
 		t.Error("hooks snippet after-kill-pane hook should call demux event pane_closed")
 	}
 }
+
+func TestTmuxHooksSnippet_PaneFocusIncludesPaneID(t *testing.T) {
+	if !strings.Contains(tmuxHooksSnippet, "--pane-id #{pane_id}") {
+		t.Error("pane_focus hooks should pass --pane-id #{pane_id}")
+	}
+}

--- a/cmd/session_config.go
+++ b/cmd/session_config.go
@@ -245,7 +245,17 @@ func clearSessionStates(name string) string {
 	}
 	defer database.Close()
 
-	n, err := database.StateDeleteBySession(name)
+	// Collect pane_ids for this session from live tmux (best-effort).
+	var sessionPaneIDs []string
+	if panes, err := tmux.ListPanes(); err == nil {
+		for _, p := range panes {
+			if p.Session == name && p.PaneID != "" {
+				sessionPaneIDs = append(sessionPaneIDs, p.PaneID)
+			}
+		}
+	}
+
+	n, err := database.StateDeleteBySessionWithPaneIDs(name, sessionPaneIDs)
 	if err != nil {
 		return fmt.Sprintf("error: %v", err)
 	}

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/format"
 	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -161,6 +162,18 @@ func (r stateRow) Fields() []string {
 	return []string{r.target, r.tool, r.value, r.message, r.source, r.updated}
 }
 
+// resolveStateTarget returns the current "session:window.pane" for a state,
+// using the live pane_id map when available. Falls back to the stored target
+// for legacy records (no pane_id) or when tmux is unavailable.
+func resolveStateTarget(st db.ToolState, paneIDMap map[string]string) string {
+	if st.PaneID != "" {
+		if resolved, ok := paneIDMap[st.PaneID]; ok {
+			return resolved
+		}
+	}
+	return st.Target
+}
+
 func runStateList(cmd *cobra.Command, args []string) error {
 	d, err := openDB()
 	if err != nil {
@@ -183,6 +196,13 @@ func runStateList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("state list: %w", err)
 	}
 
+	// Build pane_id → current target map for display resolution.
+	// Best-effort: if tmux is unavailable, fall back to stored targets.
+	paneIDMap := map[string]string{}
+	if panes, pErr := tmux.ListPanes(); pErr == nil {
+		paneIDMap = tmux.PaneIDToTargetMap(panes)
+	}
+
 	rows := make([]format.Row, len(states))
 	for i, st := range states {
 		tool := st.Tool
@@ -190,7 +210,7 @@ func runStateList(cmd *cobra.Command, args []string) error {
 			tool = "-"
 		}
 		rows[i] = stateRow{
-			target:  st.Target,
+			target:  resolveStateTarget(st, paneIDMap),
 			tool:    tool,
 			value:   st.Value.String(),
 			message: st.Message,

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -151,6 +151,7 @@ func applyStateClear(d *db.DB) error {
 
 type stateRow struct {
 	target  string
+	paneID  string
 	tool    string
 	value   string
 	message string
@@ -159,7 +160,7 @@ type stateRow struct {
 }
 
 func (r stateRow) Fields() []string {
-	return []string{r.target, r.tool, r.value, r.message, r.source, r.updated}
+	return []string{r.target, r.paneID, r.tool, r.value, r.message, r.source, r.updated}
 }
 
 // resolveStateTarget returns the current "session:window.pane" for a state,
@@ -211,6 +212,7 @@ func runStateList(cmd *cobra.Command, args []string) error {
 		}
 		rows[i] = stateRow{
 			target:  resolveStateTarget(st, paneIDMap),
+			paneID:  st.PaneID,
 			tool:    tool,
 			value:   st.Value.String(),
 			message: st.Message,
@@ -219,7 +221,7 @@ func runStateList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	headers := []string{"TARGET", "TOOL", "STATE", "MESSAGE", "SOURCE", "UPDATED"}
+	headers := []string{"TARGET", "PANE_ID", "TOOL", "STATE", "MESSAGE", "SOURCE", "UPDATED"}
 	fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTY()))
 	return nil
 }

--- a/cmd/state_test.go
+++ b/cmd/state_test.go
@@ -167,6 +167,36 @@ func TestStateSet_IfState_InvalidValue(t *testing.T) {
 	}
 }
 
+func TestResolveStateTarget_UsesResolvedWhenPaneIDMatches(t *testing.T) {
+	st := db.ToolState{Target: "work:1.0", PaneID: "%12"}
+	paneIDMap := map[string]string{"%12": "work:2.0"} // pane moved
+
+	got := resolveStateTarget(st, paneIDMap)
+	if got != "work:2.0" {
+		t.Errorf("want work:2.0, got %q", got)
+	}
+}
+
+func TestResolveStateTarget_FallsBackToTargetWhenNoPaneID(t *testing.T) {
+	st := db.ToolState{Target: "work:1.0", PaneID: ""}
+	paneIDMap := map[string]string{}
+
+	got := resolveStateTarget(st, paneIDMap)
+	if got != "work:1.0" {
+		t.Errorf("want work:1.0, got %q", got)
+	}
+}
+
+func TestResolveStateTarget_FallsBackWhenPaneIDNotInMap(t *testing.T) {
+	st := db.ToolState{Target: "work:1.0", PaneID: "%12"}
+	paneIDMap := map[string]string{} // tmux unavailable or pane truly gone
+
+	got := resolveStateTarget(st, paneIDMap)
+	if got != "work:1.0" {
+		t.Errorf("want work:1.0, got %q", got)
+	}
+}
+
 func TestStateSet_PaneIDFlag(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -96,6 +96,12 @@ func (d *DB) migrate() error {
 		}
 		version = 6
 	}
+	if version < 7 {
+		if err := d.migrateV7(); err != nil {
+			return err
+		}
+		version = 7
+	}
 	return nil
 }
 
@@ -291,6 +297,27 @@ func (d *DB) migrateV6() error {
 	if _, err := tx.Exec(`PRAGMA user_version = 6`); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("set version 6: %w", err)
+	}
+	return tx.Commit()
+}
+
+func (d *DB) migrateV7() error {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin v7: %w", err)
+	}
+	// Replace the non-unique index from v6 with a unique one.
+	if _, err := tx.Exec(`DROP INDEX IF EXISTS idx_tool_states_pane_id`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("migrate v7 drop index: %w", err)
+	}
+	if _, err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_tool_states_pane_id ON tool_states(pane_id) WHERE pane_id IS NOT NULL`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("migrate v7 unique index: %w", err)
+	}
+	if _, err := tx.Exec(`PRAGMA user_version = 7`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("set version 7: %w", err)
 	}
 	return tx.Commit()
 }

--- a/internal/db/db_migrate_test.go
+++ b/internal/db/db_migrate_test.go
@@ -57,7 +57,25 @@ func TestMigrateV3_UserVersion(t *testing.T) {
 	if err := d.sql.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
 		t.Fatalf("read user_version: %v", err)
 	}
-	if version != 6 {
-		t.Fatalf("expected user_version=6, got %d", version)
+	if version != 7 {
+		t.Fatalf("expected user_version=7, got %d", version)
+	}
+}
+
+func TestMigrateV7_PaneIDIndexIsUnique(t *testing.T) {
+	d, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	// Insert two records with the same non-empty pane_id — must fail.
+	_, err1 := d.sql.Exec(`INSERT INTO tool_states (target, tool, value, message, source, pane_id) VALUES ('s:0.0', 'c', 1, '', 1, '%1')`)
+	_, err2 := d.sql.Exec(`INSERT INTO tool_states (target, tool, value, message, source, pane_id) VALUES ('s:1.0', 'c', 1, '', 1, '%1')`)
+	if err1 != nil {
+		t.Fatalf("first insert should succeed: %v", err1)
+	}
+	if err2 == nil {
+		t.Error("second insert with same pane_id should fail (UNIQUE constraint)")
 	}
 }

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -301,6 +301,33 @@ func (d *DB) StateDeleteBySession(name string) (int64, error) {
 	return res.RowsAffected()
 }
 
+// StateDeleteBySessionWithPaneIDs removes all state records for the given session,
+// both by target prefix (existing behaviour) and by the provided pane IDs (catches
+// records whose target drifted after a pane move).
+// Returns the total number of rows deleted.
+func (d *DB) StateDeleteBySessionWithPaneIDs(name string, paneIDs []string) (int64, error) {
+	// Delete by target prefix first (original behaviour).
+	res, err := d.sql.Exec(
+		`DELETE FROM tool_states WHERE target = ? OR target LIKE ?`,
+		name, name+":%",
+	)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+
+	// Delete any remaining records for panes that belong to this session.
+	for _, pid := range paneIDs {
+		r, err := d.sql.Exec(`DELETE FROM tool_states WHERE pane_id = ?`, pid)
+		if err != nil {
+			return n, err
+		}
+		rows, _ := r.RowsAffected()
+		n += rows
+	}
+	return n, nil
+}
+
 // StateByTarget returns the ToolState for target, or nil if no record exists (idle).
 func (d *DB) StateByTarget(target string) (*ToolState, error) {
 	row := d.sql.QueryRow(`

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -169,6 +169,17 @@ func (d *DB) StateSet(target, tool string, value StateValue, message string, sou
 		}
 	}
 
+	// When a stable pane_id is provided, delete any stale record for this pane
+	// at a different target (handles panes that moved since last write).
+	if paneID != "" {
+		if _, err := tx.Exec(
+			`DELETE FROM tool_states WHERE pane_id = ? AND target != ?`,
+			paneID, target,
+		); err != nil {
+			return fmt.Errorf("delete stale pane record: %w", err)
+		}
+	}
+
 	// Apply lock rules for tool writes (skipped when force=true).
 	if !force && source == SourceTool && current != nil {
 		switch current.Value {

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -230,6 +230,17 @@ func (d *DB) StateClearByPaneID(paneID string) error {
 	return err
 }
 
+// StateDeleteIfRestingByPaneID removes the state record when value is done or idle,
+// looking up by pane_id. Used by pane_focus when pane_id is available — handles
+// panes that have moved positions since the state was written.
+func (d *DB) StateDeleteIfRestingByPaneID(paneID string) error {
+	_, err := d.sql.Exec(
+		`DELETE FROM tool_states WHERE pane_id = ? AND value IN (?, ?)`,
+		paneID, int(StateDone), int(StateIdle),
+	)
+	return err
+}
+
 // looksLikePaneTarget reports whether target is in "session:window.pane" format.
 // Used by StateGCOrphaned to skip session-level and window-level targets.
 func looksLikePaneTarget(target string) bool {

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -151,7 +151,9 @@ func (d *DB) StateSet(target, tool string, value StateValue, message string, sou
 
 	// No-op if value and tool are unchanged (avoids redundant DB writes from
 	// high-frequency hooks like PreToolUse firing working→working repeatedly).
-	if ifState == nil && current != nil && current.Value == value && current.Tool == tool {
+	// When paneID is provided we must fall through to the stale-delete path even
+	// when the value is identical, because the pane may have moved to a new target.
+	if ifState == nil && paneID == "" && current != nil && current.Value == value && current.Tool == tool {
 		demuxlog.Debug("state set skipped: no change", "target", target, "tool", tool, "state", value)
 		return tx.Rollback()
 	}
@@ -290,6 +292,10 @@ func (d *DB) StateGCOrphaned(livePaneIDs map[string]bool, livePaneTargets map[st
 // StateDeleteBySession removes all state records for the given session.
 // It matches targets equal to name (bare) or prefixed with "name:" (session:window).
 // Returns the number of rows deleted.
+//
+// Deprecated: the production path uses StateDeleteBySessionWithPaneIDs, which also
+// catches drifted-target records for panes that moved since the last state write.
+// This function is retained for callers that do not have a live pane list.
 func (d *DB) StateDeleteBySession(name string) (int64, error) {
 	res, err := d.sql.Exec(
 		`DELETE FROM tool_states WHERE target = ? OR target LIKE ?`,
@@ -306,8 +312,14 @@ func (d *DB) StateDeleteBySession(name string) (int64, error) {
 // records whose target drifted after a pane move).
 // Returns the total number of rows deleted.
 func (d *DB) StateDeleteBySessionWithPaneIDs(name string, paneIDs []string) (int64, error) {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("begin StateDeleteBySessionWithPaneIDs: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after Commit
+
 	// Delete by target prefix first (original behaviour).
-	res, err := d.sql.Exec(
+	res, err := tx.Exec(
 		`DELETE FROM tool_states WHERE target = ? OR target LIKE ?`,
 		name, name+":%",
 	)
@@ -318,12 +330,15 @@ func (d *DB) StateDeleteBySessionWithPaneIDs(name string, paneIDs []string) (int
 
 	// Delete any remaining records for panes that belong to this session.
 	for _, pid := range paneIDs {
-		r, err := d.sql.Exec(`DELETE FROM tool_states WHERE pane_id = ?`, pid)
+		r, err := tx.Exec(`DELETE FROM tool_states WHERE pane_id = ?`, pid)
 		if err != nil {
-			return n, err
+			return 0, err
 		}
 		rows, _ := r.RowsAffected()
 		n += rows
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit StateDeleteBySessionWithPaneIDs: %w", err)
 	}
 	return n, nil
 }

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -499,6 +499,49 @@ func TestStateSet_EmptyPaneID(t *testing.T) {
 	}
 }
 
+func TestStateSet_UpdatesTargetWhenPaneMoved(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	// Pane %5 was at work:0.0.
+	d.StateSet("work:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%5")
+
+	// Pane %5 has moved to work:1.0 — new state set with new target.
+	if err := d.StateSet("work:1.0", "claude", StateDone, "done", SourceTool, true, nil, "%5"); err != nil {
+		t.Fatalf("StateSet for moved pane should succeed: %v", err)
+	}
+
+	// Old target must be gone.
+	st0, _ := d.StateByTarget("work:0.0")
+	if st0 != nil {
+		t.Errorf("old target should be deleted when pane moves, got: %+v", st0)
+	}
+
+	// New target must have the state.
+	st1, _ := d.StateByTarget("work:1.0")
+	if st1 == nil || st1.Value != StateDone {
+		t.Errorf("new target should have done state, got: %+v", st1)
+	}
+	if st1.PaneID != "%5" {
+		t.Errorf("new record should carry pane_id %%5, got %q", st1.PaneID)
+	}
+}
+
+func TestStateSet_NoStaleDeleteWhenTargetUnchanged(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("work:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%5")
+	// Same target — should update in place without deleting/re-inserting.
+	if err := d.StateSet("work:0.0", "claude", StateDone, "done", SourceTool, true, nil, "%5"); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := d.StateByTarget("work:0.0")
+	if st == nil || st.Value != StateDone {
+		t.Errorf("same-target update should work, got: %+v", st)
+	}
+}
+
 func TestStateDeleteIfRestingByPaneID_DeletesDone(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -588,3 +588,31 @@ func TestStateDeleteIfRestingByPaneID_NoopWhenNotFound(t *testing.T) {
 		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
 	}
 }
+
+func TestStateDeleteBySessionWithPaneIDs_DeletesByPaneIDs(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	// Record whose target no longer has the session prefix (pane moved).
+	d.StateSet("other:0.0", "claude", StateWorking, "", SourceTool, false, nil, "%7")
+	// Normal record.
+	d.StateSet("myapp:0.0", "claude", StateWorking, "", SourceTool, false, nil, "%8")
+	// Unrelated session.
+	d.StateSet("other:1.0", "make", StateDone, "", SourceTool, false, nil, "%9")
+
+	// %7 and %8 belong to "myapp" per live tmux.
+	n, err := d.StateDeleteBySessionWithPaneIDs("myapp", []string{"%7", "%8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2 deleted, got %d", n)
+	}
+
+	if st, _ := d.StateByTarget("other:0.0"); st != nil {
+		t.Error("stale-target record with matching pane_id should be deleted")
+	}
+	if st, _ := d.StateByTarget("other:1.0"); st == nil {
+		t.Error("unrelated pane should survive")
+	}
+}

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -498,3 +498,50 @@ func TestStateSet_EmptyPaneID(t *testing.T) {
 		t.Errorf("expected empty PaneID, got %q", st.PaneID)
 	}
 }
+
+func TestStateDeleteIfRestingByPaneID_DeletesDone(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", StateDone, "finished", SourceTool, false, nil, "%7")
+	if err := d.StateDeleteIfRestingByPaneID("%7"); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := d.StateByTarget("s:0.0")
+	if st != nil {
+		t.Errorf("done state should be deleted by pane_id, got: %+v", st)
+	}
+}
+
+func TestStateDeleteIfRestingByPaneID_DeletesIdle(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", StateIdle, "available", SourceTool, false, nil, "%7")
+	d.StateDeleteIfRestingByPaneID("%7")
+	st, _ := d.StateByTarget("s:0.0")
+	if st != nil {
+		t.Errorf("idle state should be deleted by pane_id, got: %+v", st)
+	}
+}
+
+func TestStateDeleteIfRestingByPaneID_PreservesWorking(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%7")
+	d.StateDeleteIfRestingByPaneID("%7")
+	st, _ := d.StateByTarget("s:0.0")
+	if st == nil {
+		t.Error("working state should survive StateDeleteIfRestingByPaneID")
+	}
+}
+
+func TestStateDeleteIfRestingByPaneID_NoopWhenNotFound(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	if err := d.StateDeleteIfRestingByPaneID("%99"); err != nil {
+		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
+	}
+}

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -542,6 +542,31 @@ func TestStateSet_NoStaleDeleteWhenTargetUnchanged(t *testing.T) {
 	}
 }
 
+func TestStateSet_NoopDoesNotSkipStalePaneDelete(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	// Pane %5 was at work:0.0.
+	d.StateSet("work:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%5")
+	// work:1.0 already has a legacy record with the same (tool, value) — the
+	// no-op short-circuit would previously exit before reaching the stale-delete.
+	d.StateSet("work:1.0", "claude", StateWorking, "running", SourceTool, false, nil, "")
+
+	// Pane %5 has moved to work:1.0; same (tool, value) as the guard would trigger.
+	if err := d.StateSet("work:1.0", "claude", StateWorking, "still running", SourceTool, false, nil, "%5"); err != nil {
+		t.Fatalf("StateSet should succeed: %v", err)
+	}
+
+	// Stale record must be deleted even though the value did not change.
+	if st, _ := d.StateByTarget("work:0.0"); st != nil {
+		t.Errorf("stale pane record at work:0.0 should be deleted, got: %+v", st)
+	}
+	// New target must have the state.
+	if st, _ := d.StateByTarget("work:1.0"); st == nil || st.PaneID != "%5" {
+		t.Errorf("work:1.0 should carry pane_id %%5, got: %+v", st)
+	}
+}
+
 func TestStateDeleteIfRestingByPaneID_DeletesDone(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
@@ -586,6 +611,30 @@ func TestStateDeleteIfRestingByPaneID_NoopWhenNotFound(t *testing.T) {
 
 	if err := d.StateDeleteIfRestingByPaneID("%99"); err != nil {
 		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
+	}
+}
+
+func TestStateDeleteBySessionWithPaneIDs_EmptyPaneIDs(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	d.StateSet("myapp:0.0", "claude", StateWorking, "", SourceTool, false, nil, "%5")
+	d.StateSet("myapp:1.0", "make", StateDone, "", SourceTool, false, nil, "%6")
+	d.StateSet("other:0.0", "claude", StateDone, "", SourceTool, false, nil, "%7")
+
+	// nil paneIDs — should behave identically to StateDeleteBySession.
+	n, err := d.StateDeleteBySessionWithPaneIDs("myapp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2 deleted, got %d", n)
+	}
+	if st, _ := d.StateByTarget("myapp:0.0"); st != nil {
+		t.Error("myapp:0.0 should be deleted")
+	}
+	if st, _ := d.StateByTarget("other:0.0"); st == nil {
+		t.Error("unrelated session should survive")
 	}
 }
 

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -136,3 +136,15 @@ func CurrentTarget() (string, int, error) {
 func SwitchClient(target string) error {
 	return exec.Command("tmux", "switch-client", "-t", target).Run()
 }
+
+// PaneIDToTargetMap returns a map from pane_id (%N) to "session:windowIndex.paneIndex"
+// for all panes with a non-empty PaneID in the provided slice.
+func PaneIDToTargetMap(panes []Pane) map[string]string {
+	m := make(map[string]string, len(panes))
+	for _, p := range panes {
+		if p.PaneID != "" {
+			m[p.PaneID] = fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)
+		}
+	}
+	return m
+}

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -143,7 +143,7 @@ func PaneIDToTargetMap(panes []Pane) map[string]string {
 	m := make(map[string]string, len(panes))
 	for _, p := range panes {
 		if p.PaneID != "" {
-			m[p.PaneID] = fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)
+			m[p.PaneID] = p.Target()
 		}
 	}
 	return m

--- a/internal/tmux/query_test.go
+++ b/internal/tmux/query_test.go
@@ -156,3 +156,27 @@ func TestParseCurrentTarget_NoTab(t *testing.T) {
 		t.Error("expected error for input with no tab")
 	}
 }
+
+func TestPaneIDToTargetMap(t *testing.T) {
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 0, PaneIndex: 0, PaneID: "%1"},
+		{Session: "work", WindowIndex: 1, PaneIndex: 0, PaneID: "%2"},
+		{Session: "other", WindowIndex: 0, PaneIndex: 0, PaneID: "%3"},
+		{Session: "noid", WindowIndex: 0, PaneIndex: 0, PaneID: ""},
+	}
+
+	m := tmux.PaneIDToTargetMap(panes)
+
+	if m["%1"] != "work:0.0" {
+		t.Errorf("%%1: want work:0.0, got %q", m["%1"])
+	}
+	if m["%2"] != "work:1.0" {
+		t.Errorf("%%2: want work:1.0, got %q", m["%2"])
+	}
+	if m["%3"] != "other:0.0" {
+		t.Errorf("%%3: want other:0.0, got %q", m["%3"])
+	}
+	if _, ok := m[""]; ok {
+		t.Error("pane with empty PaneID should not appear in map")
+	}
+}

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -154,6 +154,11 @@ func (m Model) handleQueryResultMsg(msg queryResultMsg) (Model, tea.Cmd) {
 // resolveStateTargets returns a copy of states with each state's Target replaced
 // by the current "session:window.pane" from the live pane list when a pane_id
 // match is found. Unmatched or legacy states keep their stored Target.
+//
+// The design spec describes a lazy write-back (UPDATE stored target in DB when
+// the resolved value differs). That is deliberately omitted: Phase 4's StateSet
+// stale-delete covers the common case, and a long-lived pane in "working" state
+// will have its stored target corrected on the next state write.
 func resolveStateTargets(states []db.ToolState, panes []tmux.Pane) []db.ToolState {
 	paneIDMap := tmux.PaneIDToTargetMap(panes)
 	out := make([]db.ToolState, len(states))

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -151,8 +151,26 @@ func (m Model) handleQueryResultMsg(msg queryResultMsg) (Model, tea.Cmd) {
 	return m, nil
 }
 
+// resolveStateTargets returns a copy of states with each state's Target replaced
+// by the current "session:window.pane" from the live pane list when a pane_id
+// match is found. Unmatched or legacy states keep their stored Target.
+func resolveStateTargets(states []db.ToolState, panes []tmux.Pane) []db.ToolState {
+	paneIDMap := tmux.PaneIDToTargetMap(panes)
+	out := make([]db.ToolState, len(states))
+	for i, st := range states {
+		if st.PaneID != "" {
+			if resolved, ok := paneIDMap[st.PaneID]; ok {
+				st.Target = resolved
+			}
+		}
+		out[i] = st
+	}
+	return out
+}
+
 func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 	m.panes = msg.panes
+	m.states = resolveStateTargets(m.states, msg.panes) // re-resolve with fresh pane data
 	grouped := tmux.GroupBySessions(msg.panes)
 	merged := session.Merge(msg.panes, m.sessionsConfig.Entries)
 	m.sidebar.SetData(merged, m.states, m.gitInfo, m.cfg)
@@ -216,10 +234,10 @@ func (m Model) handleProcDataMsg(msg procDataMsg) (Model, tea.Cmd) {
 }
 
 func (m Model) handleStatesMsg(msg statesMsg) (Model, tea.Cmd) {
-	m.states = msg.states
-	m.procList.SetStates(msg.states)
+	m.states = resolveStateTargets(msg.states, m.panes)
+	m.procList.SetStates(m.states)
 	merged := session.Merge(m.panes, m.sessionsConfig.Entries)
-	m.sidebar.SetData(merged, msg.states, m.gitInfo, m.cfg)
+	m.sidebar.SetData(merged, m.states, m.gitInfo, m.cfg)
 	// Only apply startup focus once panes have landed (m.ready). If states
 	// arrived before panes, handlePanesMsg will apply focus when panes arrive.
 	if !m.startupFocusDone && m.ready {

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -1,1 +1,26 @@
 package tui
+
+import (
+	"testing"
+
+	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/tmux"
+)
+
+func TestResolveStateTargets_UpdatesMovedPane(t *testing.T) {
+	states := []db.ToolState{
+		{Target: "work:1.0", PaneID: "%3"},
+		{Target: "other:0.0", PaneID: ""},
+	}
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 2, PaneIndex: 0, PaneID: "%3"},
+	}
+
+	resolved := resolveStateTargets(states, panes)
+	if resolved[0].Target != "work:2.0" {
+		t.Errorf("want work:2.0, got %q", resolved[0].Target)
+	}
+	if resolved[1].Target != "other:0.0" {
+		t.Errorf("legacy target should be unchanged, got %q", resolved[1].Target)
+	}
+}

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/rtalexk/demux/internal/tmux"
 )
 
+func TestResolveStateTargets_NilPanes(t *testing.T) {
+	states := []db.ToolState{
+		{Target: "work:0.0", PaneID: "%1"},
+		{Target: "other:1.0", PaneID: ""},
+	}
+
+	// Must not panic; no matches possible so targets are unchanged.
+	resolved := resolveStateTargets(states, nil)
+	if resolved[0].Target != "work:0.0" {
+		t.Errorf("unmatched pane_id target should be unchanged, got %q", resolved[0].Target)
+	}
+	if resolved[1].Target != "other:1.0" {
+		t.Errorf("legacy target should be unchanged, got %q", resolved[1].Target)
+	}
+}
+
 func TestResolveStateTargets_UpdatesMovedPane(t *testing.T) {
 	states := []db.ToolState{
 		{Target: "work:1.0", PaneID: "%3"},


### PR DESCRIPTION
## Summary

- **Phase 3 (read path):** `state ls` and the TUI now resolve each state's display target from live tmux data via `pane_id`, so moved panes always show their current position. `pane_focus` clears stale done/idle states by `pane_id` so panes that moved since their last write still get cleared on focus. Hooks snippet and `~/.tmux.conf` updated to pass `--pane-id #{pane_id}` to `pane_focus`. `state ls` also gains a `PANE_ID` column.
- **Phase 4 (write path):** `pane_id` index promoted to `UNIQUE` (migrateV7). `StateSet` deletes any stale record for a pane at a different target before upserting, preventing duplicate records when panes move. `StateDeleteBySessionWithPaneIDs` added so session clear also catches records with drifted targets.
- **Pre-flight fix:** All Claude Code hook commands in `settings.json` and `README.md` updated to pass `--pane-id "$TMUX_PANE"` to `demux state set`.

Closes https://github.com/rtalexk/demux/issues/17

## Test Plan

- [ ] `go test ./...` — 473 tests pass
- [ ] `tmux show-hooks -g | grep pane_focus` — all 4 hooks contain `--pane-id #{pane_id}`
- [ ] Set state with `--pane-id`, move pane, run `demux state ls` — TARGET shows new position, PANE_ID column populated
- [ ] Set done state, move pane, focus it — state clears even though stored target no longer matches
- [ ] Set state, move pane to new target, set state again — only new target appears in `demux state ls` (no duplicate)
- [ ] `demux session remove --name <session>` — clears records for panes with drifted targets
- [ ] After Claude hook fires — `pane_id` column in DB is non-empty