### PR TITLE
feat(db/tui): replace string targets with typed identity (pane/window/session)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,17 +275,17 @@ States are stored in a local SQLite database and reflected in the sidebar and st
 <summary>Setting and clearing states</summary>
 
 ```bash
-# Mark a pane as working
-demux state set --target myproject:1.0 --state working --tool claude --message "on it"
+# Mark a pane as working (use the stable pane ID: %N)
+demux state set --target-id %5 --state working --tool claude --message "on it"
 
 # Mark as done
-demux state set --target myproject:1.0 --state done --tool claude --message "task complete"
+demux state set --target-id %5 --state done --tool claude --message "task complete"
 
 # Clear a state (return to idle)
-demux state clear --target myproject:1.0
+demux state clear --target-id %5
 
 # Clear a flagged state (requires --yes)
-demux state clear --target myproject:1.0 --yes
+demux state clear --target-id %5 --yes
 
 # List all active states
 demux state ls
@@ -301,7 +301,7 @@ Use `--if-state` to only update if the current state matches:
 
 ```bash
 # Only set to idle if currently done (avoids overwriting active states)
-demux state set --target myproject:1.0 --state idle --if-state done
+demux state set --target-id %5 --state idle --if-state done
 ```
 
 **Write lock**
@@ -309,7 +309,7 @@ demux state set --target myproject:1.0 --state idle --if-state done
 When a tool sets an active state (`working` or `waiting`), that pane is locked. Another tool cannot overwrite it unless `--force` is passed:
 
 ```bash
-demux state set --target myproject:1.0 --state working --tool other --force
+demux state set --target-id %5 --state working --tool other --force
 ```
 
 > [!WARNING]
@@ -320,7 +320,7 @@ demux state set --target myproject:1.0 --state working --tool other --force
 The `flagged` state is a user-facing bookmark. It can only be set with `--source user`:
 
 ```bash
-demux state set --target myproject:1.0 --state flagged --source user --message "review this"
+demux state set --target-id %5 --state flagged --source user --message "review this"
 ```
 
 In the TUI, press `F` on a target to flag it directly. Press `F` again to unflag it.
@@ -708,16 +708,16 @@ tmux source ~/.tmux.conf
 
 ```tmux
 # Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 ```
 
 </details>
@@ -748,7 +748,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" --force || demux event hook_error --hook PreToolUse --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" --force || demux event hook_error --hook PreToolUse --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
           },
         ],
       },
@@ -759,7 +759,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state waiting --tool claude --message \"awaiting permission\" || demux event hook_error --hook Notification.permission_prompt --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state waiting --tool claude --message \"awaiting permission\" || demux event hook_error --hook Notification.permission_prompt --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
           },
         ],
       },
@@ -768,7 +768,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state waiting --tool claude --message \"mcp input needed\" || demux event hook_error --hook Notification.elicitation_dialog --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state waiting --tool claude --message \"mcp input needed\" || demux event hook_error --hook Notification.elicitation_dialog --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
           },
         ],
       },
@@ -779,7 +779,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" || demux event hook_error --hook SessionStart.resume --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" || demux event hook_error --hook SessionStart.resume --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
           },
         ],
       },
@@ -789,7 +789,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" || demux event hook_error --hook UserPromptSubmit --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state working --tool claude --message \"on it\" || demux event hook_error --hook UserPromptSubmit --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
           },
         ],
       },
@@ -799,7 +799,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"spawning agent\" || demux event hook_error --hook SubagentStart --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state working --tool claude --message \"spawning agent\" || demux event hook_error --hook SubagentStart --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
           },
         ],
       },
@@ -809,7 +809,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state working --tool claude --message \"subagent complete\" || demux event hook_error --hook SubagentStop --tool claude --target \"$T\" --message \"state set failed\"",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state working --tool claude --message \"subagent complete\" || demux event hook_error --hook SubagentStop --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
           },
         ],
       },
@@ -819,7 +819,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state done --tool claude --message \"task complete\" || demux event hook_error --hook Stop --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state done --tool claude --message \"task complete\" || demux event hook_error --hook Stop --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\" --set-state-error",
           },
         ],
       },
@@ -830,7 +830,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state error --tool claude --message \"rate limited\" || demux event hook_error --hook StopFailure.rate_limit --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state error --tool claude --message \"rate limited\" || demux event hook_error --hook StopFailure.rate_limit --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\" --set-state-error",
           },
         ],
       },
@@ -839,7 +839,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state error --tool claude --message \"auth failed\" || demux event hook_error --hook StopFailure.authentication_failed --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state error --tool claude --message \"auth failed\" || demux event hook_error --hook StopFailure.authentication_failed --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\" --set-state-error",
           },
         ],
       },
@@ -847,7 +847,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "T=\"$(tmux display-message -t \"$TMUX_PANE\" -p '#S:#I.#P')\" && demux state set --target \"$T\" --pane-id \"$TMUX_PANE\" --state error --tool claude --message \"task failed\" || demux event hook_error --hook StopFailure --tool claude --target \"$T\" --message \"state set failed\" --set-state-error",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state error --tool claude --message \"task failed\" || demux event hook_error --hook StopFailure --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\" --set-state-error",
           },
         ],
       },
@@ -902,11 +902,11 @@ demux state ls                     # list active (non-idle) states
 demux state ls --state <value>     # filter by state
 demux state ls --tool <name>       # filter by tool
 
-demux state set   --target <session:window[.pane]> --state working|waiting|done|error|flagged
+demux state set   --target-id <%N|@N|$N> --state working|waiting|done|error|flagged
                   [--tool <name>] [--message <text>] [--source tool|user]
-                  [--force] [--if-state <value>] [--pane-id <%N>]
+                  [--force] [--if-state <value>]
 
-demux state clear --target <session:window[.pane]> [--yes]
+demux state clear --target-id <%N|@N|$N> [--yes]
 
 # Search
 demux query <term>                       # fuzzy search sessions, windows, processes
@@ -918,7 +918,7 @@ demux status --format text         # plain text summary
 
 # Hooks
 demux event pane_focus             # clear done states for the focused pane (used by tmux hooks)
-demux event pane_focus --target <session:window.pane> [--pane-id <%N>]
+demux event pane_focus [--pane-id <%N>] [--window-id <@N>] [--session-id <$N>]
 
 # Config
 demux config init                  # print default config to stdout
@@ -942,7 +942,7 @@ Or pass `--log-level` for a single invocation without touching the config:
 
 ```bash
 demux --log-level debug
-demux state set --target myproject:1.0 --state working --tool claude --log-level debug
+demux state set --target-id %5 --state working --tool claude --log-level debug
 ```
 
 Then tail the log in a separate pane:
@@ -1010,7 +1010,7 @@ tail -f /tmp/tmux-hooks.log
 If the log file gets entries but states are not clearing, run the `pane_focus` event manually to isolate whether the issue is in the hook firing or in demux itself:
 
 ```bash
-demux event pane_focus --target <session:window.pane> --log-level debug
+demux event pane_focus --pane-id %5 --log-level debug
 ```
 
 **Claude hooks not firing**
@@ -1061,7 +1061,7 @@ Old `color_alert_*` keys in `demux.toml` are silently ignored. Missing `color_st
 demux alert set --target "$TARGET" --reason "Running: $TOOL_NAME" --level warn
 
 # after
-demux state set --target "$TARGET" --state working --tool claude --message "Running: $TOOL_NAME" || true
+demux state set --target-id "$TMUX_PANE" --state working --tool claude --message "Running: $TOOL_NAME" || true
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -702,22 +702,35 @@ Paste the output into `~/.tmux.conf` and reload:
 tmux source ~/.tmux.conf
 ```
 
+> [!CAUTION]
+> Use `--flag=value` syntax (not `--flag value`) in tmux hooks. tmux expands
+> `#{session_id}` to a raw ID like `$8`; the shell then treats `$8` as a
+> positional parameter, which is empty. With `--flag value` the empty expansion
+> leaves the flag without an argument and the command silently fails. With
+> `--flag=value` the empty expansion produces `--flag=` (empty string), which
+> is valid and handled correctly.
+
 <details>
 
 <summary>Tmux hook snippet</summary>
 
 ```tmux
+# Note: flags use --flag=value (not --flag value). tmux expands #{session_id} to a
+# raw ID like $8; the shell then treats $8 as a positional parameter (empty). With
+# --flag value an empty expansion leaves the flag with no argument. With --flag=value
+# an empty expansion produces --flag= (empty string), which is valid.
+
 # Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
+set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
+set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
+set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
+set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
 ```
 
 </details>

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/rtalexk/demux/internal/db"
 	demuxlog "github.com/rtalexk/demux/internal/log"
 	"github.com/spf13/cobra"
@@ -16,8 +14,9 @@ var (
 	hookErrorSetStateError bool
 )
 
-var eventPaneFocusTarget string
-var eventPaneFocusPaneID string
+var eventPaneFocusPaneID    string
+var eventPaneFocusWindowID  string
+var eventPaneFocusSessionID string
 
 var eventCmd = &cobra.Command{
 	Use:   "event",
@@ -28,11 +27,14 @@ var eventPaneFocusCmd = &cobra.Command{
 	Use:   "pane_focus",
 	Short: "Clear done states for the focused pane, its window, and its session",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		target := eventPaneFocusTarget
 		paneID := eventPaneFocusPaneID
-		if target == "" {
+		windowID := eventPaneFocusWindowID
+		sessionID := eventPaneFocusSessionID
+
+		// Auto-detect if not provided
+		if paneID == "" {
 			var err error
-			target, paneID, err = tmuxPaneTarget()
+			paneID, windowID, sessionID, err = tmuxCurrentIDs()
 			if err != nil {
 				return err
 			}
@@ -44,44 +46,41 @@ var eventPaneFocusCmd = &cobra.Command{
 		}
 		defer d.Close()
 
-		return applyPaneFocus(d, target, paneID)
+		return applyPaneFocus(d, paneID, windowID, sessionID)
 	},
 }
 
-func applyPaneFocus(d *db.DB, paneTarget string, paneID string) error {
-	demuxlog.Debug("pane_focus", "target", paneTarget, "pane_id", paneID)
-	for _, target := range []string{
-		paneTarget,
-		windowTargetFromPane(paneTarget),
-		sessionTargetFromPane(paneTarget),
-	} {
-		if err := d.StateDeleteIfResting(target); err != nil {
-			demuxlog.Error("pane_focus: delete resting state failed", "target", target, "err", err)
-			return err
+func applyPaneFocus(d *db.DB, paneID, windowID, sessionID string) error {
+	demuxlog.Debug("pane_focus", "pane_id", paneID, "window_id", windowID, "session_id", sessionID)
+
+	// Clear resting states at all three levels
+	for _, targetType := range []string{"pane", "window", "session"} {
+		var targetID string
+		switch targetType {
+		case "pane":
+			targetID = paneID
+		case "window":
+			targetID = windowID
+		case "session":
+			targetID = sessionID
 		}
-	}
-	// Also clear by pane_id: handles panes that moved since the state was written.
-	if paneID != "" {
-		if err := d.StateDeleteIfRestingByPaneID(paneID); err != nil {
-			demuxlog.Error("pane_focus: delete resting by pane_id failed", "pane_id", paneID, "err", err)
+		if targetID == "" {
+			continue
+		}
+
+		t := db.Target{
+			Type:      targetType,
+			ID:        targetID,
+			PaneID:    paneID,
+			WindowID:  windowID,
+			SessionID: sessionID,
+		}
+		if err := d.StateDeleteIfResting(t); err != nil {
+			demuxlog.Error("pane_focus: delete resting state failed", "target", t, "err", err)
 			return err
 		}
 	}
 	return nil
-}
-
-func windowTargetFromPane(paneTarget string) string {
-	if i := strings.LastIndex(paneTarget, "."); i != -1 {
-		return paneTarget[:i]
-	}
-	return paneTarget
-}
-
-func sessionTargetFromPane(paneTarget string) string {
-	if i := strings.Index(paneTarget, ":"); i != -1 {
-		return paneTarget[:i]
-	}
-	return paneTarget
 }
 
 var eventHookErrorCmd = &cobra.Command{
@@ -90,7 +89,7 @@ var eventHookErrorCmd = &cobra.Command{
 	Long: `Records a hook delivery failure to the log file. Use this as a fallback
 in hook scripts instead of '|| true' so failures are observable:
 
-  demux state set ... || demux event hook_error --hook Stop --target "$T" --message "state set failed" --set-state-error`,
+  demux state set ... || demux event hook_error --hook Stop --target-id "$T" --message "state set failed" --set-state-error`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return applyHookError()
 	},
@@ -110,8 +109,13 @@ func applyHookError() error {
 			return err
 		}
 		defer d.Close()
-		if err := d.StateSet(hookErrorTarget, hookErrorTool, db.StateError, hookErrorMessage, db.SourceTool, true, nil, ""); err != nil {
-			demuxlog.Error("hook_error: set state error failed", "target", hookErrorTarget, "err", err)
+		t, parseErr := db.ParseTargetID(hookErrorTarget)
+		if parseErr != nil {
+			demuxlog.Warn("hook_error: invalid target id, skipping state set", "target", hookErrorTarget)
+			return nil
+		}
+		if err := d.StateSet(t, hookErrorTool, db.StateError, hookErrorMessage, db.SourceTool, true, nil); err != nil {
+			demuxlog.Error("hook_error: set state error failed", "target", t, "err", err)
 			return err
 		}
 	}
@@ -135,18 +139,20 @@ var eventPaneClosedCmd = &cobra.Command{
 
 func applyPaneClosed(d *db.DB, paneID string) error {
 	demuxlog.Debug("pane_closed", "pane_id", paneID)
-	return d.StateClearByPaneID(paneID)
+	t := db.Target{Type: "pane", ID: paneID, PaneID: paneID}
+	return d.StateClear(t)
 }
 
 func init() {
-	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusTarget, "target", "", "Pane target: session:window.pane (auto-detected if omitted)")
-	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusPaneID, "pane-id", "", "Stable pane ID (%N format) for clearing moved panes (optional, auto-detected if omitted)")
+	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusPaneID, "pane-id", "", "Stable pane ID (%N format); auto-detected if omitted")
+	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusWindowID, "window-id", "", "Stable window ID (@N format); auto-detected if omitted")
+	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusSessionID, "session-id", "", "Stable session ID ($N format); auto-detected if omitted")
 
-	eventHookErrorCmd.Flags().StringVar(&hookErrorTarget, "target", "", "Pane target: session:window.pane (optional)")
+	eventHookErrorCmd.Flags().StringVar(&hookErrorTarget, "target-id", "", "Target ID (%N, @N, or $N) (optional)")
 	eventHookErrorCmd.Flags().StringVar(&hookErrorHook, "hook", "", "Hook name that failed (e.g. Stop, PreToolUse)")
 	eventHookErrorCmd.Flags().StringVar(&hookErrorTool, "tool", "", "Tool name (e.g. claude)")
 	eventHookErrorCmd.Flags().StringVar(&hookErrorMessage, "message", "", "Failure description")
-	eventHookErrorCmd.Flags().BoolVar(&hookErrorSetStateError, "set-state-error", false, "Set the target state to error (requires --target)")
+	eventHookErrorCmd.Flags().BoolVar(&hookErrorSetStateError, "set-state-error", false, "Set the target state to error (requires --target-id)")
 	eventHookErrorCmd.MarkFlagRequired("hook")
 
 	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedPaneID, "pane", "", "Stable pane ID (%N format) of the closed pane (required)")

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -17,6 +17,7 @@ var (
 var eventPaneFocusPaneID string
 var eventPaneFocusWindowID string
 var eventPaneFocusSessionID string
+var eventPaneFocusTarget string // pre-v8: resolved to stable IDs via tmux
 
 var eventCmd = &cobra.Command{
 	Use:   "event",
@@ -31,13 +32,18 @@ var eventPaneFocusCmd = &cobra.Command{
 		windowID := eventPaneFocusWindowID
 		sessionID := eventPaneFocusSessionID
 
-		// Auto-detect if not provided
-		if paneID == "" {
-			var err error
-			paneID, windowID, sessionID, err = tmuxCurrentIDs()
-			if err != nil {
-				return err
-			}
+		var idErr error
+		switch {
+		case paneID != "":
+			// New hook: stable IDs provided directly.
+		case eventPaneFocusTarget != "":
+			// Pre-v8 hook: resolve "session:window.pane" to stable IDs.
+			paneID, windowID, sessionID, idErr = tmuxResolveTarget(eventPaneFocusTarget)
+		default:
+			paneID, windowID, sessionID, idErr = tmuxCurrentIDs()
+		}
+		if idErr != nil {
+			return idErr
 		}
 
 		d, err := openDB()
@@ -154,6 +160,9 @@ func init() {
 	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusPaneID, "pane-id", "", "Stable pane ID (%N format); auto-detected if omitted")
 	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusWindowID, "window-id", "", "Stable window ID (@N format); auto-detected if omitted")
 	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusSessionID, "session-id", "", "Stable session ID ($N format); auto-detected if omitted")
+	// --target accepted for backward compatibility with pre-v8 hook snippets; value is ignored.
+	eventPaneFocusCmd.Flags().StringVar(&eventPaneFocusTarget, "target", "", "")
+	_ = eventPaneFocusCmd.Flags().MarkHidden("target")
 
 	eventHookErrorCmd.Flags().StringVar(&hookErrorTarget, "target-id", "", "Target ID (%N, @N, or $N) (optional)")
 	eventHookErrorCmd.Flags().StringVar(&hookErrorHook, "hook", "", "Hook name that failed (e.g. Stop, PreToolUse)")

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -53,24 +53,21 @@ var eventPaneFocusCmd = &cobra.Command{
 func applyPaneFocus(d *db.DB, paneID, windowID, sessionID string) error {
 	demuxlog.Debug("pane_focus", "pane_id", paneID, "window_id", windowID, "session_id", sessionID)
 
-	// Clear resting states at all three levels
-	for _, targetType := range []db.TargetType{db.TargetTypePane, db.TargetTypeWindow, db.TargetTypeSession} {
-		var targetID string
-		switch targetType {
-		case db.TargetTypePane:
-			targetID = paneID
-		case db.TargetTypeWindow:
-			targetID = windowID
-		case db.TargetTypeSession:
-			targetID = sessionID
-		}
-		if targetID == "" {
+	// Clear resting states at all three levels.
+	for _, item := range []struct {
+		typ db.TargetType
+		id  string
+	}{
+		{db.TargetTypePane, paneID},
+		{db.TargetTypeWindow, windowID},
+		{db.TargetTypeSession, sessionID},
+	} {
+		if item.id == "" {
 			continue
 		}
-
 		t := db.Target{
-			Type:      targetType,
-			ID:        targetID,
+			Type:      item.typ,
+			ID:        item.id,
 			PaneID:    paneID,
 			WindowID:  windowID,
 			SessionID: sessionID,
@@ -124,17 +121,7 @@ func applyHookErrorDB(d *db.DB, targetID, tool, hook, message string) error {
 		return nil
 	}
 	// Resolve denormalized parent IDs (best-effort; no-op when tmux is unavailable).
-	switch t.Type {
-	case db.TargetTypePane:
-		if windowID, sessionID, tmuxErr := tmuxParentIDs(t.ID); tmuxErr == nil {
-			t.WindowID = windowID
-			t.SessionID = sessionID
-		}
-	case db.TargetTypeWindow:
-		if _, sessionID, tmuxErr := tmuxParentIDs(t.ID); tmuxErr == nil {
-			t.SessionID = sessionID
-		}
-	}
+	t = resolveParentIDs(t)
 	if err := d.StateSet(t, tool, db.StateError, message, db.SourceTool, true, nil); err != nil {
 		demuxlog.Error("hook_error: set state error failed", "target", t, "err", err)
 		return err

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -14,8 +14,8 @@ var (
 	hookErrorSetStateError bool
 )
 
-var eventPaneFocusPaneID    string
-var eventPaneFocusWindowID  string
+var eventPaneFocusPaneID string
+var eventPaneFocusWindowID string
 var eventPaneFocusSessionID string
 
 var eventCmd = &cobra.Command{
@@ -54,14 +54,14 @@ func applyPaneFocus(d *db.DB, paneID, windowID, sessionID string) error {
 	demuxlog.Debug("pane_focus", "pane_id", paneID, "window_id", windowID, "session_id", sessionID)
 
 	// Clear resting states at all three levels
-	for _, targetType := range []string{"pane", "window", "session"} {
+	for _, targetType := range []db.TargetType{db.TargetTypePane, db.TargetTypeWindow, db.TargetTypeSession} {
 		var targetID string
 		switch targetType {
-		case "pane":
+		case db.TargetTypePane:
 			targetID = paneID
-		case "window":
+		case db.TargetTypeWindow:
 			targetID = windowID
-		case "session":
+		case db.TargetTypeSession:
 			targetID = sessionID
 		}
 		if targetID == "" {
@@ -109,15 +109,35 @@ func applyHookError() error {
 			return err
 		}
 		defer d.Close()
-		t, parseErr := db.ParseTargetID(hookErrorTarget)
-		if parseErr != nil {
-			demuxlog.Warn("hook_error: invalid target id, skipping state set", "target", hookErrorTarget)
-			return nil
+		return applyHookErrorDB(d, hookErrorTarget, hookErrorTool, hookErrorHook, hookErrorMessage)
+	}
+	return nil
+}
+
+// applyHookErrorDB writes a StateError record for targetID. It resolves
+// parent IDs from tmux (best-effort) so the row is associated with its
+// session in the TUI even when no prior state record exists.
+func applyHookErrorDB(d *db.DB, targetID, tool, hook, message string) error {
+	t, parseErr := db.ParseTargetID(targetID)
+	if parseErr != nil {
+		demuxlog.Warn("hook_error: invalid target id, skipping state set", "target", targetID, "hook", hook)
+		return nil
+	}
+	// Resolve denormalized parent IDs (best-effort; no-op when tmux is unavailable).
+	switch t.Type {
+	case db.TargetTypePane:
+		if windowID, sessionID, tmuxErr := tmuxParentIDs(t.ID); tmuxErr == nil {
+			t.WindowID = windowID
+			t.SessionID = sessionID
 		}
-		if err := d.StateSet(t, hookErrorTool, db.StateError, hookErrorMessage, db.SourceTool, true, nil); err != nil {
-			demuxlog.Error("hook_error: set state error failed", "target", t, "err", err)
-			return err
+	case db.TargetTypeWindow:
+		if _, sessionID, tmuxErr := tmuxParentIDs(t.ID); tmuxErr == nil {
+			t.SessionID = sessionID
 		}
+	}
+	if err := d.StateSet(t, tool, db.StateError, message, db.SourceTool, true, nil); err != nil {
+		demuxlog.Error("hook_error: set state error failed", "target", t, "err", err)
+		return err
 	}
 	return nil
 }
@@ -139,7 +159,7 @@ var eventPaneClosedCmd = &cobra.Command{
 
 func applyPaneClosed(d *db.DB, paneID string) error {
 	demuxlog.Debug("pane_closed", "pane_id", paneID)
-	t := db.Target{Type: "pane", ID: paneID, PaneID: paneID}
+	t := db.Target{Type: db.TargetTypePane, ID: paneID, PaneID: paneID}
 	return d.StateClear(t)
 }
 

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func paneTarget(paneID, windowID, sessionID string) db.Target {
-	return db.Target{Type: "pane", ID: paneID, PaneID: paneID, WindowID: windowID, SessionID: sessionID}
+	return db.Target{Type: db.TargetTypePane, ID: paneID, PaneID: paneID, WindowID: windowID, SessionID: sessionID}
 }
 
 func windowTarget(windowID, sessionID string) db.Target {
-	return db.Target{Type: "window", ID: windowID, WindowID: windowID, SessionID: sessionID}
+	return db.Target{Type: db.TargetTypeWindow, ID: windowID, WindowID: windowID, SessionID: sessionID}
 }
 
 func TestPaneFocusClearsDoneStates(t *testing.T) {
@@ -112,7 +112,7 @@ func TestApplyPaneClosed_DeletesPaneState(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	pt := db.Target{Type: "pane", ID: "%7", PaneID: "%7", WindowID: "@0", SessionID: "$0"}
+	pt := db.Target{Type: db.TargetTypePane, ID: "%7", PaneID: "%7", WindowID: "@0", SessionID: "$0"}
 	d.StateSet(pt, "claude", db.StateWorking, "", db.SourceTool, false, nil)
 	if err := applyPaneClosed(d, "%7"); err != nil {
 		t.Fatal(err)

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -131,3 +131,33 @@ func TestApplyPaneClosed_NoopUnknownPane(t *testing.T) {
 		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
 	}
 }
+
+func TestApplyHookError_SetsErrorState(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	if err := applyHookErrorDB(d, "%5", "claude", "Stop", "state set failed"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	target, _ := db.ParseTargetID("%5")
+	st, _ := d.StateByID(target)
+	if st == nil {
+		t.Fatal("expected error state to be written, got nil")
+	}
+	if st.Value != db.StateError {
+		t.Errorf("expected StateError, got %v", st.Value)
+	}
+}
+
+func TestApplyHookError_InvalidTargetIDIsNoop(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	if err := applyHookErrorDB(d, "invalid", "claude", "Stop", "failed"); err != nil {
+		t.Fatalf("unexpected error for invalid target: %v", err)
+	}
+	states, _ := d.StateList(0, "")
+	if len(states) != 0 {
+		t.Errorf("expected no states for invalid target, got %d", len(states))
+	}
+}

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -108,6 +108,25 @@ func TestApplyPaneFocus_ClearsByStableID(t *testing.T) {
 	}
 }
 
+func TestApplyPaneFocus_PaneOnlyIDClearsPaneState(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	// Old hook style: only pane-id is known (window-id/session-id empty).
+	// Pane-level state must still be cleared even without parent IDs.
+	pt := paneTarget("%5", "@1", "$0")
+	d.StateSet(pt, "claude", db.StateDone, "finished", db.SourceTool, false, nil)
+
+	if err := applyPaneFocus(d, "%5", "", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := d.StateByID(pt)
+	if st != nil {
+		t.Errorf("pane state should be cleared even when window/session IDs absent, got: %+v", st)
+	}
+}
+
 func TestApplyPaneClosed_DeletesPaneState(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -6,47 +6,31 @@ import (
 	"github.com/rtalexk/demux/internal/db"
 )
 
-func TestWindowTargetFromPane_WithDot(t *testing.T) {
-	got := windowTargetFromPane("main:1.2")
-	want := "main:1"
-	if got != want {
-		t.Errorf("windowTargetFromPane(%q) = %q, want %q", "main:1.2", got, want)
-	}
+func paneTarget(paneID, windowID, sessionID string) db.Target {
+	return db.Target{Type: "pane", ID: paneID, PaneID: paneID, WindowID: windowID, SessionID: sessionID}
 }
 
-func TestWindowTargetFromPane_NoColon(t *testing.T) {
-	got := windowTargetFromPane("main")
-	want := "main"
-	if got != want {
-		t.Errorf("windowTargetFromPane(%q) = %q, want %q", "main", got, want)
-	}
-}
-
-func TestSessionTargetFromPane(t *testing.T) {
-	got := sessionTargetFromPane("myses:0.1")
-	want := "myses"
-	if got != want {
-		t.Errorf("sessionTargetFromPane(%q) = %q, want %q", "myses:0.1", got, want)
-	}
+func windowTarget(windowID, sessionID string) db.Target {
+	return db.Target{Type: "window", ID: windowID, WindowID: windowID, SessionID: sessionID}
 }
 
 func TestPaneFocusClearsDoneStates(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("myses:0.1", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
-	d.StateSet("myses:0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
+	pt := paneTarget("%1", "@0", "$0")
+	wt := windowTarget("@0", "$0")
+	d.StateSet(pt, "claude", db.StateDone, "finished", db.SourceTool, false, nil)
+	d.StateSet(wt, "claude", db.StateDone, "finished", db.SourceTool, false, nil)
 
-	if err := applyPaneFocus(d, "myses:0.1", ""); err != nil {
+	if err := applyPaneFocus(d, "%1", "@0", "$0"); err != nil {
 		t.Fatal(err)
 	}
 
-	st1, _ := d.StateByTarget("myses:0.1")
-	if st1 != nil {
+	if st, _ := d.StateByID(pt); st != nil {
 		t.Error("done pane state should be cleared on focus")
 	}
-	st2, _ := d.StateByTarget("myses:0")
-	if st2 != nil {
+	if st, _ := d.StateByID(wt); st != nil {
 		t.Error("done window state should be cleared on focus")
 	}
 }
@@ -55,10 +39,11 @@ func TestPaneFocusDoesNotClearNonDone(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("myses:0.1", "claude", db.StateError, "boom", db.SourceTool, false, nil, "")
-	applyPaneFocus(d, "myses:0.1", "")
+	pt := paneTarget("%1", "@0", "$0")
+	d.StateSet(pt, "claude", db.StateError, "boom", db.SourceTool, false, nil)
+	applyPaneFocus(d, "%1", "@0", "$0")
 
-	st, _ := d.StateByTarget("myses:0.1")
+	st, _ := d.StateByID(pt)
 	if st == nil {
 		t.Error("error state should survive pane focus")
 	}
@@ -68,10 +53,11 @@ func TestPaneFocusDoesNotClearFlagged(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("myses:0.1", "", db.StateFlagged, "come back", db.SourceUser, false, nil, "")
-	applyPaneFocus(d, "myses:0.1", "")
+	pt := paneTarget("%1", "@0", "$0")
+	d.StateSet(pt, "", db.StateFlagged, "come back", db.SourceUser, false, nil)
+	applyPaneFocus(d, "%1", "@0", "$0")
 
-	st, _ := d.StateByTarget("myses:0.1")
+	st, _ := d.StateByID(pt)
 	if st == nil {
 		t.Error("flagged state should survive pane focus")
 	}
@@ -81,7 +67,7 @@ func TestPaneFocusNoStatesIsNoop(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	if err := applyPaneFocus(d, "work:2.3", ""); err != nil {
+	if err := applyPaneFocus(d, "%1", "@0", "$0"); err != nil {
 		t.Fatalf("unexpected error on empty db: %v", err)
 	}
 }
@@ -90,62 +76,48 @@ func TestPaneFocusClearsIdleStates(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("myses:0.1", "claude", db.StateIdle, "available", db.SourceTool, false, nil, "")
+	pt := paneTarget("%1", "@0", "$0")
+	d.StateSet(pt, "claude", db.StateIdle, "available", db.SourceTool, false, nil)
 
-	if err := applyPaneFocus(d, "myses:0.1", ""); err != nil {
+	if err := applyPaneFocus(d, "%1", "@0", "$0"); err != nil {
 		t.Fatal(err)
 	}
 
-	st, _ := d.StateByTarget("myses:0.1")
+	st, _ := d.StateByID(pt)
 	if st != nil {
 		t.Error("idle pane state should be cleared on focus")
 	}
 }
 
-func TestApplyPaneFocus_ClearsByPaneID(t *testing.T) {
+func TestApplyPaneFocus_ClearsByStableID(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	// Pane %5 was at s:0.0 (stored target), but is now at s:1.0 (new target).
-	// The done state was written when pane was at s:0.0.
-	d.StateSet("s:0.0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "%5")
+	// State keyed by pane_id %5 — stable regardless of pane position.
+	pt := paneTarget("%5", "@1", "$0")
+	d.StateSet(pt, "claude", db.StateDone, "finished", db.SourceTool, false, nil)
 
-	// pane_focus fires with new target s:1.0 and pane_id %5.
-	if err := applyPaneFocus(d, "s:1.0", "%5"); err != nil {
+	// pane_focus fires with the same pane_id; state should be cleared.
+	if err := applyPaneFocus(d, "%5", "@1", "$0"); err != nil {
 		t.Fatal(err)
 	}
 
-	// The state should be cleared via pane_id even though the target string didn't match.
-	st, _ := d.StateByTarget("s:0.0")
+	st, _ := d.StateByID(pt)
 	if st != nil {
-		t.Errorf("state should be cleared by pane_id after pane moved, got: %+v", st)
+		t.Errorf("state should be cleared by pane ID, got: %+v", st)
 	}
 }
 
-func TestApplyPaneFocus_EmptyPaneIDFallsBackToTarget(t *testing.T) {
+func TestApplyPaneClosed_DeletesPaneState(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
-
-	if err := applyPaneFocus(d, "s:0.0", ""); err != nil {
-		t.Fatal(err)
-	}
-	st, _ := d.StateByTarget("s:0.0")
-	if st != nil {
-		t.Errorf("legacy target should still be cleared when pane_id is empty, got: %+v", st)
-	}
-}
-
-func TestApplyPaneClosed_DeletesByPaneID(t *testing.T) {
-	d, _ := db.Open(":memory:")
-	defer d.Close()
-
-	d.StateSet("s:0.0", "claude", db.StateWorking, "", db.SourceTool, false, nil, "%7")
+	pt := db.Target{Type: "pane", ID: "%7", PaneID: "%7", WindowID: "@0", SessionID: "$0"}
+	d.StateSet(pt, "claude", db.StateWorking, "", db.SourceTool, false, nil)
 	if err := applyPaneClosed(d, "%7"); err != nil {
 		t.Fatal(err)
 	}
-	st, _ := d.StateByTarget("s:0.0")
+	st, _ := d.StateByID(pt)
 	if st != nil {
 		t.Errorf("state should be deleted after pane_closed, got: %+v", st)
 	}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -25,13 +25,18 @@ func runGCStates(_ *cobra.Command, _ []string) error {
 	}
 
 	livePaneIDs := make(map[string]bool, len(panes))
-	livePaneTargets := make(map[string]bool, len(panes))
+	liveWindowIDs := make(map[string]bool)
+	liveSessionIDs := make(map[string]bool)
 	for _, p := range panes {
 		if p.PaneID != "" {
 			livePaneIDs[p.PaneID] = true
 		}
-		target := p.Target()
-		livePaneTargets[target] = true
+		if p.WindowID != "" {
+			liveWindowIDs[p.WindowID] = true
+		}
+		if p.SessionID != "" {
+			liveSessionIDs[p.SessionID] = true
+		}
 	}
 
 	d, err := openDB()
@@ -40,7 +45,7 @@ func runGCStates(_ *cobra.Command, _ []string) error {
 	}
 	defer d.Close()
 
-	n, err := d.StateGCOrphaned(livePaneIDs, livePaneTargets)
+	n, err := d.StateGCOrphaned(livePaneIDs, liveWindowIDs, liveSessionIDs)
 	if err != nil {
 		return fmt.Errorf("gc states: %w", err)
 	}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -39,6 +39,11 @@ func runGCStates(_ *cobra.Command, _ []string) error {
 		}
 	}
 
+	if len(livePaneIDs) == 0 && len(liveWindowIDs) == 0 && len(liveSessionIDs) == 0 {
+		fmt.Println("No live tmux targets found; skipping GC to avoid data loss.")
+		return nil
+	}
+
 	d, err := openDB()
 	if err != nil {
 		return err

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -18,7 +18,7 @@ func TestBuildLivePaneMaps(t *testing.T) {
 		if p.PaneID != "" {
 			liveIDs[p.PaneID] = true
 		}
-		liveTargets[p.Target()] = true
+		liveTargets[p.DisplayLabel()] = true
 	}
 
 	if !liveIDs["%1"] || !liveIDs["%2"] {

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -99,6 +99,21 @@ func tmuxParentIDs(targetID string) (windowID, sessionID string, err error) {
 	return parts[0], parts[1], nil
 }
 
+// tmuxResolveTarget resolves any tmux target string (including human-readable
+// "session:window.pane" format) to stable pane, window, and session IDs.
+// Used to handle pre-v8 hook snippets that passed --target instead of --pane-id.
+func tmuxResolveTarget(target string) (paneID, windowID, sessionID string, err error) {
+	out, execErr := exec.Command("tmux", "display-message", "-t", target, "-p", "#{pane_id}\t#{window_id}\t#{session_id}").Output()
+	if execErr != nil {
+		return "", "", "", fmt.Errorf("resolve tmux target %q: %w", target, execErr)
+	}
+	parts := strings.Split(strings.TrimSpace(string(out)), "\t")
+	if len(parts) < 3 {
+		return "", "", "", fmt.Errorf("unexpected tmux output for %q", target)
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
 const tmuxHooksSnippet = `# demux tmux hooks
 # ──────────────────────────────────────────────────────────────────────────────
 # Paste the lines below into ~/.tmux.conf, then reload with:

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -62,17 +62,23 @@ func tmuxCurrentIDs() (paneID, windowID, sessionID string, err error) {
 	if paneID == "" {
 		return "", "", "", fmt.Errorf("TMUX_PANE not set")
 	}
+	windowID, sessionID, err = tmuxParentIDs(paneID)
+	return paneID, windowID, sessionID, err
+}
 
-	out, execErr := exec.Command("tmux", "display-message", "-t", paneID, "-p", "#{window_id}\t#{session_id}").Output()
+// tmuxParentIDs queries tmux for the window_id and session_id of the given
+// stable target ID (%N pane or @N window). It uses the provided ID directly
+// so callers that know their target ID do not need to go through $TMUX_PANE.
+func tmuxParentIDs(targetID string) (windowID, sessionID string, err error) {
+	out, execErr := exec.Command("tmux", "display-message", "-t", targetID, "-p", "#{window_id}\t#{session_id}").Output()
 	if execErr != nil {
-		return paneID, "", "", fmt.Errorf("get tmux pane IDs: %w", execErr)
+		return "", "", fmt.Errorf("get tmux parent IDs for %s: %w", targetID, execErr)
 	}
-
 	parts := strings.Split(strings.TrimSpace(string(out)), "\t")
 	if len(parts) < 2 {
-		return paneID, "", "", fmt.Errorf("unexpected format from tmux")
+		return "", "", fmt.Errorf("unexpected tmux output for %s", targetID)
 	}
-	return paneID, parts[0], parts[1], nil
+	return parts[0], parts[1], nil
 }
 
 const tmuxHooksSnippet = `# demux tmux hooks

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -55,20 +55,24 @@ func resolveAgent(name string) (agentDef, error) {
 	return agentDef{}, fmt.Errorf("unknown tool %q: supported tools: %s", name, strings.Join(supported, ", "))
 }
 
-// tmuxPaneTarget returns the current tmux target as "session:windowIndex.paneIndex"
-// and the stable pane ID (%N) from $TMUX_PANE.
-func tmuxPaneTarget() (target string, paneID string, err error) {
-	paneID = os.Getenv("TMUX_PANE") // already %N — set by tmux at process start
-	args := []string{"display-message", "-p", "#S:#I.#P"}
-	if paneID != "" {
-		args = []string{"display-message", "-t", paneID, "-p", "#S:#I.#P"}
+// tmuxCurrentIDs returns the stable pane, window, and session IDs for the
+// tmux pane that launched this process.
+func tmuxCurrentIDs() (paneID, windowID, sessionID string, err error) {
+	paneID = os.Getenv("TMUX_PANE") // $TMUX_PANE is set by tmux as %N
+	if paneID == "" {
+		return "", "", "", fmt.Errorf("TMUX_PANE not set")
 	}
-	out, execErr := exec.Command("tmux", args...).Output()
+
+	out, execErr := exec.Command("tmux", "display-message", "-t", paneID, "-p", "#{window_id}\t#{session_id}").Output()
 	if execErr != nil {
-		return "", paneID, fmt.Errorf("get tmux pane target: %w", execErr)
+		return paneID, "", "", fmt.Errorf("get tmux pane IDs: %w", execErr)
 	}
-	target = strings.TrimSpace(string(out))
-	return target, paneID, nil
+
+	parts := strings.Split(strings.TrimSpace(string(out)), "\t")
+	if len(parts) < 2 {
+		return paneID, "", "", fmt.Errorf("unexpected format from tmux")
+	}
+	return paneID, parts[0], parts[1], nil
 }
 
 const tmuxHooksSnippet = `# demux tmux hooks
@@ -82,22 +86,20 @@ const tmuxHooksSnippet = `# demux tmux hooks
 #   client-session-changed — fires when you switch to a different session.
 #   All three are needed: each navigation action fires a different hook.
 #   Together they cover every way a pane can receive focus.
-#   Each hook targets the now-active pane and clears any done states on it and its
-#   parent window.
 #   after-kill-pane     — fires when a pane is closed; removes its state record.
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --target #{session_name}:#{window_index}.#{pane_index} --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id #{pane_id} 2>/dev/null; true'"
 
 # Removes Demux state when a pane is closed (prevents stale state accumulation).
 set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane #{pane_id} 2>/dev/null; true'"

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -90,16 +90,16 @@ const tmuxHooksSnippet = `# demux tmux hooks
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id #{pane_id} 2>/dev/null; true'"
+set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 
 # Removes Demux state when a pane is closed (prevents stale state accumulation).
 set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane #{pane_id} 2>/dev/null; true'"

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/rtalexk/demux/internal/db"
 	"github.com/spf13/cobra"
 )
 
@@ -66,6 +67,23 @@ func tmuxCurrentIDs() (paneID, windowID, sessionID string, err error) {
 	return paneID, windowID, sessionID, err
 }
 
+// resolveParentIDs fills in parent window/session IDs on t by querying tmux.
+// Best-effort: returns t unchanged when tmux is unavailable or target is a session.
+func resolveParentIDs(t db.Target) db.Target {
+	switch t.Type {
+	case db.TargetTypePane:
+		if windowID, sessionID, err := tmuxParentIDs(t.ID); err == nil {
+			t.WindowID = windowID
+			t.SessionID = sessionID
+		}
+	case db.TargetTypeWindow:
+		if _, sessionID, err := tmuxParentIDs(t.ID); err == nil {
+			t.SessionID = sessionID
+		}
+	}
+	return t
+}
+
 // tmuxParentIDs queries tmux for the window_id and session_id of the given
 // stable target ID (%N pane or @N window). It uses the provided ID directly
 // so callers that know their target ID do not need to go through $TMUX_PANE.
@@ -108,7 +126,9 @@ set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id 
 set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
 
 # Removes Demux state when a pane is closed (prevents stale state accumulation).
-set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane #{pane_id} 2>/dev/null; true'"
+# #{hook_pane} is the killed pane's ID; #{pane_id} is the new active pane after
+# the kill — using #{pane_id} here would clear the wrong pane's state.
+set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane #{hook_pane} 2>/dev/null; true'"
 # ──────────────────────────────────────────────────────────────────────────────
 `
 

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -126,24 +126,30 @@ const tmuxHooksSnippet = `# demux tmux hooks
 #   All three are needed: each navigation action fires a different hook.
 #   Together they cover every way a pane can receive focus.
 #   after-kill-pane     — fires when a pane is closed; removes its state record.
+#
+# Flag syntax note: flags use --flag=value (not --flag value). tmux expands
+# #{session_id} to the raw tmux ID (e.g. $8). The shell then expands $8 as a
+# positional parameter, which is empty. With --flag value, an empty expansion
+# leaves the flag with no argument and the command fails. With --flag=value, an
+# empty expansion produces --flag= (empty string), which is valid.
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
+set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
+set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
+set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
 
 # Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id #{pane_id} --window-id #{window_id} --session-id #{session_id} 2>/dev/null; true'"
+set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
 
 # Removes Demux state when a pane is closed (prevents stale state accumulation).
 # #{hook_pane} is the killed pane's ID; #{pane_id} is the new active pane after
 # the kill — using #{pane_id} here would clear the wrong pane's state.
-set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane #{hook_pane} 2>/dev/null; true'"
+set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true'"
 # ──────────────────────────────────────────────────────────────────────────────
 `
 

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -48,7 +48,32 @@ func TestTmuxHooksSnippet_ContainsAfterKillPane(t *testing.T) {
 }
 
 func TestTmuxHooksSnippet_PaneFocusIncludesPaneID(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "--pane-id #{pane_id}") {
-		t.Error("pane_focus hooks should pass --pane-id #{pane_id}")
+	if !strings.Contains(tmuxHooksSnippet, "--pane-id=#{pane_id}") {
+		t.Error("pane_focus hooks should pass --pane-id=#{pane_id}")
+	}
+}
+
+func TestTmuxParentIDs_ParsesTabSeparatedOutput(t *testing.T) {
+	// parseTmuxTabOutput is the same logic used by tmuxParentIDs:
+	// split on tab, expect [windowID, sessionID].
+	raw := "@3\t$1\n"
+	parts := strings.Split(strings.TrimSpace(raw), "\t")
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d from %q", len(parts), raw)
+	}
+	if parts[0] != "@3" {
+		t.Errorf("windowID: want @3, got %q", parts[0])
+	}
+	if parts[1] != "$1" {
+		t.Errorf("sessionID: want $1, got %q", parts[1])
+	}
+}
+
+func TestTmuxParentIDs_RejectsInsufficientParts(t *testing.T) {
+	// If tmux returns only one field, tmuxParentIDs returns an error.
+	raw := "@3\n"
+	parts := strings.Split(strings.TrimSpace(raw), "\t")
+	if len(parts) >= 2 {
+		t.Errorf("expected fewer than 2 parts for malformed output, got %d", len(parts))
 	}
 }

--- a/cmd/session_config.go
+++ b/cmd/session_config.go
@@ -189,7 +189,10 @@ func runSessionRemoveFull(_ *cobra.Command, _ []string) error {
 
 	// Fetch session ID before killing the session.
 	var sessionID string
-	if panes, err := tmux.ListPanes(); err == nil {
+	var dbOut string
+	if panes, err := tmux.ListPanes(); err != nil {
+		dbOut = fmt.Sprintf("tmux unavailable (%v); run 'demux gc' to clean orphaned records", err)
+	} else {
 		for _, p := range panes {
 			if p.Session == name {
 				sessionID = p.SessionID
@@ -200,7 +203,9 @@ func runSessionRemoveFull(_ *cobra.Command, _ []string) error {
 
 	tmuxOut := killTmuxSession(name)
 	configOut := removeSessionConfig(name, sessionRemoveFullPrivate)
-	dbOut := clearSessionStatesWithID(name, sessionID)
+	if dbOut == "" {
+		dbOut = clearSessionStatesWithID(name, sessionID)
+	}
 	todosOut := clearSessionTodos(name)
 
 	fmt.Printf("tmux:   %s\n", tmuxOut)

--- a/cmd/session_config.go
+++ b/cmd/session_config.go
@@ -187,9 +187,20 @@ func init() {
 func runSessionRemoveFull(_ *cobra.Command, _ []string) error {
 	name := sessionRemoveFullName
 
+	// Fetch session ID before killing the session.
+	var sessionID string
+	if panes, err := tmux.ListPanes(); err == nil {
+		for _, p := range panes {
+			if p.Session == name {
+				sessionID = p.SessionID
+				break
+			}
+		}
+	}
+
 	tmuxOut := killTmuxSession(name)
 	configOut := removeSessionConfig(name, sessionRemoveFullPrivate)
-	dbOut := clearSessionStates(name)
+	dbOut := clearSessionStatesWithID(name, sessionID)
 	todosOut := clearSessionTodos(name)
 
 	fmt.Printf("tmux:   %s\n", tmuxOut)
@@ -238,24 +249,19 @@ func removeSessionConfig(name string, private bool) string {
 	return "not found in sessions.toml or private.toml (skipped)"
 }
 
-func clearSessionStates(name string) string {
+func clearSessionStatesWithID(name, sessionID string) string {
 	database, err := openDB()
 	if err != nil {
 		return fmt.Sprintf("error opening db: %v", err)
 	}
 	defer database.Close()
 
-	// Collect pane_ids for this session from live tmux (best-effort).
-	var sessionPaneIDs []string
-	if panes, err := tmux.ListPanes(); err == nil {
-		for _, p := range panes {
-			if p.Session == name && p.PaneID != "" {
-				sessionPaneIDs = append(sessionPaneIDs, p.PaneID)
-			}
-		}
+	if sessionID == "" {
+		// Session not found in tmux; skip
+		return "session not found in tmux (skipped)"
 	}
 
-	n, err := database.StateDeleteBySessionWithPaneIDs(name, sessionPaneIDs)
+	n, err := database.StateDeleteBySession(sessionID)
 	if err != nil {
 		return fmt.Sprintf("error: %v", err)
 	}

--- a/cmd/sessions.go
+++ b/cmd/sessions.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/mattn/go-isatty"
 	"github.com/rtalexk/demux/internal/config"
@@ -143,16 +142,16 @@ func buildSessionRows(grouped map[string]map[int][]tmux.Pane, sessionProcCount m
 	return rows
 }
 
-func buildStatesBySession(states []db.ToolState) map[string]db.ToolState {
+func buildStatesBySession(states []db.ToolState, sessionIDToName map[string]string) map[string]db.ToolState {
 	out := map[string]db.ToolState{}
 	for _, st := range states {
-		parts := strings.SplitN(st.Target, ":", 2)
-		if len(parts) > 0 {
-			sessName := parts[0]
-			// Keep highest-priority state per session
-			if existing, ok := out[sessName]; !ok || st.Value.Priority() > existing.Value.Priority() {
-				out[sessName] = st
-			}
+		sessName := sessionIDToName[st.Target.SessionID]
+		if sessName == "" {
+			continue
+		}
+		// Keep highest-priority state per session
+		if existing, ok := out[sessName]; !ok || st.Value.Priority() > existing.Value.Priority() {
+			out[sessName] = st
 		}
 	}
 	return out
@@ -177,7 +176,8 @@ func runSessions(cmd *cobra.Command, _ []string) error {
 		demuxlog.Warn("failed to list states", "err", err)
 	}
 
-	statesBySession := buildStatesBySession(states)
+	sessionIDToName := tmux.SessionIDToNameMap(panes)
+	statesBySession := buildStatesBySession(states, sessionIDToName)
 
 	headers := []string{"SESSION", "WINDOWS", "PROCS", "STATE", "STATUS"}
 	if sessionListGitOnly {

--- a/cmd/sessions_test.go
+++ b/cmd/sessions_test.go
@@ -57,9 +57,9 @@ func TestClearSessionStatesWithID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	myapp1 := db.Target{Type: "pane", ID: "%1", SessionID: "$1", WindowID: "@1", PaneID: "%1"}
-	myapp2 := db.Target{Type: "pane", ID: "%2", SessionID: "$1", WindowID: "@1", PaneID: "%2"}
-	other := db.Target{Type: "pane", ID: "%3", SessionID: "$2", WindowID: "@2", PaneID: "%3"}
+	myapp1 := db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1", WindowID: "@1", PaneID: "%1"}
+	myapp2 := db.Target{Type: db.TargetTypePane, ID: "%2", SessionID: "$1", WindowID: "@1", PaneID: "%2"}
+	other := db.Target{Type: db.TargetTypePane, ID: "%3", SessionID: "$2", WindowID: "@2", PaneID: "%3"}
 	d.StateSet(myapp1, "claude", db.StateWorking, "", db.SourceTool, false, nil)
 	d.StateSet(myapp2, "make", db.StateError, "fail", db.SourceTool, false, nil)
 	d.StateSet(other, "claude", db.StateDone, "ok", db.SourceTool, false, nil)

--- a/cmd/sessions_test.go
+++ b/cmd/sessions_test.go
@@ -41,8 +41,8 @@ func TestBuildSessionProcCounts(t *testing.T) {
 	}
 }
 
-func TestClearSessionStates(t *testing.T) {
-	// Use a temp file so we can open a second handle after clearSessionStates
+func TestClearSessionStatesWithID(t *testing.T) {
+	// Use a temp file so we can open a second handle after clearSessionStatesWithID
 	// closes the first one.
 	f, err := os.CreateTemp("", "demux-test-*.db")
 	if err != nil {
@@ -57,18 +57,21 @@ func TestClearSessionStates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.StateSet("myapp:0", "claude", db.StateWorking, "", db.SourceTool, false, nil, "")
-	d.StateSet("myapp:1", "make", db.StateError, "fail", db.SourceTool, false, nil, "")
-	d.StateSet("other:0", "claude", db.StateDone, "ok", db.SourceTool, false, nil, "")
+	myapp1 := db.Target{Type: "pane", ID: "%1", SessionID: "$1", WindowID: "@1", PaneID: "%1"}
+	myapp2 := db.Target{Type: "pane", ID: "%2", SessionID: "$1", WindowID: "@1", PaneID: "%2"}
+	other := db.Target{Type: "pane", ID: "%3", SessionID: "$2", WindowID: "@2", PaneID: "%3"}
+	d.StateSet(myapp1, "claude", db.StateWorking, "", db.SourceTool, false, nil)
+	d.StateSet(myapp2, "make", db.StateError, "fail", db.SourceTool, false, nil)
+	d.StateSet(other, "claude", db.StateDone, "ok", db.SourceTool, false, nil)
 	d.Close()
 
-	// Each clearSessionStates call opens and closes its own handle.
+	// Each clearSessionStatesWithID call opens and closes its own handle.
 	openHandles := func() (*db.DB, error) { return db.Open(dbPath) }
 	orig := openDB
 	openDB = openHandles
 	defer func() { openDB = orig }()
 
-	got := clearSessionStates("myapp")
+	got := clearSessionStatesWithID("myapp", "$1")
 	if got != "2 state(s) cleared" {
 		t.Errorf("got %q, want %q", got, "2 state(s) cleared")
 	}
@@ -79,13 +82,13 @@ func TestClearSessionStates(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer d2.Close()
-	st, _ := d2.StateByTarget("other:0")
+	st, _ := d2.StateByID(other)
 	if st == nil {
-		t.Error("other:0 should not be deleted")
+		t.Error("other session state should not be deleted")
 	}
 }
 
-func TestClearSessionStates_NoneExist(t *testing.T) {
+func TestClearSessionStatesWithID_NoneExist(t *testing.T) {
 	d, err := db.Open(":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -95,8 +98,24 @@ func TestClearSessionStates_NoneExist(t *testing.T) {
 	openDB = func() (*db.DB, error) { return d, nil }
 	defer func() { openDB = orig }()
 
-	got := clearSessionStates("ghost")
+	got := clearSessionStatesWithID("ghost", "$99")
 	if got != "0 state(s) cleared" {
 		t.Errorf("got %q, want %q", got, "0 state(s) cleared")
+	}
+}
+
+func TestClearSessionStatesWithID_EmptySessionIDSkips(t *testing.T) {
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig := openDB
+	openDB = func() (*db.DB, error) { return d, nil }
+	defer func() { openDB = orig }()
+
+	got := clearSessionStatesWithID("ghost", "")
+	if got != "session not found in tmux (skipped)" {
+		t.Errorf("got %q, want \"session not found in tmux (skipped)\"", got)
 	}
 }

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -179,17 +179,17 @@ func applyStateClear(d *db.DB) error {
 }
 
 type stateRow struct {
-	target  string
-	paneID  string
-	tool    string
-	value   string
-	message string
-	source  string
-	updated string
+	target   string
+	targetID string
+	tool     string
+	value    string
+	message  string
+	source   string
+	updated  string
 }
 
 func (r stateRow) Fields() []string {
-	return []string{r.target, r.paneID, r.tool, r.value, r.message, r.source, r.updated}
+	return []string{r.target, r.targetID, r.tool, r.value, r.message, r.source, r.updated}
 }
 
 // formatTarget resolves the display string for a Target from the live tmux maps.
@@ -251,17 +251,17 @@ func runStateList(cmd *cobra.Command, args []string) error {
 			tool = "-"
 		}
 		rows[i] = stateRow{
-			target:  formatTarget(st.Target, paneIDMap, windowIDMap, sessionIDMap),
-			paneID:  st.Target.PaneID,
-			tool:    tool,
-			value:   st.Value.String(),
-			message: st.Message,
-			source:  st.Source.String(),
-			updated: format.Age(st.UpdatedAt),
+			target:   formatTarget(st.Target, paneIDMap, windowIDMap, sessionIDMap),
+			targetID: st.Target.ID,
+			tool:     tool,
+			value:    st.Value.String(),
+			message:  st.Message,
+			source:   st.Source.String(),
+			updated:  format.Age(st.UpdatedAt),
 		}
 	}
 
-	headers := []string{"TARGET", "PANE_ID", "TOOL", "STATE", "MESSAGE", "SOURCE", "UPDATED"}
+	headers := []string{"TARGET", "TARGET_ID", "TOOL", "STATE", "MESSAGE", "SOURCE", "UPDATED"}
 	fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTY()))
 	return nil
 }

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -179,17 +179,18 @@ func applyStateClear(d *db.DB) error {
 }
 
 type stateRow struct {
-	target   string
-	targetID string
-	tool     string
-	value    string
-	message  string
-	source   string
-	updated  string
+	target     string
+	targetID   string
+	targetType string
+	tool       string
+	value      string
+	message    string
+	source     string
+	updated    string
 }
 
 func (r stateRow) Fields() []string {
-	return []string{r.target, r.targetID, r.tool, r.value, r.message, r.source, r.updated}
+	return []string{r.target, r.targetID, r.targetType, r.tool, r.value, r.message, r.source, r.updated}
 }
 
 // formatTarget resolves the display string for a Target from the live tmux maps.
@@ -251,17 +252,18 @@ func runStateList(cmd *cobra.Command, args []string) error {
 			tool = "-"
 		}
 		rows[i] = stateRow{
-			target:   formatTarget(st.Target, paneIDMap, windowIDMap, sessionIDMap),
-			targetID: st.Target.ID,
-			tool:     tool,
-			value:    st.Value.String(),
-			message:  st.Message,
-			source:   st.Source.String(),
-			updated:  format.Age(st.UpdatedAt),
+			target:     formatTarget(st.Target, paneIDMap, windowIDMap, sessionIDMap),
+			targetID:   st.Target.ID,
+			targetType: st.Target.Type,
+			tool:       tool,
+			value:      st.Value.String(),
+			message:    st.Message,
+			source:     st.Source.String(),
+			updated:    format.Age(st.UpdatedAt),
 		}
 	}
 
-	headers := []string{"TARGET", "TARGET_ID", "TOOL", "STATE", "MESSAGE", "SOURCE", "UPDATED"}
+	headers := []string{"TARGET", "TARGET_ID", "TYPE", "TOOL", "STATE", "MESSAGE", "SOURCE", "UPDATED"}
 	fmt.Println(format.Render(resolveFormat(cmd), headers, rows, isTTY()))
 	return nil
 }

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -101,19 +101,19 @@ func applyStateSet(d *db.DB) error {
 	// directly, so cross-pane calls (--target-id %7 from pane %5) store the
 	// correct parent IDs rather than the caller's own context.
 	switch target.Type {
-	case "pane":
+	case db.TargetTypePane:
 		target.PaneID = target.ID
 		if windowID, sessionID, tmuxErr := tmuxParentIDs(target.ID); tmuxErr == nil {
 			target.WindowID = windowID
 			target.SessionID = sessionID
 		}
 		// Best-effort: if tmux fails, continue with partial Target
-	case "window":
+	case db.TargetTypeWindow:
 		target.WindowID = target.ID
 		if _, sessionID, tmuxErr := tmuxParentIDs(target.ID); tmuxErr == nil {
 			target.SessionID = sessionID
 		}
-	case "session":
+	case db.TargetTypeSession:
 		target.SessionID = target.ID
 	}
 
@@ -197,15 +197,15 @@ func (r stateRow) Fields() []string {
 // Falls back to the raw stable ID if not found in maps.
 func formatTarget(t db.Target, paneIDMap, windowIDMap, sessionIDMap map[string]string) string {
 	switch t.Type {
-	case "pane":
+	case db.TargetTypePane:
 		if resolved, ok := paneIDMap[t.ID]; ok {
 			return resolved
 		}
-	case "window":
+	case db.TargetTypeWindow:
 		if resolved, ok := windowIDMap[t.ID]; ok {
 			return resolved
 		}
-	case "session":
+	case db.TargetTypeSession:
 		if resolved, ok := sessionIDMap[t.ID]; ok {
 			return resolved
 		}
@@ -254,7 +254,7 @@ func runStateList(cmd *cobra.Command, args []string) error {
 		rows[i] = stateRow{
 			target:     formatTarget(st.Target, paneIDMap, windowIDMap, sessionIDMap),
 			targetID:   st.Target.ID,
-			targetType: st.Target.Type,
+			targetType: string(st.Target.Type),
 			tool:       tool,
 			value:      st.Value.String(),
 			message:    st.Message,

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -97,22 +97,23 @@ func applyStateSet(d *db.DB) error {
 		return fmt.Errorf("invalid --target-id: %w", err)
 	}
 
-	// For window and pane targets, resolve the missing session/window IDs from tmux.
-	if target.Type == "pane" || target.Type == "window" {
-		paneID, windowID, sessionID, tmuxErr := tmuxCurrentIDs()
-		if tmuxErr == nil {
-			if target.Type == "pane" {
-				target.PaneID = paneID
-				target.WindowID = windowID
-				target.SessionID = sessionID
-			} else {
-				target.WindowID = target.ID // already @N
-				target.SessionID = sessionID
-			}
+	// Resolve denormalized session/window IDs from tmux using the target ID
+	// directly, so cross-pane calls (--target-id %7 from pane %5) store the
+	// correct parent IDs rather than the caller's own context.
+	switch target.Type {
+	case "pane":
+		target.PaneID = target.ID
+		if windowID, sessionID, tmuxErr := tmuxParentIDs(target.ID); tmuxErr == nil {
+			target.WindowID = windowID
+			target.SessionID = sessionID
 		}
 		// Best-effort: if tmux fails, continue with partial Target
-	} else {
-		// Session target: session_id is the ID itself
+	case "window":
+		target.WindowID = target.ID
+		if _, sessionID, tmuxErr := tmuxParentIDs(target.ID); tmuxErr == nil {
+			target.SessionID = sessionID
+		}
+	case "session":
 		target.SessionID = target.ID
 	}
 

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -97,25 +97,8 @@ func applyStateSet(d *db.DB) error {
 		return fmt.Errorf("invalid --target-id: %w", err)
 	}
 
-	// Resolve denormalized session/window IDs from tmux using the target ID
-	// directly, so cross-pane calls (--target-id %7 from pane %5) store the
-	// correct parent IDs rather than the caller's own context.
-	switch target.Type {
-	case db.TargetTypePane:
-		target.PaneID = target.ID
-		if windowID, sessionID, tmuxErr := tmuxParentIDs(target.ID); tmuxErr == nil {
-			target.WindowID = windowID
-			target.SessionID = sessionID
-		}
-		// Best-effort: if tmux fails, continue with partial Target
-	case db.TargetTypeWindow:
-		target.WindowID = target.ID
-		if _, sessionID, tmuxErr := tmuxParentIDs(target.ID); tmuxErr == nil {
-			target.SessionID = sessionID
-		}
-	case db.TargetTypeSession:
-		target.SessionID = target.ID
-	}
+	// Resolve denormalized parent IDs from tmux (best-effort; no-op on session targets).
+	target = resolveParentIDs(target)
 
 	src := db.SourceTool
 	if stateSource == "user" {

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -20,7 +20,6 @@ var (
 	stateSource  string
 	stateForce   bool
 	stateIfState string
-	statePaneID  string
 
 	clearTarget string
 	clearYes    bool
@@ -50,15 +49,14 @@ func init() {
 			return applyStateSet(d)
 		},
 	}
-	stateSetCmd.Flags().StringVar(&stateTarget, "target", "", "Target: session:window.pane (required)")
+	stateSetCmd.Flags().StringVar(&stateTarget, "target-id", "", "Target ID: pane (%%N), window (@N), or session ($N) (required)")
 	stateSetCmd.Flags().StringVar(&stateValue, "state", "", "State: working|waiting|done|error|flagged (required)")
 	stateSetCmd.Flags().StringVar(&stateTool, "tool", "", "Tool name")
 	stateSetCmd.Flags().StringVar(&stateMessage, "message", "", "Human-readable detail")
 	stateSetCmd.Flags().StringVar(&stateSource, "source", "tool", "Source: tool|user")
 	stateSetCmd.Flags().BoolVar(&stateForce, "force", false, "Override write-lock (allow overwriting another tool's active state)")
 	stateSetCmd.Flags().StringVar(&stateIfState, "if-state", "", "Only write if current state matches this value")
-	stateSetCmd.Flags().StringVar(&statePaneID, "pane-id", "", "Stable tmux pane ID (%N format, e.g. %12); stored alongside target for GC")
-	stateSetCmd.MarkFlagRequired("target")
+	stateSetCmd.MarkFlagRequired("target-id")
 	stateSetCmd.MarkFlagRequired("state")
 
 	// state clear
@@ -74,9 +72,9 @@ func init() {
 			return applyStateClear(d)
 		},
 	}
-	stateClearCmd.Flags().StringVar(&clearTarget, "target", "", "Target to clear (required)")
+	stateClearCmd.Flags().StringVar(&clearTarget, "target-id", "", "Target ID (required)")
 	stateClearCmd.Flags().BoolVar(&clearYes, "yes", false, "Confirm clearing a flagged target")
-	stateClearCmd.MarkFlagRequired("target")
+	stateClearCmd.MarkFlagRequired("target-id")
 
 	// state ls
 	stateListCmd = &cobra.Command{
@@ -93,6 +91,31 @@ func init() {
 }
 
 func applyStateSet(d *db.DB) error {
+	// Parse the target ID and infer type.
+	target, err := db.ParseTargetID(stateTarget)
+	if err != nil {
+		return fmt.Errorf("invalid --target-id: %w", err)
+	}
+
+	// For window and pane targets, resolve the missing session/window IDs from tmux.
+	if target.Type == "pane" || target.Type == "window" {
+		paneID, windowID, sessionID, tmuxErr := tmuxCurrentIDs()
+		if tmuxErr == nil {
+			if target.Type == "pane" {
+				target.PaneID = paneID
+				target.WindowID = windowID
+				target.SessionID = sessionID
+			} else {
+				target.WindowID = target.ID // already @N
+				target.SessionID = sessionID
+			}
+		}
+		// Best-effort: if tmux fails, continue with partial Target
+	} else {
+		// Session target: session_id is the ID itself
+		target.SessionID = target.ID
+	}
+
 	src := db.SourceTool
 	if stateSource == "user" {
 		src = db.SourceUser
@@ -118,34 +141,39 @@ func applyStateSet(d *db.DB) error {
 		ifState = &sv
 	}
 
-	if err := d.StateSet(stateTarget, stateTool, val, stateMessage, src, stateForce, ifState, statePaneID); err != nil {
+	if err := d.StateSet(target, stateTool, val, stateMessage, src, stateForce, ifState); err != nil {
 		if errors.Is(err, db.ErrStateLocked) {
-			demuxlog.Warn("state set rejected: lock", "target", stateTarget, "tool", stateTool, "state", stateValue, "err", err)
+			demuxlog.Warn("state set rejected: lock", "target", target, "tool", stateTool, "state", stateValue, "err", err)
 			fmt.Fprintln(os.Stderr, "error:", err)
 			os.Exit(1)
 		}
-		demuxlog.Error("state set failed", "target", stateTarget, "tool", stateTool, "state", stateValue, "err", err)
+		demuxlog.Error("state set failed", "target", target, "tool", stateTool, "state", stateValue, "err", err)
 		return fmt.Errorf("state set: %w", err)
 	}
-	demuxlog.Debug("state set", "target", stateTarget, "tool", stateTool, "state", stateValue)
+	demuxlog.Debug("state set", "target", target, "tool", stateTool, "state", stateValue)
 	return nil
 }
 
 func applyStateClear(d *db.DB) error {
-	st, err := d.StateByTarget(clearTarget)
+	target, err := db.ParseTargetID(clearTarget)
 	if err != nil {
-		demuxlog.Error("state clear lookup failed", "target", clearTarget, "err", err)
+		return fmt.Errorf("invalid --target-id: %w", err)
+	}
+
+	st, err := d.StateByID(target)
+	if err != nil {
+		demuxlog.Error("state clear lookup failed", "target", target, "err", err)
 		return fmt.Errorf("state lookup: %w", err)
 	}
 	if st != nil && st.Value == db.StateFlagged && !clearYes {
-		demuxlog.Warn("state clear rejected: flagged", "target", clearTarget)
+		demuxlog.Warn("state clear rejected: flagged", "target", target)
 		return fmt.Errorf("target is flagged; use --yes to clear it")
 	}
-	if err := d.StateClear(clearTarget); err != nil {
-		demuxlog.Error("state clear failed", "target", clearTarget, "err", err)
+	if err := d.StateClear(target); err != nil {
+		demuxlog.Error("state clear failed", "target", target, "err", err)
 		return err
 	}
-	demuxlog.Debug("state cleared", "target", clearTarget)
+	demuxlog.Debug("state cleared", "target", target)
 	return nil
 }
 
@@ -163,16 +191,24 @@ func (r stateRow) Fields() []string {
 	return []string{r.target, r.paneID, r.tool, r.value, r.message, r.source, r.updated}
 }
 
-// resolveStateTarget returns the current "session:window.pane" for a state,
-// using the live pane_id map when available. Falls back to the stored target
-// for legacy records (no pane_id) or when tmux is unavailable.
-func resolveStateTarget(st db.ToolState, paneIDMap map[string]string) string {
-	if st.PaneID != "" {
-		if resolved, ok := paneIDMap[st.PaneID]; ok {
+// formatTarget resolves the display string for a Target from the live tmux maps.
+// Falls back to the raw stable ID if not found in maps.
+func formatTarget(t db.Target, paneIDMap, windowIDMap, sessionIDMap map[string]string) string {
+	switch t.Type {
+	case "pane":
+		if resolved, ok := paneIDMap[t.ID]; ok {
+			return resolved
+		}
+	case "window":
+		if resolved, ok := windowIDMap[t.ID]; ok {
+			return resolved
+		}
+	case "session":
+		if resolved, ok := sessionIDMap[t.ID]; ok {
 			return resolved
 		}
 	}
-	return st.Target
+	return t.ID
 }
 
 func runStateList(cmd *cobra.Command, args []string) error {
@@ -197,11 +233,14 @@ func runStateList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("state list: %w", err)
 	}
 
-	// Build pane_id → current target map for display resolution.
-	// Best-effort: if tmux is unavailable, fall back to stored targets.
+	// Build display maps from live tmux (best-effort).
 	paneIDMap := map[string]string{}
+	windowIDMap := map[string]string{}
+	sessionIDMap := map[string]string{}
 	if panes, pErr := tmux.ListPanes(); pErr == nil {
 		paneIDMap = tmux.PaneIDToTargetMap(panes)
+		windowIDMap = tmux.WindowIDToTargetMap(panes)
+		sessionIDMap = tmux.SessionIDToNameMap(panes)
 	}
 
 	rows := make([]format.Row, len(states))
@@ -211,8 +250,8 @@ func runStateList(cmd *cobra.Command, args []string) error {
 			tool = "-"
 		}
 		rows[i] = stateRow{
-			target:  resolveStateTarget(st, paneIDMap),
-			paneID:  st.PaneID,
+			target:  formatTarget(st.Target, paneIDMap, windowIDMap, sessionIDMap),
+			paneID:  st.Target.PaneID,
 			tool:    tool,
 			value:   st.Value.String(),
 			message: st.Message,

--- a/cmd/state_test.go
+++ b/cmd/state_test.go
@@ -7,11 +7,14 @@ import (
 	"github.com/rtalexk/demux/internal/db"
 )
 
+// stateTarget format is now "%N", "@N", or "$N" (stable tmux IDs).
+// Tests use "%1" as a representative pane target.
+
 func TestStateSet_ToolWrite(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	stateTarget = "s:0.0"
+	stateTarget = "%1"
 	stateValue = "working"
 	stateTool = "claude"
 	stateMessage = "running"
@@ -21,7 +24,8 @@ func TestStateSet_ToolWrite(t *testing.T) {
 	if err := applyStateSet(d); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	st, _ := d.StateByTarget("s:0.0")
+	target, _ := db.ParseTargetID("%1")
+	st, _ := d.StateByID(target)
 	if st == nil || st.Value != db.StateWorking {
 		t.Errorf("expected working state, got: %+v", st)
 	}
@@ -31,7 +35,7 @@ func TestStateSet_FlaggedRequiresUserSource(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	stateTarget = "s:0.0"
+	stateTarget = "%1"
 	stateValue = "flagged"
 	stateTool = "claude"
 	stateSource = "tool"
@@ -46,9 +50,10 @@ func TestStateClear_FlaggedRequiresYes(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "", db.StateFlagged, "note", db.SourceUser, false, nil, "")
+	target := db.Target{Type: "pane", ID: "%1", PaneID: "%1"}
+	d.StateSet(target, "", db.StateFlagged, "note", db.SourceUser, false, nil)
 
-	clearTarget = "s:0.0"
+	clearTarget = "%1"
 	clearYes = false
 
 	if err := applyStateClear(d); err == nil {
@@ -59,7 +64,7 @@ func TestStateClear_FlaggedRequiresYes(t *testing.T) {
 	if err := applyStateClear(d); err != nil {
 		t.Fatalf("with --yes should succeed: %v", err)
 	}
-	st, _ := d.StateByTarget("s:0.0")
+	st, _ := d.StateByID(target)
 	if st != nil {
 		t.Error("state should be cleared")
 	}
@@ -69,9 +74,10 @@ func TestStateClear_NonFlagged_NoYesRequired(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "claude", db.StateError, "boom", db.SourceTool, false, nil, "")
+	target := db.Target{Type: "pane", ID: "%1", PaneID: "%1"}
+	d.StateSet(target, "claude", db.StateError, "boom", db.SourceTool, false, nil)
 
-	clearTarget = "s:0.0"
+	clearTarget = "%1"
 	clearYes = false
 
 	if err := applyStateClear(d); err != nil {
@@ -83,7 +89,7 @@ func TestStateSet_IdleIsValid(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	stateTarget = "s:0.0"
+	stateTarget = "%1"
 	stateValue = "idle"
 	stateTool = "claude"
 	stateMessage = "available"
@@ -94,7 +100,8 @@ func TestStateSet_IdleIsValid(t *testing.T) {
 	if err := applyStateSet(d); err != nil {
 		t.Fatalf("--state idle should be valid: %v", err)
 	}
-	st, _ := d.StateByTarget("s:0.0")
+	target, _ := db.ParseTargetID("%1")
+	st, _ := d.StateByID(target)
 	if st == nil || st.Value != db.StateIdle {
 		t.Errorf("expected idle state, got: %+v", st)
 	}
@@ -105,9 +112,10 @@ func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
 	defer d.Close()
 
 	// Pre-set state to done.
-	d.StateSet("s:0.0", "claude", db.StateDone, "finished", db.SourceTool, false, nil, "")
+	target := db.Target{Type: "pane", ID: "%1", PaneID: "%1"}
+	d.StateSet(target, "claude", db.StateDone, "finished", db.SourceTool, false, nil)
 
-	stateTarget = "s:0.0"
+	stateTarget = "%1"
 	stateValue = "waiting"
 	stateTool = "claude"
 	stateMessage = "awaiting input"
@@ -118,7 +126,7 @@ func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
 	if err := applyStateSet(d); err != nil {
 		t.Fatalf("--if-state mismatch should succeed silently: %v", err)
 	}
-	st, _ := d.StateByTarget("s:0.0")
+	st, _ := d.StateByID(target)
 	if st == nil || st.Value != db.StateDone {
 		t.Errorf("state should remain done, got: %+v", st)
 	}
@@ -128,9 +136,10 @@ func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "claude", db.StateWorking, "running", db.SourceTool, false, nil, "")
+	target := db.Target{Type: "pane", ID: "%1", PaneID: "%1"}
+	d.StateSet(target, "claude", db.StateWorking, "running", db.SourceTool, false, nil)
 
-	stateTarget = "s:0.0"
+	stateTarget = "%1"
 	stateValue = "done"
 	stateTool = "claude"
 	stateMessage = "task complete"
@@ -141,7 +150,7 @@ func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
 	if err := applyStateSet(d); err != nil {
 		t.Fatalf("--if-state match should write: %v", err)
 	}
-	st, _ := d.StateByTarget("s:0.0")
+	st, _ := d.StateByID(target)
 	if st == nil || st.Value != db.StateDone {
 		t.Errorf("expected done state, got: %+v", st)
 	}
@@ -151,7 +160,7 @@ func TestStateSet_IfState_InvalidValue(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	stateTarget = "s:0.0"
+	stateTarget = "%1"
 	stateValue = "working"
 	stateTool = "claude"
 	stateSource = "tool"
@@ -167,57 +176,35 @@ func TestStateSet_IfState_InvalidValue(t *testing.T) {
 	}
 }
 
-func TestResolveStateTarget_UsesResolvedWhenPaneIDMatches(t *testing.T) {
-	st := db.ToolState{Target: "work:1.0", PaneID: "%12"}
-	paneIDMap := map[string]string{"%12": "work:2.0"} // pane moved
-
-	got := resolveStateTarget(st, paneIDMap)
-	if got != "work:2.0" {
-		t.Errorf("want work:2.0, got %q", got)
-	}
-}
-
-func TestResolveStateTarget_FallsBackToTargetWhenNoPaneID(t *testing.T) {
-	st := db.ToolState{Target: "work:1.0", PaneID: ""}
-	paneIDMap := map[string]string{}
-
-	got := resolveStateTarget(st, paneIDMap)
-	if got != "work:1.0" {
-		t.Errorf("want work:1.0, got %q", got)
-	}
-}
-
-func TestResolveStateTarget_FallsBackWhenPaneIDNotInMap(t *testing.T) {
-	st := db.ToolState{Target: "work:1.0", PaneID: "%12"}
-	paneIDMap := map[string]string{} // tmux unavailable or pane truly gone
-
-	got := resolveStateTarget(st, paneIDMap)
-	if got != "work:1.0" {
-		t.Errorf("want work:1.0, got %q", got)
-	}
-}
-
-func TestStateSet_PaneIDFlag(t *testing.T) {
+func TestStateSet_InvalidTargetID(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	stateTarget = "s:0.0"
+	stateTarget = "s:0.0" // old format — invalid
 	stateValue = "working"
 	stateTool = "claude"
-	stateMessage = "running"
 	stateSource = "tool"
 	stateForce = false
 	stateIfState = ""
-	statePaneID = "%42"
 
-	if err := applyStateSet(d); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	err := applyStateSet(d)
+	if err == nil {
+		t.Fatal("expected error for invalid --target-id format")
 	}
-	st, _ := d.StateByTarget("s:0.0")
-	if st == nil {
-		t.Fatal("expected state, got nil")
+	if !strings.Contains(err.Error(), "--target-id") {
+		t.Errorf("error should mention --target-id, got: %v", err)
 	}
-	if st.PaneID != "%42" {
-		t.Errorf("expected PaneID %%42, got %q", st.PaneID)
+}
+
+func TestStateClear_InvalidTargetID(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	clearTarget = "s:0.0" // old format — invalid
+	clearYes = false
+
+	err := applyStateClear(d)
+	if err == nil {
+		t.Fatal("expected error for invalid --target-id format")
 	}
 }

--- a/cmd/state_test.go
+++ b/cmd/state_test.go
@@ -10,7 +10,42 @@ import (
 // stateTarget format is now "%N", "@N", or "$N" (stable tmux IDs).
 // Tests use "%1" as a representative pane target.
 
+// saveStateVars snapshots all package-level state-command globals and restores
+// them via t.Cleanup. Call at the start of any test that sets these globals to
+// eliminate ordering dependencies between tests.
+func saveStateVars(t *testing.T) {
+	t.Helper()
+	prev := struct {
+		target, value, tool, message, source, ifState string
+		force                                         bool
+		clearTarget                                   string
+		clearYes                                      bool
+	}{
+		target:      stateTarget,
+		value:       stateValue,
+		tool:        stateTool,
+		message:     stateMessage,
+		source:      stateSource,
+		ifState:     stateIfState,
+		force:       stateForce,
+		clearTarget: clearTarget,
+		clearYes:    clearYes,
+	}
+	t.Cleanup(func() {
+		stateTarget = prev.target
+		stateValue = prev.value
+		stateTool = prev.tool
+		stateMessage = prev.message
+		stateSource = prev.source
+		stateIfState = prev.ifState
+		stateForce = prev.force
+		clearTarget = prev.clearTarget
+		clearYes = prev.clearYes
+	})
+}
+
 func TestStateSet_ToolWrite(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -32,6 +67,7 @@ func TestStateSet_ToolWrite(t *testing.T) {
 }
 
 func TestStateSet_FlaggedRequiresUserSource(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -47,6 +83,7 @@ func TestStateSet_FlaggedRequiresUserSource(t *testing.T) {
 }
 
 func TestStateClear_FlaggedRequiresYes(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -71,6 +108,7 @@ func TestStateClear_FlaggedRequiresYes(t *testing.T) {
 }
 
 func TestStateClear_NonFlagged_NoYesRequired(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -86,6 +124,7 @@ func TestStateClear_NonFlagged_NoYesRequired(t *testing.T) {
 }
 
 func TestStateSet_IdleIsValid(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -108,6 +147,7 @@ func TestStateSet_IdleIsValid(t *testing.T) {
 }
 
 func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -133,6 +173,7 @@ func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
 }
 
 func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -157,6 +198,7 @@ func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
 }
 
 func TestStateSet_IfState_InvalidValue(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -177,6 +219,7 @@ func TestStateSet_IfState_InvalidValue(t *testing.T) {
 }
 
 func TestStateSet_InvalidTargetID(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
@@ -197,6 +240,7 @@ func TestStateSet_InvalidTargetID(t *testing.T) {
 }
 
 func TestStateClear_InvalidTargetID(t *testing.T) {
+	saveStateVars(t)
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 

--- a/cmd/state_test.go
+++ b/cmd/state_test.go
@@ -87,7 +87,7 @@ func TestStateClear_FlaggedRequiresYes(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	target := db.Target{Type: "pane", ID: "%1", PaneID: "%1"}
+	target := db.Target{Type: db.TargetTypePane, ID: "%1", PaneID: "%1"}
 	d.StateSet(target, "", db.StateFlagged, "note", db.SourceUser, false, nil)
 
 	clearTarget = "%1"
@@ -112,7 +112,7 @@ func TestStateClear_NonFlagged_NoYesRequired(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	target := db.Target{Type: "pane", ID: "%1", PaneID: "%1"}
+	target := db.Target{Type: db.TargetTypePane, ID: "%1", PaneID: "%1"}
 	d.StateSet(target, "claude", db.StateError, "boom", db.SourceTool, false, nil)
 
 	clearTarget = "%1"
@@ -152,7 +152,7 @@ func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
 	defer d.Close()
 
 	// Pre-set state to done.
-	target := db.Target{Type: "pane", ID: "%1", PaneID: "%1"}
+	target := db.Target{Type: db.TargetTypePane, ID: "%1", PaneID: "%1"}
 	d.StateSet(target, "claude", db.StateDone, "finished", db.SourceTool, false, nil)
 
 	stateTarget = "%1"
@@ -177,7 +177,7 @@ func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	target := db.Target{Type: "pane", ID: "%1", PaneID: "%1"}
+	target := db.Target{Type: db.TargetTypePane, ID: "%1", PaneID: "%1"}
 	d.StateSet(target, "claude", db.StateWorking, "running", db.SourceTool, false, nil)
 
 	stateTarget = "%1"

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -102,6 +102,12 @@ func (d *DB) migrate() error {
 		}
 		version = 7
 	}
+	if version < 8 {
+		if err := d.migrateV8(); err != nil {
+			return err
+		}
+		version = 8
+	}
 	return nil
 }
 
@@ -318,6 +324,62 @@ func (d *DB) migrateV7() error {
 	if _, err := tx.Exec(`PRAGMA user_version = 7`); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("set version 7: %w", err)
+	}
+	return tx.Commit()
+}
+
+func (d *DB) migrateV8() error {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin v8: %w", err)
+	}
+
+	// Drop the old table.
+	if _, err := tx.Exec(`DROP TABLE IF EXISTS tool_states`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("drop tool_states v8: %w", err)
+	}
+
+	// Create the new table with explicit target type and stable IDs.
+	if _, err := tx.Exec(`
+		CREATE TABLE IF NOT EXISTS tool_states (
+			id          INTEGER PRIMARY KEY AUTOINCREMENT,
+			target_type TEXT NOT NULL CHECK(target_type IN ('session', 'window', 'pane')),
+			target_id   TEXT NOT NULL,
+			session_id  TEXT,
+			window_id   TEXT,
+			pane_id     TEXT,
+			tool        TEXT NOT NULL DEFAULT '',
+			value       INTEGER NOT NULL,
+			message     TEXT NOT NULL DEFAULT '',
+			source      INTEGER NOT NULL DEFAULT 1,
+			updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)
+	`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("create tool_states v8: %w", err)
+	}
+
+	if _, err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_tool_states_type_id ON tool_states(target_type, target_id)`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("index type_id v8: %w", err)
+	}
+	if _, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_tool_states_session ON tool_states(session_id)`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("index session v8: %w", err)
+	}
+	if _, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_tool_states_window ON tool_states(window_id)`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("index window v8: %w", err)
+	}
+	if _, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_tool_states_value ON tool_states(value)`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("index value v8: %w", err)
+	}
+
+	if _, err := tx.Exec(`PRAGMA user_version = 8`); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("set version 8: %w", err)
 	}
 	return tx.Commit()
 }

--- a/internal/db/db_migrate_test.go
+++ b/internal/db/db_migrate_test.go
@@ -11,7 +11,7 @@ func TestMigrateV3_CreatesToolStates(t *testing.T) {
 	}
 	defer d.Close()
 
-	_, err = d.sql.Exec(`INSERT INTO tool_states (target, tool, value, message, source) VALUES ('s:0:0', 'claude', 1, 'running', 1)`)
+	_, err = d.sql.Exec(`INSERT INTO tool_states (target_type, target_id, tool, value, message, source) VALUES ('pane', '%1', 'claude', 1, 'running', 1)`)
 	if err != nil {
 		t.Fatalf("tool_states table missing after migration: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestMigrateV6_AddsPaneIDColumn(t *testing.T) {
 	}
 }
 
-func TestMigrateV3_UserVersion(t *testing.T) {
+func TestMigrateV8_UserVersion(t *testing.T) {
 	d, err := Open(":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -57,25 +57,47 @@ func TestMigrateV3_UserVersion(t *testing.T) {
 	if err := d.sql.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
 		t.Fatalf("read user_version: %v", err)
 	}
-	if version != 7 {
-		t.Fatalf("expected user_version=7, got %d", version)
+	if version != 8 {
+		t.Fatalf("expected user_version=8, got %d", version)
 	}
 }
 
-func TestMigrateV7_PaneIDIndexIsUnique(t *testing.T) {
+func TestMigrateV8_TypeIDIndexIsUnique(t *testing.T) {
 	d, err := Open(":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer d.Close()
 
-	// Insert two records with the same non-empty pane_id — must fail.
-	_, err1 := d.sql.Exec(`INSERT INTO tool_states (target, tool, value, message, source, pane_id) VALUES ('s:0.0', 'c', 1, '', 1, '%1')`)
-	_, err2 := d.sql.Exec(`INSERT INTO tool_states (target, tool, value, message, source, pane_id) VALUES ('s:1.0', 'c', 1, '', 1, '%1')`)
+	// Insert two records with the same (target_type, target_id) — must fail.
+	_, err1 := d.sql.Exec(`INSERT INTO tool_states (target_type, target_id, tool, value, message, source) VALUES ('pane', '%1', 'c', 1, '', 1)`)
+	_, err2 := d.sql.Exec(`INSERT INTO tool_states (target_type, target_id, tool, value, message, source) VALUES ('pane', '%1', 'c', 1, '', 1)`)
 	if err1 != nil {
 		t.Fatalf("first insert should succeed: %v", err1)
 	}
 	if err2 == nil {
-		t.Error("second insert with same pane_id should fail (UNIQUE constraint)")
+		t.Error("second insert with same (target_type, target_id) should fail (UNIQUE constraint)")
+	}
+}
+
+func TestMigrateV8_HasIndexes(t *testing.T) {
+	d, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	indexes := []string{
+		"idx_tool_states_type_id",
+		"idx_tool_states_session",
+		"idx_tool_states_window",
+		"idx_tool_states_value",
+	}
+	for _, idxName := range indexes {
+		var name string
+		err := d.sql.QueryRow(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, idxName).Scan(&name)
+		if err != nil {
+			t.Errorf("index %q not found: %v", idxName, err)
+		}
 	}
 }

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -283,16 +283,6 @@ func (d *DB) StateClear(t Target) error {
 	return err
 }
 
-// StateDeleteIfDone removes the state record only if the current value is done.
-// Used by event pane_focus to silently clear done states on navigation.
-func (d *DB) StateDeleteIfDone(t Target) error {
-	_, err := d.sql.Exec(
-		`DELETE FROM tool_states WHERE target_type = ? AND target_id = ? AND value = ?`,
-		t.Type, t.ID, int(StateDone),
-	)
-	return err
-}
-
 // StateDeleteIfResting removes the state record when value is done or idle.
 // Used by event pane_focus to clear resting states on navigation.
 func (d *DB) StateDeleteIfResting(t Target) error {

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -20,6 +20,15 @@ func parseTS(s string) time.Time {
 	return time.Time{}
 }
 
+// TargetType identifies the kind of tmux entity a state record is attached to.
+type TargetType string
+
+const (
+	TargetTypePane    TargetType = "pane"
+	TargetTypeWindow  TargetType = "window"
+	TargetTypeSession TargetType = "session"
+)
+
 // StateValue is the integer enum stored in tool_states.value.
 type StateValue int
 
@@ -118,11 +127,11 @@ var ErrStateLocked = errors.New("target locked")
 
 // Target represents the identity of a state record.
 type Target struct {
-	Type      string // "session", "window", "pane"
-	ID        string // $N, @N, %N
-	SessionID string // $N — all record types
-	WindowID  string // @N — window and pane records
-	PaneID    string // %N — pane records only
+	Type      TargetType // TargetTypePane, TargetTypeWindow, or TargetTypeSession
+	ID        string     // $N, @N, %N
+	SessionID string     // $N — all record types
+	WindowID  string     // @N — window and pane records
+	PaneID    string     // %N — pane records only
 }
 
 // Format resolves the target to a compact human-readable display string using
@@ -132,8 +141,11 @@ type Target struct {
 // windowMap maps @N → "session:windowIndex"
 // sessionMap maps $N → session_name
 func (t Target) Format(paneMap, windowMap, sessionMap map[string]string) string {
+	// Note: pane rendering strips the session prefix and produces "winN·pM"
+	// (compact form). This intentionally differs from formatTarget in cmd/state.go,
+	// which uses the full resolved path for tabular CLI output.
 	switch t.Type {
-	case "pane":
+	case TargetTypePane:
 		if full := paneMap[t.ID]; full != "" {
 			if idx := strings.Index(full, ":"); idx >= 0 {
 				rest := full[idx+1:]
@@ -146,7 +158,7 @@ func (t Target) Format(paneMap, windowMap, sessionMap map[string]string) string 
 			return full
 		}
 		return t.ID
-	case "window":
+	case TargetTypeWindow:
 		if full := windowMap[t.ID]; full != "" {
 			if idx := strings.Index(full, ":"); idx >= 0 {
 				return "win" + full[idx+1:]
@@ -154,7 +166,7 @@ func (t Target) Format(paneMap, windowMap, sessionMap map[string]string) string 
 			return full
 		}
 		return t.ID
-	case "session":
+	case TargetTypeSession:
 		if name := sessionMap[t.ID]; name != "" {
 			return name
 		}
@@ -172,11 +184,11 @@ func ParseTargetID(id string) (Target, error) {
 	}
 	switch id[0] {
 	case '%':
-		return Target{Type: "pane", ID: id, PaneID: id}, nil
+		return Target{Type: TargetTypePane, ID: id, PaneID: id}, nil
 	case '@':
-		return Target{Type: "window", ID: id, WindowID: id}, nil
+		return Target{Type: TargetTypeWindow, ID: id, WindowID: id}, nil
 	case '$':
-		return Target{Type: "session", ID: id, SessionID: id}, nil
+		return Target{Type: TargetTypeSession, ID: id, SessionID: id}, nil
 	default:
 		return Target{}, fmt.Errorf("invalid target ID prefix %q: must start with %%, @, or $", id[:1])
 	}
@@ -294,30 +306,56 @@ func (d *DB) StateDeleteIfResting(t Target) error {
 // StateGCOrphaned deletes state records whose target is no longer live.
 // Takes maps of live pane IDs, window IDs, and session IDs.
 // Returns the number of records deleted.
+// Uses one DELETE per target type rather than one per orphaned row.
 func (d *DB) StateGCOrphaned(livePaneIDs, liveWindowIDs, liveSessionIDs map[string]bool) (int64, error) {
-	states, err := d.StateList(0, "")
+	tx, err := d.sql.Begin()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("begin StateGCOrphaned: %w", err)
 	}
-	var deleted int64
-	for _, st := range states {
-		orphaned := false
-		switch st.Target.Type {
-		case "pane":
-			orphaned = !livePaneIDs[st.Target.ID]
-		case "window":
-			orphaned = !liveWindowIDs[st.Target.ID]
-		case "session":
-			orphaned = !liveSessionIDs[st.Target.ID]
+	defer tx.Rollback() //nolint:errcheck // no-op after Commit
+
+	var total int64
+	for _, item := range []struct {
+		targetType TargetType
+		live       map[string]bool
+	}{
+		{TargetTypePane, livePaneIDs},
+		{TargetTypeWindow, liveWindowIDs},
+		{TargetTypeSession, liveSessionIDs},
+	} {
+		n, err := gcDeleteOrphaned(tx, item.targetType, item.live)
+		if err != nil {
+			return total, err
 		}
-		if orphaned {
-			if err := d.StateClear(st.Target); err != nil {
-				return deleted, fmt.Errorf("gc: clear %v: %w", st.Target, err)
-			}
-			deleted++
-		}
+		total += n
 	}
-	return deleted, nil
+	return total, tx.Commit()
+}
+
+// gcDeleteOrphaned removes records of the given target type whose ID is not in liveIDs.
+func gcDeleteOrphaned(tx *sql.Tx, targetType TargetType, liveIDs map[string]bool) (int64, error) {
+	var res sql.Result
+	var err error
+	if len(liveIDs) == 0 {
+		res, err = tx.Exec(`DELETE FROM tool_states WHERE target_type = ?`, string(targetType))
+	} else {
+		args := make([]interface{}, 0, len(liveIDs)+1)
+		args = append(args, string(targetType))
+		placeholders := make([]string, 0, len(liveIDs))
+		for id := range liveIDs {
+			placeholders = append(placeholders, "?")
+			args = append(args, id)
+		}
+		query := fmt.Sprintf(
+			`DELETE FROM tool_states WHERE target_type = ? AND target_id NOT IN (%s)`,
+			strings.Join(placeholders, ", "),
+		)
+		res, err = tx.Exec(query, args...)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("gc orphaned %s: %w", targetType, err)
+	}
+	return res.RowsAffected()
 }
 
 // StateDeleteBySession removes all state records for the given session.

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -116,6 +116,33 @@ func (s StateSource) String() string {
 // ErrStateLocked is returned by StateSet when a write is rejected due to lock rules.
 var ErrStateLocked = errors.New("target locked")
 
+// Target represents the identity of a state record.
+type Target struct {
+	Type      string // "session", "window", "pane"
+	ID        string // $N, @N, %N
+	SessionID string // $N — all record types
+	WindowID  string // @N — window and pane records
+	PaneID    string // %N — pane records only
+}
+
+// ParseTargetID infers the target type from the tmux ID prefix.
+// % → pane, @ → window, $ → session
+func ParseTargetID(id string) (Target, error) {
+	if len(id) == 0 {
+		return Target{}, fmt.Errorf("target ID cannot be empty")
+	}
+	switch id[0] {
+	case '%':
+		return Target{Type: "pane", ID: id, PaneID: id}, nil
+	case '@':
+		return Target{Type: "window", ID: id, WindowID: id}, nil
+	case '$':
+		return Target{Type: "session", ID: id, SessionID: id}, nil
+	default:
+		return Target{}, fmt.Errorf("invalid target ID prefix %q: must start with %%, @, or $", id[:1])
+	}
+}
+
 // ToolState represents a row in tool_states.
 type ToolState struct {
 	ID        int

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	demuxlog "github.com/rtalexk/demux/internal/log"
@@ -122,6 +123,45 @@ type Target struct {
 	SessionID string // $N — all record types
 	WindowID  string // @N — window and pane records
 	PaneID    string // %N — pane records only
+}
+
+// Format resolves the target to a compact human-readable display string using
+// live tmux ID→label maps. Falls back to the raw ID when no map entry exists.
+//
+// paneMap   maps %N → "session:windowIndex.paneIndex"
+// windowMap maps @N → "session:windowIndex"
+// sessionMap maps $N → session_name
+func (t Target) Format(paneMap, windowMap, sessionMap map[string]string) string {
+	switch t.Type {
+	case "pane":
+		if full := paneMap[t.ID]; full != "" {
+			if idx := strings.Index(full, ":"); idx >= 0 {
+				rest := full[idx+1:]
+				parts := strings.SplitN(rest, ".", 2)
+				if len(parts) == 2 {
+					return "win" + parts[0] + "·p" + parts[1]
+				}
+				return rest
+			}
+			return full
+		}
+		return t.ID
+	case "window":
+		if full := windowMap[t.ID]; full != "" {
+			if idx := strings.Index(full, ":"); idx >= 0 {
+				return "win" + full[idx+1:]
+			}
+			return full
+		}
+		return t.ID
+	case "session":
+		if name := sessionMap[t.ID]; name != "" {
+			return name
+		}
+		return t.ID
+	default:
+		return t.ID
+	}
 }
 
 // ParseTargetID infers the target type from the tmux ID prefix.

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -146,11 +146,10 @@ func ParseTargetID(id string) (Target, error) {
 // ToolState represents a row in tool_states.
 type ToolState struct {
 	ID        int
-	Target    string
+	Target    Target // embedded struct with Type, ID, SessionID, WindowID, PaneID
 	Tool      string
 	Value     StateValue
 	Message   string
-	PaneID    string
 	Source    StateSource
 	UpdatedAt time.Time
 }

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -339,7 +339,7 @@ func gcDeleteOrphaned(tx *sql.Tx, targetType TargetType, liveIDs map[string]bool
 	if len(liveIDs) == 0 {
 		res, err = tx.Exec(`DELETE FROM tool_states WHERE target_type = ?`, string(targetType))
 	} else {
-		args := make([]interface{}, 0, len(liveIDs)+1)
+		args := make([]any, 0, len(liveIDs)+1)
 		args = append(args, string(targetType))
 		placeholders := make([]string, 0, len(liveIDs))
 		for id := range liveIDs {

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	demuxlog "github.com/rtalexk/demux/internal/log"
@@ -156,7 +155,7 @@ type ToolState struct {
 
 // StateSet writes a state record for target, applying write-lock rules.
 // Returns ErrStateLocked (wrapped) if the write is rejected.
-func (d *DB) StateSet(target, tool string, value StateValue, message string, source StateSource, force bool, ifState *StateValue, paneID string) error {
+func (d *DB) StateSet(t Target, tool string, value StateValue, message string, source StateSource, force bool, ifState *StateValue) error {
 	tx, err := d.sql.Begin()
 	if err != nil {
 		return fmt.Errorf("begin StateSet: %w", err)
@@ -165,7 +164,7 @@ func (d *DB) StateSet(target, tool string, value StateValue, message string, sou
 
 	// Read current record within the transaction.
 	var current *ToolState
-	row := tx.QueryRow(`SELECT tool, value, source FROM tool_states WHERE target = ?`, target)
+	row := tx.QueryRow(`SELECT tool, value, source FROM tool_states WHERE target_type = ? AND target_id = ?`, t.Type, t.ID)
 	var cur ToolState
 	err = row.Scan(&cur.Tool, &cur.Value, &cur.Source)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -177,16 +176,12 @@ func (d *DB) StateSet(target, tool string, value StateValue, message string, sou
 
 	// No-op if value and tool are unchanged (avoids redundant DB writes from
 	// high-frequency hooks like PreToolUse firing working→working repeatedly).
-	// When paneID is provided we must fall through to the stale-delete path even
-	// when the value is identical, because the pane may have moved to a new target.
-	if ifState == nil && paneID == "" && current != nil && current.Value == value && current.Tool == tool {
-		demuxlog.Debug("state set skipped: no change", "target", target, "tool", tool, "state", value)
+	if ifState == nil && current != nil && current.Value == value && current.Tool == tool {
+		demuxlog.Debug("state set skipped: no change", "target_type", t.Type, "target_id", t.ID, "tool", tool, "state", value)
 		return tx.Rollback()
 	}
 
 	// Apply --if-state condition: no-op if current state doesn't match.
-	// A missing row is treated as StateValue(0), not StateIdle; callers
-	// wanting "write if currently idle" must pass StateValue(0), not &StateIdle.
 	if ifState != nil {
 		currentValue := StateValue(0)
 		if current != nil {
@@ -194,17 +189,6 @@ func (d *DB) StateSet(target, tool string, value StateValue, message string, sou
 		}
 		if currentValue != *ifState {
 			return tx.Rollback()
-		}
-	}
-
-	// When a stable pane_id is provided, delete any stale record for this pane
-	// at a different target (handles panes that moved since last write).
-	if paneID != "" {
-		if _, err := tx.Exec(
-			`DELETE FROM tool_states WHERE pane_id = ? AND target != ?`,
-			paneID, target,
-		); err != nil {
-			return fmt.Errorf("delete stale pane record: %w", err)
 		}
 	}
 
@@ -221,16 +205,18 @@ func (d *DB) StateSet(target, tool string, value StateValue, message string, sou
 	}
 
 	_, err = tx.Exec(`
-		INSERT INTO tool_states (target, tool, value, message, source, pane_id, updated_at)
-		VALUES (?, ?, ?, ?, ?, NULLIF(?, ''), CURRENT_TIMESTAMP)
-		ON CONFLICT(target) DO UPDATE SET
+		INSERT INTO tool_states (target_type, target_id, session_id, window_id, pane_id, tool, value, message, source, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(target_type, target_id) DO UPDATE SET
 			tool       = excluded.tool,
 			value      = excluded.value,
 			message    = excluded.message,
 			source     = excluded.source,
+			session_id = COALESCE(excluded.session_id, tool_states.session_id),
+			window_id  = COALESCE(excluded.window_id, tool_states.window_id),
 			pane_id    = COALESCE(excluded.pane_id, tool_states.pane_id),
 			updated_at = excluded.updated_at
-	`, target, tool, int(value), message, int(source), paneID)
+	`, t.Type, t.ID, t.SessionID, t.WindowID, t.PaneID, tool, int(value), message, int(source))
 	if err != nil {
 		return fmt.Errorf("upsert state: %w", err)
 	}
@@ -240,59 +226,35 @@ func (d *DB) StateSet(target, tool string, value StateValue, message string, sou
 
 // StateClear removes the state record for target, returning it to idle.
 // Always succeeds regardless of current state.
-func (d *DB) StateClear(target string) error {
-	_, err := d.sql.Exec(`DELETE FROM tool_states WHERE target = ?`, target)
+func (d *DB) StateClear(t Target) error {
+	_, err := d.sql.Exec(`DELETE FROM tool_states WHERE target_type = ? AND target_id = ?`, t.Type, t.ID)
 	return err
 }
 
 // StateDeleteIfDone removes the state record only if the current value is done.
 // Used by event pane_focus to silently clear done states on navigation.
-func (d *DB) StateDeleteIfDone(target string) error {
-	_, err := d.sql.Exec(`DELETE FROM tool_states WHERE target = ? AND value = ?`, target, int(StateDone))
+func (d *DB) StateDeleteIfDone(t Target) error {
+	_, err := d.sql.Exec(
+		`DELETE FROM tool_states WHERE target_type = ? AND target_id = ? AND value = ?`,
+		t.Type, t.ID, int(StateDone),
+	)
 	return err
 }
 
 // StateDeleteIfResting removes the state record when value is done or idle.
 // Used by event pane_focus to clear resting states on navigation.
-func (d *DB) StateDeleteIfResting(target string) error {
+func (d *DB) StateDeleteIfResting(t Target) error {
 	_, err := d.sql.Exec(
-		`DELETE FROM tool_states WHERE target = ? AND value IN (?, ?)`,
-		target, int(StateDone), int(StateIdle),
+		`DELETE FROM tool_states WHERE target_type = ? AND target_id = ? AND value IN (?, ?)`,
+		t.Type, t.ID, int(StateDone), int(StateIdle),
 	)
 	return err
 }
 
-// StateClearByPaneID removes the state record whose pane_id matches.
-// No-op if no record has that pane_id.
-func (d *DB) StateClearByPaneID(paneID string) error {
-	_, err := d.sql.Exec(`DELETE FROM tool_states WHERE pane_id = ?`, paneID)
-	return err
-}
-
-// StateDeleteIfRestingByPaneID removes the state record when value is done or idle,
-// looking up by pane_id. Used by pane_focus when pane_id is available — handles
-// panes that have moved positions since the state was written.
-func (d *DB) StateDeleteIfRestingByPaneID(paneID string) error {
-	_, err := d.sql.Exec(
-		`DELETE FROM tool_states WHERE pane_id = ? AND value IN (?, ?)`,
-		paneID, int(StateDone), int(StateIdle),
-	)
-	return err
-}
-
-// looksLikePaneTarget reports whether target is in "session:window.pane" format.
-// Used by StateGCOrphaned to skip session-level and window-level targets.
-func looksLikePaneTarget(target string) bool {
-	return strings.Contains(target, ":") && strings.Contains(target, ".")
-}
-
-// StateGCOrphaned deletes state records whose pane is no longer live.
-// For records with a pane_id: orphaned when pane_id is not in livePaneIDs.
-// For legacy records (pane_id empty) that look like "session:window.pane":
-// orphaned when target is not in livePaneTargets.
-// Session-level and window-level targets (no ".") are never deleted.
+// StateGCOrphaned deletes state records whose target is no longer live.
+// Takes maps of live pane IDs, window IDs, and session IDs.
 // Returns the number of records deleted.
-func (d *DB) StateGCOrphaned(livePaneIDs map[string]bool, livePaneTargets map[string]bool) (int64, error) {
+func (d *DB) StateGCOrphaned(livePaneIDs, liveWindowIDs, liveSessionIDs map[string]bool) (int64, error) {
 	states, err := d.StateList(0, "")
 	if err != nil {
 		return 0, err
@@ -300,14 +262,17 @@ func (d *DB) StateGCOrphaned(livePaneIDs map[string]bool, livePaneTargets map[st
 	var deleted int64
 	for _, st := range states {
 		orphaned := false
-		if st.PaneID != "" {
-			orphaned = !livePaneIDs[st.PaneID]
-		} else if looksLikePaneTarget(st.Target) {
-			orphaned = !livePaneTargets[st.Target]
+		switch st.Target.Type {
+		case "pane":
+			orphaned = !livePaneIDs[st.Target.ID]
+		case "window":
+			orphaned = !liveWindowIDs[st.Target.ID]
+		case "session":
+			orphaned = !liveSessionIDs[st.Target.ID]
 		}
 		if orphaned {
 			if err := d.StateClear(st.Target); err != nil {
-				return deleted, fmt.Errorf("gc: clear %q: %w", st.Target, err)
+				return deleted, fmt.Errorf("gc: clear %v: %w", st.Target, err)
 			}
 			deleted++
 		}
@@ -315,53 +280,25 @@ func (d *DB) StateGCOrphaned(livePaneIDs map[string]bool, livePaneTargets map[st
 	return deleted, nil
 }
 
-// StateDeleteBySessionWithPaneIDs removes all state records for the given session,
-// both by target prefix (existing behaviour) and by the provided pane IDs (catches
-// records whose target drifted after a pane move).
+// StateDeleteBySession removes all state records for the given session.
 // Returns the total number of rows deleted.
-func (d *DB) StateDeleteBySessionWithPaneIDs(name string, paneIDs []string) (int64, error) {
-	tx, err := d.sql.Begin()
-	if err != nil {
-		return 0, fmt.Errorf("begin StateDeleteBySessionWithPaneIDs: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck // no-op after Commit
-
-	// Delete by target prefix first (original behaviour).
-	res, err := tx.Exec(
-		`DELETE FROM tool_states WHERE target = ? OR target LIKE ?`,
-		name, name+":%",
-	)
+func (d *DB) StateDeleteBySession(sessionID string) (int64, error) {
+	res, err := d.sql.Exec(`DELETE FROM tool_states WHERE session_id = ?`, sessionID)
 	if err != nil {
 		return 0, err
 	}
-	n, _ := res.RowsAffected()
-
-	// Delete any remaining records for panes that belong to this session.
-	for _, pid := range paneIDs {
-		r, err := tx.Exec(`DELETE FROM tool_states WHERE pane_id = ?`, pid)
-		if err != nil {
-			return 0, err
-		}
-		rows, _ := r.RowsAffected()
-		n += rows
-	}
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit StateDeleteBySessionWithPaneIDs: %w", err)
-	}
-	return n, nil
+	return res.RowsAffected()
 }
 
-// StateByTarget returns the ToolState for target, or nil if no record exists (idle).
-func (d *DB) StateByTarget(target string) (*ToolState, error) {
+// StateByID returns the ToolState for the given target identity, or nil if no record exists (idle).
+func (d *DB) StateByID(t Target) (*ToolState, error) {
 	row := d.sql.QueryRow(`
-		SELECT id, target, tool, value, message, pane_id, source, updated_at
-		FROM tool_states WHERE target = ?
-	`, target)
+		SELECT id, target_type, target_id, session_id, window_id, pane_id, tool, value, message, source, updated_at
+		FROM tool_states WHERE target_type = ? AND target_id = ?
+	`, t.Type, t.ID)
 	var st ToolState
 	var updatedAt string
-	var paneID sql.NullString
-	err := row.Scan(&st.ID, &st.Target, &st.Tool, &st.Value, &st.Message, &paneID, &st.Source, &updatedAt)
-	st.PaneID = paneID.String
+	err := row.Scan(&st.ID, &st.Target.Type, &st.Target.ID, &st.Target.SessionID, &st.Target.WindowID, &st.Target.PaneID, &st.Tool, &st.Value, &st.Message, &st.Source, &updatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -374,7 +311,7 @@ func (d *DB) StateByTarget(target string) (*ToolState, error) {
 
 // StateList returns all non-idle state records. Pass value=0 or tool="" to skip that filter.
 func (d *DB) StateList(value StateValue, tool string) ([]ToolState, error) {
-	q := `SELECT id, target, tool, value, message, pane_id, source, updated_at FROM tool_states WHERE 1=1`
+	q := `SELECT id, target_type, target_id, session_id, window_id, pane_id, tool, value, message, source, updated_at FROM tool_states WHERE 1=1`
 	var args []any
 	if value != 0 {
 		q += ` AND value = ?`
@@ -396,11 +333,9 @@ func (d *DB) StateList(value StateValue, tool string) ([]ToolState, error) {
 	for rows.Next() {
 		var st ToolState
 		var updatedAt string
-		var paneID sql.NullString
-		if err := rows.Scan(&st.ID, &st.Target, &st.Tool, &st.Value, &st.Message, &paneID, &st.Source, &updatedAt); err != nil {
+		if err := rows.Scan(&st.ID, &st.Target.Type, &st.Target.ID, &st.Target.SessionID, &st.Target.WindowID, &st.Target.PaneID, &st.Tool, &st.Value, &st.Message, &st.Source, &updatedAt); err != nil {
 			return nil, err
 		}
-		st.PaneID = paneID.String
 		st.UpdatedAt = parseTS(updatedAt)
 		states = append(states, st)
 	}

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -30,10 +30,11 @@ func TestStateSet_BasicUpsert(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	if err := d.StateSet("s:0:0", "claude", StateWorking, "running tests", SourceTool, false, nil, ""); err != nil {
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	if err := d.StateSet(target, "claude", StateWorking, "running tests", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}
-	st, err := d.StateByTarget("s:0:0")
+	st, err := d.StateByID(target)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,13 +50,14 @@ func TestStateSet_LockWorking_DifferentTool(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, "")
-	err := d.StateSet("s:0:0", "make", StateWorking, "", SourceTool, false, nil, "")
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil)
+	err := d.StateSet(target, "make", StateWorking, "", SourceTool, false, nil)
 	if err == nil {
 		t.Fatal("expected locked error, got nil")
 	}
 	// original owner should be unchanged
-	st, _ := d.StateByTarget("s:0:0")
+	st, _ := d.StateByID(target)
 	if st.Tool != "claude" {
 		t.Errorf("lock violated: tool changed to %q", st.Tool)
 	}
@@ -65,8 +67,9 @@ func TestStateSet_LockWorking_SameTool(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "step 1", SourceTool, false, nil, "")
-	if err := d.StateSet("s:0:0", "claude", StateWorking, "step 2", SourceTool, false, nil, ""); err != nil {
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	d.StateSet(target, "claude", StateWorking, "step 1", SourceTool, false, nil)
+	if err := d.StateSet(target, "claude", StateWorking, "step 2", SourceTool, false, nil); err != nil {
 		t.Errorf("same tool should not be locked: %v", err)
 	}
 }
@@ -75,9 +78,10 @@ func TestStateSet_LockFlagged_BlocksAllTools(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "", StateFlagged, "come back", SourceUser, false, nil, "")
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	d.StateSet(target, "", StateFlagged, "come back", SourceUser, false, nil)
 	// same tool name should still be blocked
-	if err := d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, ""); err == nil {
+	if err := d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil); err == nil {
 		t.Fatal("flagged should block all tool writes")
 	}
 }
@@ -86,15 +90,16 @@ func TestStateSet_ForceOverridesLock(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	// Flagged blocks tool writes normally.
-	d.StateSet("s:0:0", "", StateFlagged, "come back", SourceUser, false, nil, "")
-	if err := d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, true, nil, ""); err != nil {
+	d.StateSet(target, "", StateFlagged, "come back", SourceUser, false, nil)
+	if err := d.StateSet(target, "claude", StateWorking, "", SourceTool, true, nil); err != nil {
 		t.Fatalf("force should override flagged lock: %v", err)
 	}
 
 	// Different-tool lock overridden by force.
-	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, "")
-	if err := d.StateSet("s:0:0", "make", StateWorking, "", SourceTool, true, nil, ""); err != nil {
+	d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil)
+	if err := d.StateSet(target, "make", StateWorking, "", SourceTool, true, nil); err != nil {
 		t.Fatalf("force should override different-tool lock: %v", err)
 	}
 }
@@ -103,8 +108,9 @@ func TestStateSet_UserWriteAlwaysSucceeds(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, "")
-	if err := d.StateSet("s:0:0", "", StateFlagged, "note", SourceUser, false, nil, ""); err != nil {
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil)
+	if err := d.StateSet(target, "", StateFlagged, "note", SourceUser, false, nil); err != nil {
 		t.Errorf("user write should always succeed: %v", err)
 	}
 }
@@ -113,11 +119,12 @@ func TestStateClear(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateError, "boom", SourceTool, false, nil, "")
-	if err := d.StateClear("s:0:0"); err != nil {
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	d.StateSet(target, "claude", StateError, "boom", SourceTool, false, nil)
+	if err := d.StateClear(target); err != nil {
 		t.Fatal(err)
 	}
-	st, _ := d.StateByTarget("s:0:0")
+	st, _ := d.StateByID(target)
 	if st != nil {
 		t.Errorf("expected nil after clear, got: %+v", st)
 	}
@@ -127,19 +134,21 @@ func TestStateDeleteIfDone(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil, "")
-	if err := d.StateDeleteIfDone("s:0:0"); err != nil {
+	target1 := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	d.StateSet(target1, "claude", StateDone, "finished", SourceTool, false, nil)
+	if err := d.StateDeleteIfDone(target1); err != nil {
 		t.Fatal(err)
 	}
-	st, _ := d.StateByTarget("s:0:0")
+	st, _ := d.StateByID(target1)
 	if st != nil {
 		t.Errorf("expected done state deleted, got: %+v", st)
 	}
 
 	// non-done states must not be deleted
-	d.StateSet("s:1:0", "claude", StateError, "boom", SourceTool, false, nil, "")
-	d.StateDeleteIfDone("s:1:0")
-	st2, _ := d.StateByTarget("s:1:0")
+	target2 := Target{Type: "pane", ID: "%2", SessionID: "$0", WindowID: "@0", PaneID: "%2"}
+	d.StateSet(target2, "claude", StateError, "boom", SourceTool, false, nil)
+	d.StateDeleteIfDone(target2)
+	st2, _ := d.StateByID(target2)
 	if st2 == nil {
 		t.Error("non-done state should not be deleted by StateDeleteIfDone")
 	}
@@ -150,33 +159,37 @@ func TestStateDeleteIfResting(t *testing.T) {
 	defer d.Close()
 
 	// done is cleared
-	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil, "")
-	d.StateDeleteIfResting("s:0:0")
-	st, _ := d.StateByTarget("s:0:0")
+	target1 := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	d.StateSet(target1, "claude", StateDone, "finished", SourceTool, false, nil)
+	d.StateDeleteIfResting(target1)
+	st, _ := d.StateByID(target1)
 	if st != nil {
 		t.Errorf("done state should be cleared by StateDeleteIfResting, got: %+v", st)
 	}
 
 	// idle is cleared
-	d.StateSet("s:1:0", "claude", StateIdle, "available", SourceTool, false, nil, "")
-	d.StateDeleteIfResting("s:1:0")
-	st2, _ := d.StateByTarget("s:1:0")
+	target2 := Target{Type: "pane", ID: "%2", SessionID: "$0", WindowID: "@0", PaneID: "%2"}
+	d.StateSet(target2, "claude", StateIdle, "available", SourceTool, false, nil)
+	d.StateDeleteIfResting(target2)
+	st2, _ := d.StateByID(target2)
 	if st2 != nil {
 		t.Errorf("idle state should be cleared by StateDeleteIfResting, got: %+v", st2)
 	}
 
 	// working is not cleared
-	d.StateSet("s:2:0", "claude", StateWorking, "running", SourceTool, false, nil, "")
-	d.StateDeleteIfResting("s:2:0")
-	st3, _ := d.StateByTarget("s:2:0")
+	target3 := Target{Type: "pane", ID: "%3", SessionID: "$0", WindowID: "@0", PaneID: "%3"}
+	d.StateSet(target3, "claude", StateWorking, "running", SourceTool, false, nil)
+	d.StateDeleteIfResting(target3)
+	st3, _ := d.StateByID(target3)
 	if st3 == nil {
 		t.Error("working state should survive StateDeleteIfResting")
 	}
 
 	// error is not cleared
-	d.StateSet("s:3:0", "claude", StateError, "boom", SourceTool, false, nil, "")
-	d.StateDeleteIfResting("s:3:0")
-	st4, _ := d.StateByTarget("s:3:0")
+	target4 := Target{Type: "pane", ID: "%4", SessionID: "$0", WindowID: "@0", PaneID: "%4"}
+	d.StateSet(target4, "claude", StateError, "boom", SourceTool, false, nil)
+	d.StateDeleteIfResting(target4)
+	st4, _ := d.StateByID(target4)
 	if st4 == nil {
 		t.Error("error state should survive StateDeleteIfResting")
 	}
@@ -186,8 +199,10 @@ func TestStateList(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "", SourceTool, false, nil, "")
-	d.StateSet("s:1:0", "make", StateError, "fail", SourceTool, false, nil, "")
+	t1 := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	t2 := Target{Type: "pane", ID: "%2", SessionID: "$0", WindowID: "@0", PaneID: "%2"}
+	d.StateSet(t1, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(t2, "make", StateError, "fail", SourceTool, false, nil)
 
 	all, err := d.StateList(0, "")
 	if err != nil {
@@ -220,10 +235,11 @@ func TestStateIdle_SetAndRetrieve(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	if err := d.StateSet("s:0:0", "claude", StateIdle, "available", SourceTool, false, nil, ""); err != nil {
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	if err := d.StateSet(target, "claude", StateIdle, "available", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}
-	st, _ := d.StateByTarget("s:0:0")
+	st, _ := d.StateByID(target)
 	if st == nil || st.Value != StateIdle {
 		t.Errorf("expected idle state, got: %+v", st)
 	}
@@ -233,17 +249,18 @@ func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	// Set to done.
-	d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, nil, "")
+	d.StateSet(target, "claude", StateDone, "finished", SourceTool, false, nil)
 
 	// Try to overwrite with working, but guard says "only if currently working".
 	ifWorking := StateWorking
-	err := d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, &ifWorking, "")
+	err := d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, &ifWorking)
 	if err != nil {
 		t.Fatalf("ifState mismatch should be a silent no-op, got: %v", err)
 	}
 
-	st, _ := d.StateByTarget("s:0:0")
+	st, _ := d.StateByID(target)
 	if st == nil || st.Value != StateDone {
 		t.Errorf("state should remain done after mismatch, got: %+v", st)
 	}
@@ -253,13 +270,14 @@ func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, nil, "")
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, nil)
 
 	ifWorking := StateWorking
-	if err := d.StateSet("s:0:0", "claude", StateDone, "finished", SourceTool, false, &ifWorking, ""); err != nil {
+	if err := d.StateSet(target, "claude", StateDone, "finished", SourceTool, false, &ifWorking); err != nil {
 		t.Fatalf("ifState match should write: %v", err)
 	}
-	st, _ := d.StateByTarget("s:0:0")
+	st, _ := d.StateByID(target)
 	if st == nil || st.Value != StateDone {
 		t.Errorf("expected done state, got: %+v", st)
 	}
@@ -269,117 +287,135 @@ func TestStateSet_IfState_NoopWhenNoRow(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	// No row exists. Passing ifState=StateIdle (6) should be a no-op because
 	// a missing row is treated as StateValue(0), not StateIdle.
 	ifIdle := StateIdle
-	err := d.StateSet("s:0:0", "claude", StateWorking, "running", SourceTool, false, &ifIdle, "")
+	err := d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, &ifIdle)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	st, _ := d.StateByTarget("s:0:0")
+	st, _ := d.StateByID(target)
 	if st != nil {
 		t.Errorf("no row should exist: missing row != StateIdle, got: %+v", st)
 	}
 }
 
-func TestStateClearByPaneID_DeletesRecord(t *testing.T) {
+func TestStateGCOrphaned_DeletesByType(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%12")
-	if err := d.StateClearByPaneID("%12"); err != nil {
-		t.Fatal(err)
-	}
-	st, _ := d.StateByTarget("s:0.0")
-	if st != nil {
-		t.Errorf("expected state deleted by pane_id, got: %+v", st)
-	}
-}
-
-func TestStateClearByPaneID_NoopWhenNotFound(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	if err := d.StateClearByPaneID("%99"); err != nil {
-		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
-	}
-}
-
-func TestStateClearByPaneID_DoesNotDeleteOtherRecords(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%12")
-	d.StateSet("s:1.0", "claude", StateWorking, "running", SourceTool, false, nil, "%13")
-	d.StateClearByPaneID("%12")
-
-	st, _ := d.StateByTarget("s:1.0")
-	if st == nil {
-		t.Error("unrelated pane state should not be deleted")
-	}
-}
-
-func TestStateGCOrphaned_DeletesByPaneID(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	d.StateSet("s:0.0", "claude", StateWorking, "", SourceTool, false, nil, "%12")
-	d.StateSet("s:1.0", "claude", StateWorking, "", SourceTool, false, nil, "%13")
+	pane1 := Target{Type: "pane", ID: "%12", SessionID: "$0", WindowID: "@0", PaneID: "%12"}
+	pane2 := Target{Type: "pane", ID: "%13", SessionID: "$0", WindowID: "@0", PaneID: "%13"}
+	d.StateSet(pane1, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(pane2, "claude", StateWorking, "", SourceTool, false, nil)
 
 	// %12 is live; %13 is gone.
-	n, err := d.StateGCOrphaned(map[string]bool{"%12": true}, map[string]bool{})
+	n, err := d.StateGCOrphaned(
+		map[string]bool{"%12": true},
+		map[string]bool{},
+		map[string]bool{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if n != 1 {
 		t.Errorf("expected 1 deleted, got %d", n)
 	}
-	if st, _ := d.StateByTarget("s:0.0"); st == nil {
+	if st, _ := d.StateByID(pane1); st == nil {
 		t.Error("live pane state should survive GC")
 	}
-	if st, _ := d.StateByTarget("s:1.0"); st != nil {
+	if st, _ := d.StateByID(pane2); st != nil {
 		t.Error("orphaned pane state should be deleted")
 	}
 }
 
-func TestStateGCOrphaned_LegacyFallback(t *testing.T) {
+func TestStateGCOrphaned_DeletesWindows(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	// Legacy record: no pane_id, target is session:window.pane format.
-	d.StateSet("s:0.0", "claude", StateWorking, "", SourceTool, false, nil, "")
-	d.StateSet("s:1.0", "claude", StateWorking, "", SourceTool, false, nil, "")
+	win1 := Target{Type: "window", ID: "@5", SessionID: "$0", WindowID: "@5"}
+	win2 := Target{Type: "window", ID: "@6", SessionID: "$0", WindowID: "@6"}
+	d.StateSet(win1, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(win2, "claude", StateWorking, "", SourceTool, false, nil)
 
-	// s:0.0 is live; s:1.0 is not.
-	n, err := d.StateGCOrphaned(map[string]bool{}, map[string]bool{"s:0.0": true})
+	// @5 is live; @6 is gone.
+	n, err := d.StateGCOrphaned(
+		map[string]bool{},
+		map[string]bool{"@5": true},
+		map[string]bool{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if n != 1 {
 		t.Errorf("expected 1 deleted, got %d", n)
 	}
-	if st, _ := d.StateByTarget("s:0.0"); st == nil {
-		t.Error("live legacy target should survive")
+	if st, _ := d.StateByID(win1); st == nil {
+		t.Error("live window state should survive GC")
 	}
-	if st, _ := d.StateByTarget("s:1.0"); st != nil {
-		t.Error("orphaned legacy target should be deleted")
+	if st, _ := d.StateByID(win2); st != nil {
+		t.Error("orphaned window state should be deleted")
 	}
 }
 
-func TestStateGCOrphaned_SkipsSessionAndWindowTargets(t *testing.T) {
+func TestStateGCOrphaned_DeletesSessions(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	// Bare session target and window target have no pane_id and no dot — skip GC.
-	d.StateSet("myapp", "claude", StateWorking, "", SourceTool, false, nil, "")
-	d.StateSet("myapp:1", "claude", StateWorking, "", SourceTool, false, nil, "")
+	sess1 := Target{Type: "session", ID: "$1", SessionID: "$1"}
+	sess2 := Target{Type: "session", ID: "$2", SessionID: "$2"}
+	d.StateSet(sess1, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(sess2, "claude", StateWorking, "", SourceTool, false, nil)
 
-	n, err := d.StateGCOrphaned(map[string]bool{}, map[string]bool{})
+	// $1 is live; $2 is gone.
+	n, err := d.StateGCOrphaned(
+		map[string]bool{},
+		map[string]bool{},
+		map[string]bool{"$1": true},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n != 0 {
-		t.Errorf("session/window targets should not be GC'd, deleted %d", n)
+	if n != 1 {
+		t.Errorf("expected 1 deleted, got %d", n)
+	}
+	if st, _ := d.StateByID(sess1); st == nil {
+		t.Error("live session state should survive GC")
+	}
+	if st, _ := d.StateByID(sess2); st != nil {
+		t.Error("orphaned session state should be deleted")
+	}
+}
+
+func TestStateDeleteBySession_DeletesAll(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	t1 := Target{Type: "pane", ID: "%5", SessionID: "$0", WindowID: "@0", PaneID: "%5"}
+	t2 := Target{Type: "pane", ID: "%6", SessionID: "$0", WindowID: "@0", PaneID: "%6"}
+	t3 := Target{Type: "pane", ID: "%7", SessionID: "$1", WindowID: "@1", PaneID: "%7"}
+
+	d.StateSet(t1, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(t2, "make", StateDone, "", SourceTool, false, nil)
+	d.StateSet(t3, "claude", StateDone, "", SourceTool, false, nil)
+
+	// Delete all states for session $0
+	n, err := d.StateDeleteBySession("$0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2 deleted, got %d", n)
+	}
+	if st, _ := d.StateByID(t1); st != nil {
+		t.Error("t1 should be deleted")
+	}
+	if st, _ := d.StateByID(t2); st != nil {
+		t.Error("t2 should be deleted")
+	}
+	if st, _ := d.StateByID(t3); st == nil {
+		t.Error("t3 (different session) should survive")
 	}
 }
 
@@ -387,214 +423,59 @@ func TestStateSet_StoresPaneID(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	if err := d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%12"); err != nil {
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	if err := d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}
-	st, _ := d.StateByTarget("s:0.0")
+	st, _ := d.StateByID(target)
 	if st == nil {
 		t.Fatal("expected state, got nil")
 	}
-	if st.PaneID != "%12" {
-		t.Errorf("expected PaneID %%12, got %q", st.PaneID)
+	if st.Target.PaneID != "%1" {
+		t.Errorf("expected PaneID %%1, got %q", st.Target.PaneID)
 	}
 }
 
-func TestStateSet_PaneIDPreservedOnUpdate(t *testing.T) {
+func TestStateSet_PreservesSessionWindowPaneIDs(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%12")
-	// Update with empty pane_id — existing value must be kept.
-	d.StateSet("s:0.0", "claude", StateDone, "done", SourceTool, true, nil, "")
-
-	st, _ := d.StateByTarget("s:0.0")
+	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	if err := d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := d.StateByID(target)
 	if st == nil {
 		t.Fatal("expected state, got nil")
 	}
-	if st.PaneID != "%12" {
-		t.Errorf("pane_id should be preserved when update passes empty string, got %q", st.PaneID)
+	if st.Target.SessionID != "$0" {
+		t.Errorf("expected SessionID $0, got %q", st.Target.SessionID)
+	}
+	if st.Target.WindowID != "@0" {
+		t.Errorf("expected WindowID @0, got %q", st.Target.WindowID)
+	}
+	if st.Target.PaneID != "%1" {
+		t.Errorf("expected PaneID %%1, got %q", st.Target.PaneID)
 	}
 }
 
-func TestStateSet_EmptyPaneID(t *testing.T) {
+func TestStateSet_EmptySessionWindowPaneIDs(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	if err := d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, ""); err != nil {
+	// Session target has no WindowID or PaneID
+	target := Target{Type: "session", ID: "$0", SessionID: "$0"}
+	if err := d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}
-	st, _ := d.StateByTarget("s:0.0")
+	st, _ := d.StateByID(target)
 	if st == nil {
 		t.Fatal("expected state, got nil")
 	}
-	if st.PaneID != "" {
-		t.Errorf("expected empty PaneID, got %q", st.PaneID)
+	if st.Target.WindowID != "" {
+		t.Errorf("expected empty WindowID, got %q", st.Target.WindowID)
 	}
-}
-
-func TestStateSet_UpdatesTargetWhenPaneMoved(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	// Pane %5 was at work:0.0.
-	d.StateSet("work:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%5")
-
-	// Pane %5 has moved to work:1.0 — new state set with new target.
-	if err := d.StateSet("work:1.0", "claude", StateDone, "done", SourceTool, true, nil, "%5"); err != nil {
-		t.Fatalf("StateSet for moved pane should succeed: %v", err)
-	}
-
-	// Old target must be gone.
-	st0, _ := d.StateByTarget("work:0.0")
-	if st0 != nil {
-		t.Errorf("old target should be deleted when pane moves, got: %+v", st0)
-	}
-
-	// New target must have the state.
-	st1, _ := d.StateByTarget("work:1.0")
-	if st1 == nil || st1.Value != StateDone {
-		t.Errorf("new target should have done state, got: %+v", st1)
-	}
-	if st1.PaneID != "%5" {
-		t.Errorf("new record should carry pane_id %%5, got %q", st1.PaneID)
-	}
-}
-
-func TestStateSet_NoStaleDeleteWhenTargetUnchanged(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	d.StateSet("work:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%5")
-	// Same target — should update in place without deleting/re-inserting.
-	if err := d.StateSet("work:0.0", "claude", StateDone, "done", SourceTool, true, nil, "%5"); err != nil {
-		t.Fatal(err)
-	}
-	st, _ := d.StateByTarget("work:0.0")
-	if st == nil || st.Value != StateDone {
-		t.Errorf("same-target update should work, got: %+v", st)
-	}
-}
-
-func TestStateSet_NoopDoesNotSkipStalePaneDelete(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	// Pane %5 was at work:0.0.
-	d.StateSet("work:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%5")
-	// work:1.0 already has a legacy record with the same (tool, value) — the
-	// no-op short-circuit would previously exit before reaching the stale-delete.
-	d.StateSet("work:1.0", "claude", StateWorking, "running", SourceTool, false, nil, "")
-
-	// Pane %5 has moved to work:1.0; same (tool, value) as the guard would trigger.
-	if err := d.StateSet("work:1.0", "claude", StateWorking, "still running", SourceTool, false, nil, "%5"); err != nil {
-		t.Fatalf("StateSet should succeed: %v", err)
-	}
-
-	// Stale record must be deleted even though the value did not change.
-	if st, _ := d.StateByTarget("work:0.0"); st != nil {
-		t.Errorf("stale pane record at work:0.0 should be deleted, got: %+v", st)
-	}
-	// New target must have the state.
-	if st, _ := d.StateByTarget("work:1.0"); st == nil || st.PaneID != "%5" {
-		t.Errorf("work:1.0 should carry pane_id %%5, got: %+v", st)
-	}
-}
-
-func TestStateDeleteIfRestingByPaneID_DeletesDone(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	d.StateSet("s:0.0", "claude", StateDone, "finished", SourceTool, false, nil, "%7")
-	if err := d.StateDeleteIfRestingByPaneID("%7"); err != nil {
-		t.Fatal(err)
-	}
-	st, _ := d.StateByTarget("s:0.0")
-	if st != nil {
-		t.Errorf("done state should be deleted by pane_id, got: %+v", st)
-	}
-}
-
-func TestStateDeleteIfRestingByPaneID_DeletesIdle(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	d.StateSet("s:0.0", "claude", StateIdle, "available", SourceTool, false, nil, "%7")
-	d.StateDeleteIfRestingByPaneID("%7")
-	st, _ := d.StateByTarget("s:0.0")
-	if st != nil {
-		t.Errorf("idle state should be deleted by pane_id, got: %+v", st)
-	}
-}
-
-func TestStateDeleteIfRestingByPaneID_PreservesWorking(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	d.StateSet("s:0.0", "claude", StateWorking, "running", SourceTool, false, nil, "%7")
-	d.StateDeleteIfRestingByPaneID("%7")
-	st, _ := d.StateByTarget("s:0.0")
-	if st == nil {
-		t.Error("working state should survive StateDeleteIfRestingByPaneID")
-	}
-}
-
-func TestStateDeleteIfRestingByPaneID_NoopWhenNotFound(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	if err := d.StateDeleteIfRestingByPaneID("%99"); err != nil {
-		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
-	}
-}
-
-func TestStateDeleteBySessionWithPaneIDs_EmptyPaneIDs(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	d.StateSet("myapp:0.0", "claude", StateWorking, "", SourceTool, false, nil, "%5")
-	d.StateSet("myapp:1.0", "make", StateDone, "", SourceTool, false, nil, "%6")
-	d.StateSet("other:0.0", "claude", StateDone, "", SourceTool, false, nil, "%7")
-
-	// nil paneIDs — should behave identically to StateDeleteBySession.
-	n, err := d.StateDeleteBySessionWithPaneIDs("myapp", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 2 {
-		t.Errorf("expected 2 deleted, got %d", n)
-	}
-	if st, _ := d.StateByTarget("myapp:0.0"); st != nil {
-		t.Error("myapp:0.0 should be deleted")
-	}
-	if st, _ := d.StateByTarget("other:0.0"); st == nil {
-		t.Error("unrelated session should survive")
-	}
-}
-
-func TestStateDeleteBySessionWithPaneIDs_DeletesByPaneIDs(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	// Record whose target no longer has the session prefix (pane moved).
-	d.StateSet("other:0.0", "claude", StateWorking, "", SourceTool, false, nil, "%7")
-	// Normal record.
-	d.StateSet("myapp:0.0", "claude", StateWorking, "", SourceTool, false, nil, "%8")
-	// Unrelated session.
-	d.StateSet("other:1.0", "make", StateDone, "", SourceTool, false, nil, "%9")
-
-	// %7 and %8 belong to "myapp" per live tmux.
-	n, err := d.StateDeleteBySessionWithPaneIDs("myapp", []string{"%7", "%8"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 2 {
-		t.Errorf("expected 2 deleted, got %d", n)
-	}
-
-	if st, _ := d.StateByTarget("other:0.0"); st != nil {
-		t.Error("stale-target record with matching pane_id should be deleted")
-	}
-	if st, _ := d.StateByTarget("other:1.0"); st == nil {
-		t.Error("unrelated pane should survive")
+	if st.Target.PaneID != "" {
+		t.Errorf("expected empty PaneID, got %q", st.Target.PaneID)
 	}
 }

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -30,7 +30,7 @@ func TestStateSet_BasicUpsert(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	if err := d.StateSet(target, "claude", StateWorking, "running tests", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestStateSet_LockWorking_DifferentTool(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil)
 	err := d.StateSet(target, "make", StateWorking, "", SourceTool, false, nil)
 	if err == nil {
@@ -67,7 +67,7 @@ func TestStateSet_LockWorking_SameTool(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	d.StateSet(target, "claude", StateWorking, "step 1", SourceTool, false, nil)
 	if err := d.StateSet(target, "claude", StateWorking, "step 2", SourceTool, false, nil); err != nil {
 		t.Errorf("same tool should not be locked: %v", err)
@@ -78,7 +78,7 @@ func TestStateSet_LockFlagged_BlocksAllTools(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	d.StateSet(target, "", StateFlagged, "come back", SourceUser, false, nil)
 	// same tool name should still be blocked
 	if err := d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil); err == nil {
@@ -90,7 +90,7 @@ func TestStateSet_ForceOverridesLock(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	// Flagged blocks tool writes normally.
 	d.StateSet(target, "", StateFlagged, "come back", SourceUser, false, nil)
 	if err := d.StateSet(target, "claude", StateWorking, "", SourceTool, true, nil); err != nil {
@@ -108,7 +108,7 @@ func TestStateSet_UserWriteAlwaysSucceeds(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil)
 	if err := d.StateSet(target, "", StateFlagged, "note", SourceUser, false, nil); err != nil {
 		t.Errorf("user write should always succeed: %v", err)
@@ -119,7 +119,7 @@ func TestStateClear(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	d.StateSet(target, "claude", StateError, "boom", SourceTool, false, nil)
 	if err := d.StateClear(target); err != nil {
 		t.Fatal(err)
@@ -130,36 +130,12 @@ func TestStateClear(t *testing.T) {
 	}
 }
 
-func TestStateDeleteIfDone(t *testing.T) {
-	d, _ := Open(":memory:")
-	defer d.Close()
-
-	target1 := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
-	d.StateSet(target1, "claude", StateDone, "finished", SourceTool, false, nil)
-	if err := d.StateDeleteIfDone(target1); err != nil {
-		t.Fatal(err)
-	}
-	st, _ := d.StateByID(target1)
-	if st != nil {
-		t.Errorf("expected done state deleted, got: %+v", st)
-	}
-
-	// non-done states must not be deleted
-	target2 := Target{Type: "pane", ID: "%2", SessionID: "$0", WindowID: "@0", PaneID: "%2"}
-	d.StateSet(target2, "claude", StateError, "boom", SourceTool, false, nil)
-	d.StateDeleteIfDone(target2)
-	st2, _ := d.StateByID(target2)
-	if st2 == nil {
-		t.Error("non-done state should not be deleted by StateDeleteIfDone")
-	}
-}
-
 func TestStateDeleteIfResting(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
 	// done is cleared
-	target1 := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target1 := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	d.StateSet(target1, "claude", StateDone, "finished", SourceTool, false, nil)
 	d.StateDeleteIfResting(target1)
 	st, _ := d.StateByID(target1)
@@ -168,7 +144,7 @@ func TestStateDeleteIfResting(t *testing.T) {
 	}
 
 	// idle is cleared
-	target2 := Target{Type: "pane", ID: "%2", SessionID: "$0", WindowID: "@0", PaneID: "%2"}
+	target2 := Target{Type: TargetTypePane, ID: "%2", SessionID: "$0", WindowID: "@0", PaneID: "%2"}
 	d.StateSet(target2, "claude", StateIdle, "available", SourceTool, false, nil)
 	d.StateDeleteIfResting(target2)
 	st2, _ := d.StateByID(target2)
@@ -177,7 +153,7 @@ func TestStateDeleteIfResting(t *testing.T) {
 	}
 
 	// working is not cleared
-	target3 := Target{Type: "pane", ID: "%3", SessionID: "$0", WindowID: "@0", PaneID: "%3"}
+	target3 := Target{Type: TargetTypePane, ID: "%3", SessionID: "$0", WindowID: "@0", PaneID: "%3"}
 	d.StateSet(target3, "claude", StateWorking, "running", SourceTool, false, nil)
 	d.StateDeleteIfResting(target3)
 	st3, _ := d.StateByID(target3)
@@ -186,7 +162,7 @@ func TestStateDeleteIfResting(t *testing.T) {
 	}
 
 	// error is not cleared
-	target4 := Target{Type: "pane", ID: "%4", SessionID: "$0", WindowID: "@0", PaneID: "%4"}
+	target4 := Target{Type: TargetTypePane, ID: "%4", SessionID: "$0", WindowID: "@0", PaneID: "%4"}
 	d.StateSet(target4, "claude", StateError, "boom", SourceTool, false, nil)
 	d.StateDeleteIfResting(target4)
 	st4, _ := d.StateByID(target4)
@@ -199,8 +175,8 @@ func TestStateList(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	t1 := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
-	t2 := Target{Type: "pane", ID: "%2", SessionID: "$0", WindowID: "@0", PaneID: "%2"}
+	t1 := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	t2 := Target{Type: TargetTypePane, ID: "%2", SessionID: "$0", WindowID: "@0", PaneID: "%2"}
 	d.StateSet(t1, "claude", StateWorking, "", SourceTool, false, nil)
 	d.StateSet(t2, "make", StateError, "fail", SourceTool, false, nil)
 
@@ -235,7 +211,7 @@ func TestStateIdle_SetAndRetrieve(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	if err := d.StateSet(target, "claude", StateIdle, "available", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +225,7 @@ func TestStateSet_IfState_NoopWhenMismatch(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	// Set to done.
 	d.StateSet(target, "claude", StateDone, "finished", SourceTool, false, nil)
 
@@ -270,7 +246,7 @@ func TestStateSet_IfState_WritesWhenMatch(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, nil)
 
 	ifWorking := StateWorking
@@ -287,7 +263,7 @@ func TestStateSet_IfState_NoopWhenNoRow(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	// No row exists. Passing ifState=StateIdle (6) should be a no-op because
 	// a missing row is treated as StateValue(0), not StateIdle.
 	ifIdle := StateIdle
@@ -305,8 +281,8 @@ func TestStateGCOrphaned_DeletesByType(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	pane1 := Target{Type: "pane", ID: "%12", SessionID: "$0", WindowID: "@0", PaneID: "%12"}
-	pane2 := Target{Type: "pane", ID: "%13", SessionID: "$0", WindowID: "@0", PaneID: "%13"}
+	pane1 := Target{Type: TargetTypePane, ID: "%12", SessionID: "$0", WindowID: "@0", PaneID: "%12"}
+	pane2 := Target{Type: TargetTypePane, ID: "%13", SessionID: "$0", WindowID: "@0", PaneID: "%13"}
 	d.StateSet(pane1, "claude", StateWorking, "", SourceTool, false, nil)
 	d.StateSet(pane2, "claude", StateWorking, "", SourceTool, false, nil)
 
@@ -334,8 +310,8 @@ func TestStateGCOrphaned_DeletesWindows(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	win1 := Target{Type: "window", ID: "@5", SessionID: "$0", WindowID: "@5"}
-	win2 := Target{Type: "window", ID: "@6", SessionID: "$0", WindowID: "@6"}
+	win1 := Target{Type: TargetTypeWindow, ID: "@5", SessionID: "$0", WindowID: "@5"}
+	win2 := Target{Type: TargetTypeWindow, ID: "@6", SessionID: "$0", WindowID: "@6"}
 	d.StateSet(win1, "claude", StateWorking, "", SourceTool, false, nil)
 	d.StateSet(win2, "claude", StateWorking, "", SourceTool, false, nil)
 
@@ -363,8 +339,8 @@ func TestStateGCOrphaned_DeletesSessions(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	sess1 := Target{Type: "session", ID: "$1", SessionID: "$1"}
-	sess2 := Target{Type: "session", ID: "$2", SessionID: "$2"}
+	sess1 := Target{Type: TargetTypeSession, ID: "$1", SessionID: "$1"}
+	sess2 := Target{Type: TargetTypeSession, ID: "$2", SessionID: "$2"}
 	d.StateSet(sess1, "claude", StateWorking, "", SourceTool, false, nil)
 	d.StateSet(sess2, "claude", StateWorking, "", SourceTool, false, nil)
 
@@ -388,13 +364,42 @@ func TestStateGCOrphaned_DeletesSessions(t *testing.T) {
 	}
 }
 
+func TestStateGCOrphaned_EmptyLiveSetsDeleteAll(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	pane := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	win := Target{Type: TargetTypeWindow, ID: "@1", SessionID: "$0", WindowID: "@1"}
+	d.StateSet(pane, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(win, "claude", StateWorking, "", SourceTool, false, nil)
+
+	// All live sets empty: every record should be deleted.
+	n, err := d.StateGCOrphaned(
+		map[string]bool{},
+		map[string]bool{},
+		map[string]bool{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2 deleted, got %d", n)
+	}
+	if st, _ := d.StateByID(pane); st != nil {
+		t.Error("pane record should be deleted when live pane set is empty")
+	}
+	if st, _ := d.StateByID(win); st != nil {
+		t.Error("window record should be deleted when live window set is empty")
+	}
+}
+
 func TestStateDeleteBySession_DeletesAll(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	t1 := Target{Type: "pane", ID: "%5", SessionID: "$0", WindowID: "@0", PaneID: "%5"}
-	t2 := Target{Type: "pane", ID: "%6", SessionID: "$0", WindowID: "@0", PaneID: "%6"}
-	t3 := Target{Type: "pane", ID: "%7", SessionID: "$1", WindowID: "@1", PaneID: "%7"}
+	t1 := Target{Type: TargetTypePane, ID: "%5", SessionID: "$0", WindowID: "@0", PaneID: "%5"}
+	t2 := Target{Type: TargetTypePane, ID: "%6", SessionID: "$0", WindowID: "@0", PaneID: "%6"}
+	t3 := Target{Type: TargetTypePane, ID: "%7", SessionID: "$1", WindowID: "@1", PaneID: "%7"}
 
 	d.StateSet(t1, "claude", StateWorking, "", SourceTool, false, nil)
 	d.StateSet(t2, "make", StateDone, "", SourceTool, false, nil)
@@ -423,7 +428,7 @@ func TestStateSet_StoresPaneID(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	if err := d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +445,7 @@ func TestStateSet_PreservesSessionWindowPaneIDs(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()
 
-	target := Target{Type: "pane", ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
 	if err := d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -464,7 +469,7 @@ func TestStateSet_EmptySessionWindowPaneIDs(t *testing.T) {
 	defer d.Close()
 
 	// Session target has no WindowID or PaneID
-	target := Target{Type: "session", ID: "$0", SessionID: "$0"}
+	target := Target{Type: TargetTypeSession, ID: "$0", SessionID: "$0"}
 	if err := d.StateSet(target, "claude", StateWorking, "running", SourceTool, false, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/db/target_test.go
+++ b/internal/db/target_test.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestParseTargetID_Pane(t *testing.T) {
+	target, err := ParseTargetID("%12")
+	if err != nil {
+		t.Fatalf("ParseTargetID(%q) failed: %v", "%12", err)
+	}
+	if target.Type != "pane" {
+		t.Errorf("type: want pane, got %q", target.Type)
+	}
+	if target.ID != "%12" {
+		t.Errorf("ID: want %%12, got %q", target.ID)
+	}
+	if target.PaneID != "%12" {
+		t.Errorf("PaneID: want %%12, got %q", target.PaneID)
+	}
+}
+
+func TestParseTargetID_Window(t *testing.T) {
+	target, err := ParseTargetID("@5")
+	if err != nil {
+		t.Fatalf("ParseTargetID(%q) failed: %v", "@5", err)
+	}
+	if target.Type != "window" {
+		t.Errorf("type: want window, got %q", target.Type)
+	}
+	if target.ID != "@5" {
+		t.Errorf("ID: want @5, got %q", target.ID)
+	}
+	if target.WindowID != "@5" {
+		t.Errorf("WindowID: want @5, got %q", target.WindowID)
+	}
+}
+
+func TestParseTargetID_Session(t *testing.T) {
+	target, err := ParseTargetID("$1")
+	if err != nil {
+		t.Fatalf("ParseTargetID(%q) failed: %v", "$1", err)
+	}
+	if target.Type != "session" {
+		t.Errorf("type: want session, got %q", target.Type)
+	}
+	if target.ID != "$1" {
+		t.Errorf("ID: want $1, got %q", target.ID)
+	}
+	if target.SessionID != "$1" {
+		t.Errorf("SessionID: want $1, got %q", target.SessionID)
+	}
+}
+
+func TestParseTargetID_InvalidPrefix(t *testing.T) {
+	_, err := ParseTargetID("invalid")
+	if err == nil {
+		t.Error("ParseTargetID(invalid) should fail")
+	}
+}
+
+func TestParseTargetID_EmptyID(t *testing.T) {
+	_, err := ParseTargetID("")
+	if err == nil {
+		t.Error("ParseTargetID() should fail on empty string")
+	}
+}

--- a/internal/db/target_test.go
+++ b/internal/db/target_test.go
@@ -65,3 +65,62 @@ func TestParseTargetID_EmptyID(t *testing.T) {
 		t.Error("ParseTargetID() should fail on empty string")
 	}
 }
+
+func TestTargetFormat_Pane(t *testing.T) {
+	target := Target{Type: TargetTypePane, ID: "%3"}
+	paneMap := map[string]string{"%3": "mySession:1.0"}
+	got := target.Format(paneMap, nil, nil)
+	if got != "win1·p0" {
+		t.Errorf("Format() = %q, want %q", got, "win1·p0")
+	}
+}
+
+func TestTargetFormat_Pane_FallbackToRawID(t *testing.T) {
+	target := Target{Type: TargetTypePane, ID: "%3"}
+	got := target.Format(nil, nil, nil)
+	if got != "%3" {
+		t.Errorf("Format() = %q, want %q", got, "%3")
+	}
+}
+
+func TestTargetFormat_Window(t *testing.T) {
+	target := Target{Type: TargetTypeWindow, ID: "@2"}
+	windowMap := map[string]string{"@2": "mySession:3"}
+	got := target.Format(nil, windowMap, nil)
+	if got != "win3" {
+		t.Errorf("Format() = %q, want %q", got, "win3")
+	}
+}
+
+func TestTargetFormat_Window_FallbackToRawID(t *testing.T) {
+	target := Target{Type: TargetTypeWindow, ID: "@2"}
+	got := target.Format(nil, nil, nil)
+	if got != "@2" {
+		t.Errorf("Format() = %q, want %q", got, "@2")
+	}
+}
+
+func TestTargetFormat_Session(t *testing.T) {
+	target := Target{Type: TargetTypeSession, ID: "$1"}
+	sessionMap := map[string]string{"$1": "mySession"}
+	got := target.Format(nil, nil, sessionMap)
+	if got != "mySession" {
+		t.Errorf("Format() = %q, want %q", got, "mySession")
+	}
+}
+
+func TestTargetFormat_Session_FallbackToRawID(t *testing.T) {
+	target := Target{Type: TargetTypeSession, ID: "$1"}
+	got := target.Format(nil, nil, nil)
+	if got != "$1" {
+		t.Errorf("Format() = %q, want %q", got, "$1")
+	}
+}
+
+func TestTargetFormat_UnknownType(t *testing.T) {
+	target := Target{Type: "bogus", ID: "xyz"}
+	got := target.Format(nil, nil, nil)
+	if got != "xyz" {
+		t.Errorf("Format() = %q, want raw ID %q for unknown type", got, "xyz")
+	}
+}

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -8,9 +8,27 @@ import (
 	"time"
 )
 
+// Session represents a tmux session.
+type Session struct {
+	ID       string // e.g. $1
+	Name     string
+	Activity time.Time
+}
+
+// Window represents a tmux window.
+type Window struct {
+	ID          string // e.g. @5
+	SessionID   string // e.g. $1
+	Session     string
+	WindowIndex int
+	Name        string
+}
+
 type Pane struct {
 	Session         string
+	SessionID       string // $N — new
 	WindowIndex     int
+	WindowID        string // @N — new
 	PaneIndex       int
 	CWD             string
 	PaneID          string // e.g. %12
@@ -27,7 +45,7 @@ func (p Pane) Target() string {
 // ListPanes runs tmux list-panes and returns all panes across all sessions.
 func ListPanes() ([]Pane, error) {
 	out, err := exec.Command("tmux", "list-panes", "-a",
-		"-F", "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_current_path}\t#{pane_id}\t#{window_name}\t#{pane_pid}\t#{session_activity}",
+		"-F", "#{session_name}\t#{session_id}\t#{window_index}\t#{window_id}\t#{pane_index}\t#{pane_current_path}\t#{pane_id}\t#{window_name}\t#{pane_pid}\t#{session_activity}",
 	).Output()
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes: %w", err)
@@ -43,30 +61,32 @@ func ParsePanes(raw string) ([]Pane, error) {
 			continue
 		}
 		parts := strings.Split(line, "\t")
-		if len(parts) < 4 {
+		if len(parts) < 5 {
 			continue
 		}
-		wi, _ := strconv.Atoi(parts[1])
-		pi, _ := strconv.Atoi(parts[2])
+		wi, _ := strconv.Atoi(parts[2])
+		pi, _ := strconv.Atoi(parts[4])
 		p := Pane{
 			Session:     parts[0],
+			SessionID:   parts[1],
 			WindowIndex: wi,
+			WindowID:    parts[3],
 			PaneIndex:   pi,
-			CWD:         parts[3],
-		}
-		if len(parts) >= 5 {
-			p.PaneID = parts[4]
-		}
-		if len(parts) >= 6 {
-			p.WindowName = parts[5]
+			CWD:         parts[5],
 		}
 		if len(parts) >= 7 {
-			if pid, err := strconv.ParseInt(strings.TrimSpace(parts[6]), 10, 32); err == nil {
+			p.PaneID = parts[6]
+		}
+		if len(parts) >= 8 {
+			p.WindowName = parts[7]
+		}
+		if len(parts) >= 9 {
+			if pid, err := strconv.ParseInt(strings.TrimSpace(parts[8]), 10, 32); err == nil {
 				p.PanePID = int32(pid)
 			}
 		}
-		if len(parts) >= 8 {
-			if ts, err := strconv.ParseInt(strings.TrimSpace(parts[7]), 10, 64); err == nil {
+		if len(parts) >= 10 {
+			if ts, err := strconv.ParseInt(strings.TrimSpace(parts[9]), 10, 64); err == nil {
 				p.SessionActivity = ts
 			}
 		}
@@ -144,6 +164,30 @@ func PaneIDToTargetMap(panes []Pane) map[string]string {
 	for _, p := range panes {
 		if p.PaneID != "" {
 			m[p.PaneID] = p.Target()
+		}
+	}
+	return m
+}
+
+// WindowIDToTargetMap returns a map from window_id (@N) to "session:windowIndex"
+// for all panes with a non-empty WindowID in the provided slice.
+func WindowIDToTargetMap(panes []Pane) map[string]string {
+	m := make(map[string]string, len(panes))
+	for _, p := range panes {
+		if p.WindowID != "" {
+			m[p.WindowID] = fmt.Sprintf("%s:%d", p.Session, p.WindowIndex)
+		}
+	}
+	return m
+}
+
+// SessionIDToNameMap returns a map from session_id ($N) to session_name
+// for all panes with a non-empty SessionID in the provided slice.
+func SessionIDToNameMap(panes []Pane) map[string]string {
+	m := make(map[string]string, len(panes))
+	for _, p := range panes {
+		if p.SessionID != "" && m[p.SessionID] == "" {
+			m[p.SessionID] = p.Session
 		}
 	}
 	return m

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -37,8 +37,8 @@ type Pane struct {
 	SessionActivity int64 // Unix timestamp from #{session_activity}
 }
 
-// Target returns the "session:windowIndex.paneIndex" string used as a human-readable display label.
-func (p Pane) Target() string {
+// DisplayLabel returns the "session:windowIndex.paneIndex" string used as a human-readable display label.
+func (p Pane) DisplayLabel() string {
 	return fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)
 }
 
@@ -163,7 +163,7 @@ func PaneIDToTargetMap(panes []Pane) map[string]string {
 	m := make(map[string]string, len(panes))
 	for _, p := range panes {
 		if p.PaneID != "" {
-			m[p.PaneID] = p.Target()
+			m[p.PaneID] = p.DisplayLabel()
 		}
 	}
 	return m
@@ -188,6 +188,18 @@ func SessionIDToNameMap(panes []Pane) map[string]string {
 	for _, p := range panes {
 		if p.SessionID != "" && m[p.SessionID] == "" {
 			m[p.SessionID] = p.Session
+		}
+	}
+	return m
+}
+
+// SessionNameToIDMap returns a map from session_name to session_id ($N)
+// for all panes with a non-empty SessionID in the provided slice.
+func SessionNameToIDMap(panes []Pane) map[string]string {
+	m := make(map[string]string, len(panes))
+	for _, p := range panes {
+		if p.SessionID != "" && m[p.Session] == "" {
+			m[p.Session] = p.SessionID
 		}
 	}
 	return m

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -37,7 +37,7 @@ type Pane struct {
 	SessionActivity int64 // Unix timestamp from #{session_activity}
 }
 
-// Target returns the "session:windowIndex.paneIndex" target string used as a demux state key.
+// Target returns the "session:windowIndex.paneIndex" string used as a human-readable display label.
 func (p Pane) Target() string {
 	return fmt.Sprintf("%s:%d.%d", p.Session, p.WindowIndex, p.PaneIndex)
 }
@@ -157,7 +157,7 @@ func SwitchClient(target string) error {
 	return exec.Command("tmux", "switch-client", "-t", target).Run()
 }
 
-// PaneIDToTargetMap returns a map from pane_id (%N) to "session:windowIndex.paneIndex"
+// PaneIDToTargetMap returns a map from pane_id (%N) to display label "session:windowIndex.paneIndex"
 // for all panes with a non-empty PaneID in the provided slice.
 func PaneIDToTargetMap(panes []Pane) map[string]string {
 	m := make(map[string]string, len(panes))
@@ -169,7 +169,7 @@ func PaneIDToTargetMap(panes []Pane) map[string]string {
 	return m
 }
 
-// WindowIDToTargetMap returns a map from window_id (@N) to "session:windowIndex"
+// WindowIDToTargetMap returns a map from window_id (@N) to display label "session:windowIndex"
 // for all panes with a non-empty WindowID in the provided slice.
 func WindowIDToTargetMap(panes []Pane) map[string]string {
 	m := make(map[string]string, len(panes))

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -8,22 +8,6 @@ import (
 	"time"
 )
 
-// Session represents a tmux session.
-type Session struct {
-	ID       string // e.g. $1
-	Name     string
-	Activity time.Time
-}
-
-// Window represents a tmux window.
-type Window struct {
-	ID          string // e.g. @5
-	SessionID   string // e.g. $1
-	Session     string
-	WindowIndex int
-	Name        string
-}
-
 type Pane struct {
 	Session         string
 	SessionID       string // $N — new
@@ -61,7 +45,7 @@ func ParsePanes(raw string) ([]Pane, error) {
 			continue
 		}
 		parts := strings.Split(line, "\t")
-		if len(parts) < 5 {
+		if len(parts) < 6 {
 			continue
 		}
 		wi, _ := strconv.Atoi(parts[2])

--- a/internal/tmux/query_test.go
+++ b/internal/tmux/query_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 func TestParsePanes(t *testing.T) {
-	raw := "mysession\t0\t0\t/home/dev/project\t%1\teditor\n" +
-		"mysession\t0\t1\t/home/dev/project/ui\t%2\teditor\n" +
-		"mysession\t1\t0\t/home/dev/project\t%3\tserver\n"
+	// 10 fields: session_name, session_id, window_index, window_id, pane_index, cwd, pane_id, window_name, pane_pid, session_activity
+	raw := "mysession\t$1\t0\t@5\t0\t/home/dev/project\t%1\teditor\t1234\t1711652000\n" +
+		"mysession\t$1\t0\t@5\t1\t/home/dev/project/ui\t%2\teditor\t1235\t1711652000\n" +
+		"mysession\t$1\t1\t@6\t0\t/home/dev/project\t%3\tserver\t1236\t1711652000\n"
 
 	panes, err := tmux.ParsePanes(raw)
 	if err != nil {
@@ -20,6 +21,12 @@ func TestParsePanes(t *testing.T) {
 	}
 	if panes[0].Session != "mysession" {
 		t.Errorf("unexpected session: %s", panes[0].Session)
+	}
+	if panes[0].SessionID != "$1" {
+		t.Errorf("unexpected session id: %s", panes[0].SessionID)
+	}
+	if panes[0].WindowID != "@5" {
+		t.Errorf("unexpected window id: %s", panes[0].WindowID)
 	}
 	if panes[1].PaneIndex != 1 {
 		t.Errorf("unexpected pane index: %d", panes[1].PaneIndex)
@@ -69,8 +76,8 @@ func TestParsePanesEmpty(t *testing.T) {
 }
 
 func TestParsePanes_WithSessionActivity(t *testing.T) {
-	// 8 fields: session, window_index, pane_index, cwd, pane_id, window_name, pane_pid, session_activity
-	raw := "mysession\t0\t0\t/home/dev\t%1\teditor\t1234\t1711652000\n"
+	// 10 fields: session_name, session_id, window_index, window_id, pane_index, cwd, pane_id, window_name, pane_pid, session_activity
+	raw := "mysession\t$1\t0\t@5\t0\t/home/dev\t%1\teditor\t1234\t1711652000\n"
 	panes, err := tmux.ParsePanes(raw)
 	if err != nil {
 		t.Fatal(err)
@@ -84,8 +91,8 @@ func TestParsePanes_WithSessionActivity(t *testing.T) {
 }
 
 func TestParsePanes_WithoutSessionActivity_BackwardCompat(t *testing.T) {
-	// Old 7-field format (no session_activity) should still parse with SessionActivity=0
-	raw := "mysession\t0\t0\t/home/dev\t%1\teditor\t1234\n"
+	// 9-field format (no session_activity) should still parse with SessionActivity=0
+	raw := "mysession\t$1\t0\t@5\t0\t/home/dev\t%1\teditor\t1234\n"
 	panes, err := tmux.ParsePanes(raw)
 	if err != nil {
 		t.Fatal(err)
@@ -178,5 +185,42 @@ func TestPaneIDToTargetMap(t *testing.T) {
 	}
 	if _, ok := m[""]; ok {
 		t.Error("pane with empty PaneID should not appear in map")
+	}
+}
+
+func TestWindowIDToTargetMap(t *testing.T) {
+	panes := []tmux.Pane{
+		{Session: "work", WindowIndex: 0, WindowID: "@5", PaneIndex: 0, PaneID: "%1"},
+		{Session: "work", WindowIndex: 1, WindowID: "@6", PaneIndex: 0, PaneID: "%2"},
+		{Session: "other", WindowIndex: 0, WindowID: "@7", PaneIndex: 0, PaneID: "%3"},
+	}
+
+	m := tmux.WindowIDToTargetMap(panes)
+
+	if m["@5"] != "work:0" {
+		t.Errorf("@5: want work:0, got %q", m["@5"])
+	}
+	if m["@6"] != "work:1" {
+		t.Errorf("@6: want work:1, got %q", m["@6"])
+	}
+	if m["@7"] != "other:0" {
+		t.Errorf("@7: want other:0, got %q", m["@7"])
+	}
+}
+
+func TestSessionIDToNameMap(t *testing.T) {
+	panes := []tmux.Pane{
+		{Session: "work", SessionID: "$1", PaneID: "%1"},
+		{Session: "other", SessionID: "$2", PaneID: "%2"},
+		{Session: "work", SessionID: "$1", PaneID: "%3"},
+	}
+
+	m := tmux.SessionIDToNameMap(panes)
+
+	if m["$1"] != "work" {
+		t.Errorf("$1: want work, got %q", m["$1"])
+	}
+	if m["$2"] != "other" {
+		t.Errorf("$2: want other, got %q", m["$2"])
 	}
 }

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -146,41 +146,9 @@ func inlineStat(label, value string) string {
 }
 
 // targetDisplayStr returns a compact display string for a state target.
-// For pane targets, formats as "win{wi}·p{pi}" using the paneIDMap lookup.
-// For window targets, formats as "win{wi}" using the windowIDMap lookup.
-// For session targets, returns the session name from sessionIDMap.
-// Falls back to the raw target ID when no map entry exists.
+// Delegates to db.Target.Format using the provided display maps.
 func targetDisplayStr(t db.Target, paneIDMap, windowIDMap, sessionIDMap map[string]string) string {
-	switch t.Type {
-	case "pane":
-		if full := paneIDMap[t.ID]; full != "" {
-			if idx := strings.Index(full, ":"); idx >= 0 {
-				rest := full[idx+1:]
-				parts := strings.SplitN(rest, ".", 2)
-				if len(parts) == 2 {
-					return "win" + parts[0] + "·p" + parts[1]
-				}
-				return rest
-			}
-			return full
-		}
-		return t.ID
-	case "window":
-		if full := windowIDMap[t.ID]; full != "" {
-			if idx := strings.Index(full, ":"); idx >= 0 {
-				return "win" + full[idx+1:]
-			}
-			return full
-		}
-		return t.ID
-	case "session":
-		if name := sessionIDMap[t.ID]; name != "" {
-			return name
-		}
-		return t.ID
-	default:
-		return t.ID
-	}
+	return t.Format(paneIDMap, windowIDMap, sessionIDMap)
 }
 
 // renderStateSection builds detail lines for displayable states of the focused session.

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -145,12 +145,6 @@ func inlineStat(label, value string) string {
 	return detailLabelStyle.Width(0).Render(label+":") + " " + detailValueStyle.Render(value)
 }
 
-// targetDisplayStr returns a compact display string for a state target.
-// Delegates to db.Target.Format using the provided display maps.
-func targetDisplayStr(t db.Target, paneIDMap, windowIDMap, sessionIDMap map[string]string) string {
-	return t.Format(paneIDMap, windowIDMap, sessionIDMap)
-}
-
 // renderStateSection builds detail lines for displayable states of the focused session.
 // Returns nil when there are no states to show.
 func (d DetailModel) renderStateSection() []string {
@@ -167,14 +161,14 @@ func (d DetailModel) renderStateSection() []string {
 	}
 	// Sort by display string for stable ordering.
 	sort.Slice(active, func(i, j int) bool {
-		di := targetDisplayStr(active[i].Target, d.paneIDMap, d.windowIDMap, d.sessionIDMap)
-		dj := targetDisplayStr(active[j].Target, d.paneIDMap, d.windowIDMap, d.sessionIDMap)
+		di := active[i].Target.Format(d.paneIDMap, d.windowIDMap, d.sessionIDMap)
+		dj := active[j].Target.Format(d.paneIDMap, d.windowIDMap, d.sessionIDMap)
 		return di < dj
 	})
 	lines := []string{""}
 	for _, st := range active {
 		icon := stateIcon(st.Value)
-		target := targetDisplayStr(st.Target, d.paneIDMap, d.windowIDMap, d.sessionIDMap)
+		target := st.Target.Format(d.paneIDMap, d.windowIDMap, d.sessionIDMap)
 		tool := st.Tool
 		if tool == "" {
 			tool = "-"

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -46,6 +46,11 @@ type DetailModel struct {
 	// session states (non-idle states for the focused session)
 	sessionStates []db.ToolState
 
+	// display maps for resolving stable IDs to human-readable targets
+	paneIDMap    map[string]string // %N → "session:wi.pi"
+	windowIDMap  map[string]string // @N → "session:wi"
+	sessionIDMap map[string]string // $N → session_name
+
 	// window
 	windowIndex int
 	windowPanes []tmux.Pane
@@ -140,6 +145,44 @@ func inlineStat(label, value string) string {
 	return detailLabelStyle.Width(0).Render(label+":") + " " + detailValueStyle.Render(value)
 }
 
+// targetDisplayStr returns a compact display string for a state target.
+// For pane targets, formats as "win{wi}·p{pi}" using the paneIDMap lookup.
+// For window targets, formats as "win{wi}" using the windowIDMap lookup.
+// For session targets, returns the session name from sessionIDMap.
+// Falls back to the raw target ID when no map entry exists.
+func targetDisplayStr(t db.Target, paneIDMap, windowIDMap, sessionIDMap map[string]string) string {
+	switch t.Type {
+	case "pane":
+		if full := paneIDMap[t.ID]; full != "" {
+			if idx := strings.Index(full, ":"); idx >= 0 {
+				rest := full[idx+1:]
+				parts := strings.SplitN(rest, ".", 2)
+				if len(parts) == 2 {
+					return "win" + parts[0] + "·p" + parts[1]
+				}
+				return rest
+			}
+			return full
+		}
+		return t.ID
+	case "window":
+		if full := windowIDMap[t.ID]; full != "" {
+			if idx := strings.Index(full, ":"); idx >= 0 {
+				return "win" + full[idx+1:]
+			}
+			return full
+		}
+		return t.ID
+	case "session":
+		if name := sessionIDMap[t.ID]; name != "" {
+			return name
+		}
+		return t.ID
+	default:
+		return t.ID
+	}
+}
+
 // renderStateSection builds detail lines for displayable states of the focused session.
 // Returns nil when there are no states to show.
 func (d DetailModel) renderStateSection() []string {
@@ -154,20 +197,16 @@ func (d DetailModel) renderStateSection() []string {
 	if len(active) == 0 {
 		return nil
 	}
-	// Sort by target for stable ordering.
-	sort.Slice(active, func(i, j int) bool { return active[i].Target < active[j].Target })
+	// Sort by display string for stable ordering.
+	sort.Slice(active, func(i, j int) bool {
+		di := targetDisplayStr(active[i].Target, d.paneIDMap, d.windowIDMap, d.sessionIDMap)
+		dj := targetDisplayStr(active[j].Target, d.paneIDMap, d.windowIDMap, d.sessionIDMap)
+		return di < dj
+	})
 	lines := []string{""}
 	for _, st := range active {
 		icon := stateIcon(st.Value)
-		target := st.Target
-		// Strip session prefix: "mysess:1.0" → "win1·p0"
-		if prefix := d.session + ":"; strings.HasPrefix(target, prefix) {
-			rest := target[len(prefix):]
-			parts := strings.SplitN(rest, ".", 2)
-			if len(parts) == 2 {
-				target = "win" + parts[0] + "·p" + parts[1]
-			}
-		}
+		target := targetDisplayStr(st.Target, d.paneIDMap, d.windowIDMap, d.sessionIDMap)
 		tool := st.Tool
 		if tool == "" {
 			tool = "-"

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -103,6 +103,12 @@ type Model struct {
 	procs   []proc.Process
 	cwdMap  map[int32]string // PID -> CWD, pre-fetched async
 
+	// Display maps built from panes on every refresh.
+	paneIDMap    map[string]string // %N → "session:wi.pi"
+	windowIDMap  map[string]string // @N → "session:wi"
+	sessionIDMap map[string]string // $N → "session_name"
+	nameToIDMap  map[string]string // "session_name" → $N
+
 	sidebar  SidebarModel
 	procList ProcListModel
 	detail   DetailModel
@@ -298,7 +304,7 @@ func (m Model) buildProcTitle() string {
 		procTitleSuffix = "  "
 	}
 	title := " [l] " + bc + procTitleSuffix
-	if st := activeStateFor(m.states, bc); st != nil {
+	if st := m.sidebar.stateForSession(bc); st != nil {
 		effective := *st
 		effective.Value = ageDrivenValue(*st, m.cfg.Tui.DoneIdleAfterSecs)
 		title += paneSepStyle.Render("────") + "  " + paneStateIndicator(&effective) + " "

--- a/internal/tui/model_focus_test.go
+++ b/internal/tui/model_focus_test.go
@@ -83,7 +83,7 @@ func TestFocusSearchOnOpen_false(t *testing.T) {
 // before the panesMsg (the race introduced by fetching both in Init).
 func TestStateSession_StatesBeforePanes(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWaiting},
+		{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWaiting},
 	}
 	m := focusTestModel("state_session")
 	m.height = 40
@@ -108,7 +108,7 @@ func TestStateSession_StatesBeforePanes(t *testing.T) {
 // in handleStatesMsg once m.ready is true.
 func TestStateSession_PanesBeforeStates(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWaiting},
+		{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWaiting},
 	}
 	m := focusTestModel("state_session")
 	m.height = 40
@@ -130,7 +130,7 @@ func TestStateSession_PanesBeforeStates(t *testing.T) {
 // state priority on the first panes render when states arrived first.
 func TestStartupSort_StatesBeforePanes(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateError},
+		{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateError},
 	}
 	m := focusTestModel("")
 	m.height = 40

--- a/internal/tui/model_focus_test.go
+++ b/internal/tui/model_focus_test.go
@@ -18,9 +18,9 @@ func focusTestModel(focusOnOpen string) Model {
 
 func applyPanesMsg(m Model, currentSession string) (Model, tea.Cmd) {
 	panes := []tmux.Pane{
-		{Session: "alpha", WindowIndex: 0},
-		{Session: "alpha", WindowIndex: 1},
-		{Session: "beta", WindowIndex: 0},
+		{Session: "alpha", SessionID: "$1", WindowIndex: 0},
+		{Session: "alpha", SessionID: "$1", WindowIndex: 1},
+		{Session: "beta", SessionID: "$2", WindowIndex: 0},
 	}
 	msg := panesMsg{panes: panes, currentSession: currentSession}
 	updated, cmd := m.Update(msg)
@@ -83,7 +83,7 @@ func TestFocusSearchOnOpen_false(t *testing.T) {
 // before the panesMsg (the race introduced by fetching both in Init).
 func TestStateSession_StatesBeforePanes(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWaiting},
+		{Target: db.Target{Type: db.TargetTypeSession, ID: "$2", SessionID: "$2"}, Value: db.StateWaiting},
 	}
 	m := focusTestModel("state_session")
 	m.height = 40
@@ -108,7 +108,7 @@ func TestStateSession_StatesBeforePanes(t *testing.T) {
 // in handleStatesMsg once m.ready is true.
 func TestStateSession_PanesBeforeStates(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWaiting},
+		{Target: db.Target{Type: db.TargetTypeSession, ID: "$2", SessionID: "$2"}, Value: db.StateWaiting},
 	}
 	m := focusTestModel("state_session")
 	m.height = 40
@@ -130,7 +130,7 @@ func TestStateSession_PanesBeforeStates(t *testing.T) {
 // state priority on the first panes render when states arrived first.
 func TestStartupSort_StatesBeforePanes(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateError},
+		{Target: db.Target{Type: db.TargetTypeSession, ID: "$2", SessionID: "$2"}, Value: db.StateError},
 	}
 	m := focusTestModel("")
 	m.height = 40

--- a/internal/tui/model_focus_test.go
+++ b/internal/tui/model_focus_test.go
@@ -83,7 +83,7 @@ func TestFocusSearchOnOpen_false(t *testing.T) {
 // before the panesMsg (the race introduced by fetching both in Init).
 func TestStateSession_StatesBeforePanes(t *testing.T) {
 	states := []db.ToolState{
-		{Target: "beta", Value: db.StateWaiting},
+		{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWaiting},
 	}
 	m := focusTestModel("state_session")
 	m.height = 40
@@ -108,7 +108,7 @@ func TestStateSession_StatesBeforePanes(t *testing.T) {
 // in handleStatesMsg once m.ready is true.
 func TestStateSession_PanesBeforeStates(t *testing.T) {
 	states := []db.ToolState{
-		{Target: "beta", Value: db.StateWaiting},
+		{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWaiting},
 	}
 	m := focusTestModel("state_session")
 	m.height = 40
@@ -130,7 +130,7 @@ func TestStateSession_PanesBeforeStates(t *testing.T) {
 // state priority on the first panes render when states arrived first.
 func TestStartupSort_StatesBeforePanes(t *testing.T) {
 	states := []db.ToolState{
-		{Target: "beta", Value: db.StateError},
+		{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateError},
 	}
 	m := focusTestModel("")
 	m.height = 40

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -437,7 +437,7 @@ func (m Model) handleProcListCollapse(msg tea.KeyMsg, procH int) (Model, tea.Cmd
 func (m Model) handleProcListOpen() (Model, tea.Cmd) {
 	var target string
 	if pane := m.procList.SelectedPane(); pane != nil {
-		target = pane.Target()
+		target = pane.DisplayLabel()
 	} else if node := m.sidebar.Selected(); node != nil {
 		target = node.Session
 	}
@@ -582,7 +582,7 @@ func (m Model) showClearConfirm(t db.Target) Model {
 	if maxTargetLen < 20 {
 		maxTargetLen = 20
 	}
-	targetDisplay := targetDisplayStr(t, m.paneIDMap, m.windowIDMap, m.sessionIDMap)
+	targetDisplay := t.Format(m.paneIDMap, m.windowIDMap, m.sessionIDMap)
 	body := "  target: " + truncateTarget(targetDisplay, maxTargetLen)
 	if st != nil {
 		body += "\n  state:  " + st.Value.String()

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -220,18 +218,14 @@ func (m Model) launchConfigSession(sess *session.Session) (Model, tea.Cmd) {
 	return m, m.fetchPanes()
 }
 
-// highestPriorityPaneTarget returns the Target of the highest-priority active
-// state for the given session, or "" when no qualifying state exists.
-// Only pane/window-level targets (those containing ":") are considered so the
-// caller can switch directly to the relevant pane. Idle states are excluded;
-// Done is included so the user can navigate to a recently-finished pane.
-// The target string is returned verbatim for tmux switch-client.
-func highestPriorityPaneTarget(sessionName string, states []db.ToolState) string {
-	prefix := sessionName + ":"
+// highestPriorityPaneTarget returns the tmux target ID (%N or @N) of the
+// highest-priority active state for the given session ID, or "" when none
+// exists. Session-level states are skipped; idle states are excluded.
+func highestPriorityPaneTarget(sessionID string, states []db.ToolState) string {
 	best := ""
 	bestPri := -1
 	for _, st := range states {
-		if !strings.HasPrefix(st.Target, prefix) {
+		if st.Target.SessionID != sessionID || st.Target.Type == "session" {
 			continue
 		}
 		if !st.Value.IsDisplayable() {
@@ -239,7 +233,7 @@ func highestPriorityPaneTarget(sessionName string, states []db.ToolState) string
 		}
 		if pri := st.Value.Priority(); pri > bestPri {
 			bestPri = pri
-			best = st.Target
+			best = st.Target.ID
 		}
 	}
 	return best
@@ -248,7 +242,8 @@ func highestPriorityPaneTarget(sessionName string, states []db.ToolState) string
 // switchLiveSession switches the tmux client to the given session, landing on
 // the pane with the highest-priority active state when one exists.
 func (m Model) switchLiveSession(sessionName string) (Model, tea.Cmd) {
-	target := highestPriorityPaneTarget(sessionName, m.states)
+	sessionID := m.nameToIDMap[sessionName]
+	target := highestPriorityPaneTarget(sessionID, m.states)
 	if target == "" {
 		target = sessionName
 	}
@@ -330,9 +325,11 @@ func (m Model) handleSidebarKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, keys.FlagState.Binding):
 		if node := m.sidebar.Selected(); node != nil {
 			if st := m.sidebar.stateForSession(node.Session); st != nil && st.Value == db.StateFlagged {
-				return m, m.clearCurrentState(st.Target, st.PaneID)
+				return m, m.clearCurrentState(st.Target)
 			}
-			return m, m.flagCurrentState(node.Session, "")
+			sessionID := m.nameToIDMap[node.Session]
+			t := db.Target{Type: "session", ID: sessionID, SessionID: sessionID}
+			return m, m.flagCurrentState(t)
 		}
 	case key.Matches(msg, keys.WatchSession.Binding):
 		if node := m.sidebar.Selected(); node != nil {
@@ -340,13 +337,12 @@ func (m Model) handleSidebarKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case key.Matches(msg, keys.ClearState.Binding):
 		if node := m.sidebar.Selected(); node != nil {
-			target := node.Session
-			paneID := ""
 			if st := m.sidebar.stateForSession(node.Session); st != nil {
-				target = st.Target
-				paneID = st.PaneID
+				return m.showClearConfirm(st.Target), nil
 			}
-			return m.showClearConfirm(target, paneID), nil
+			sessionID := m.nameToIDMap[node.Session]
+			t := db.Target{Type: "session", ID: sessionID, SessionID: sessionID}
+			return m.showClearConfirm(t), nil
 		}
 	}
 	return m.sidebarNavUpdate()
@@ -475,27 +471,19 @@ func (m Model) handleProcListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, keys.Esc.Binding):
 		m.focus = panelSidebar
 	case key.Matches(msg, keys.FlagState.Binding):
-		if target := m.procListStateTarget(); target != "" {
-			paneID := ""
-			if node := m.procList.SelectedNode(); node != nil && !node.IsWindowHeader {
-				paneID = node.Pane.PaneID
+		if t := m.procListStateIdentity(); t != nil {
+			if st := activeStateFor(m.states, t.Type, t.ID); st != nil && st.Value == db.StateFlagged {
+				return m, m.clearCurrentState(*t)
 			}
-			if st := activeStateFor(m.states, target); st != nil && st.Value == db.StateFlagged {
-				return m, m.clearCurrentState(target, paneID)
-			}
-			return m, m.flagCurrentState(target, paneID)
+			return m, m.flagCurrentState(*t)
 		}
 	case key.Matches(msg, keys.WatchSession.Binding):
 		if sess := m.procListSession(); sess != "" {
 			return m, m.watchCurrentSession(sess)
 		}
 	case key.Matches(msg, keys.ClearState.Binding):
-		if target := m.procListStateTarget(); target != "" {
-			paneID := ""
-			if node := m.procList.SelectedNode(); node != nil && !node.IsWindowHeader {
-				paneID = node.Pane.PaneID
-			}
-			return m.showClearConfirm(target, paneID), nil
+		if t := m.procListStateIdentity(); t != nil {
+			return m.showClearConfirm(*t), nil
 		}
 	case key.Matches(msg, keys.Kill.Binding):
 		// TODO: confirmation prompt
@@ -525,12 +513,11 @@ func (m Model) watchCurrentSession(session string) tea.Cmd {
 }
 
 // flagCurrentState sets the flagged state for the given target.
-// paneID is stored with the record so future clear/flag operations can find it after a pane move.
-func (m Model) flagCurrentState(target string, paneID string) tea.Cmd {
+func (m Model) flagCurrentState(t db.Target) tea.Cmd {
 	d := m.db
 	msg := m.cfg.Tui.FlagDefaultMessage
 	return func() tea.Msg {
-		_ = d.StateSet(target, "", db.StateFlagged, msg, db.SourceUser, false, nil, paneID)
+		_ = d.StateSet(t, "", db.StateFlagged, msg, db.SourceUser, false, nil)
 		states, _ := d.StateList(0, "")
 		return statesMsg{states: states}
 	}
@@ -545,43 +532,52 @@ func (m Model) procListSession() string {
 	return node.Pane.Session
 }
 
-// procListStateTarget returns the state target string for the currently selected
-// proc list node: "session:wi" for window headers, "session:wi.pi" for pane/proc nodes.
-func (m Model) procListStateTarget() string {
+// procListStateIdentity returns the typed Target for the currently selected
+// proc list node: window Target for window headers, pane Target for pane/proc nodes.
+func (m Model) procListStateIdentity() *db.Target {
 	node := m.procList.SelectedNode()
 	if node == nil {
-		return ""
+		return nil
 	}
+	pane := node.Pane
 	if node.IsWindowHeader {
-		return fmt.Sprintf("%s:%d", node.Pane.Session, node.Pane.WindowIndex)
+		t := db.Target{
+			Type:      "window",
+			ID:        pane.WindowID,
+			SessionID: pane.SessionID,
+			WindowID:  pane.WindowID,
+		}
+		return &t
 	}
-	return node.Pane.Target()
+	t := db.Target{
+		Type:      "pane",
+		ID:        pane.PaneID,
+		SessionID: pane.SessionID,
+		WindowID:  pane.WindowID,
+		PaneID:    pane.PaneID,
+	}
+	return &t
 }
 
-// clearCurrentState clears the state for the given target.
-// When paneID is non-empty, clears by stable pane_id to handle moved panes.
-func (m Model) clearCurrentState(target string, paneID string) tea.Cmd {
+// clearCurrentState clears the state for the given typed target.
+func (m Model) clearCurrentState(t db.Target) tea.Cmd {
 	d := m.db
 	return func() tea.Msg {
-		if paneID != "" {
-			_ = d.StateClearByPaneID(paneID)
-		} else {
-			_ = d.StateClear(target)
-		}
+		_ = d.StateClear(t)
 		states, _ := d.StateList(0, "")
 		return statesMsg{states: states}
 	}
 }
 
 // showClearConfirm opens the confirmation overlay for clearing the state of target.
-// paneID is passed through to clearCurrentState so moved panes are handled correctly.
-func (m Model) showClearConfirm(target string, paneID string) Model {
-	st := activeStateFor(m.states, target)
+func (m Model) showClearConfirm(t db.Target) Model {
+	st := activeStateFor(m.states, t.Type, t.ID)
 	maxTargetLen := m.width/2 - 12 // leave room for label + border + padding
 	if maxTargetLen < 20 {
 		maxTargetLen = 20
 	}
-	body := "  target: " + truncateTarget(target, maxTargetLen)
+	targetDisplay := targetDisplayStr(t, m.paneIDMap, m.windowIDMap, m.sessionIDMap)
+	body := "  target: " + truncateTarget(targetDisplay, maxTargetLen)
 	if st != nil {
 		body += "\n  state:  " + st.Value.String()
 		if st.Message != "" {
@@ -596,7 +592,7 @@ func (m Model) showClearConfirm(target string, paneID string) Model {
 		prompt: "Clear state?",
 		body:   body,
 	}
-	m.confirmCmd = m.clearCurrentState(target, paneID)
+	m.confirmCmd = m.clearCurrentState(t)
 	m.showConfirm = true
 	return m
 }

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -225,7 +225,7 @@ func highestPriorityPaneTarget(sessionID string, states []db.ToolState) string {
 	best := ""
 	bestPri := -1
 	for _, st := range states {
-		if st.Target.SessionID != sessionID || st.Target.Type == "session" {
+		if st.Target.SessionID != sessionID || st.Target.Type == db.TargetTypeSession {
 			continue
 		}
 		if !st.Value.IsDisplayable() {
@@ -328,7 +328,7 @@ func (m Model) handleSidebarKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, m.clearCurrentState(st.Target)
 			}
 			sessionID := m.nameToIDMap[node.Session]
-			t := db.Target{Type: "session", ID: sessionID, SessionID: sessionID}
+			t := db.Target{Type: db.TargetTypeSession, ID: sessionID, SessionID: sessionID}
 			return m, m.flagCurrentState(t)
 		}
 	case key.Matches(msg, keys.WatchSession.Binding):
@@ -341,7 +341,7 @@ func (m Model) handleSidebarKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m.showClearConfirm(st.Target), nil
 			}
 			sessionID := m.nameToIDMap[node.Session]
-			t := db.Target{Type: "session", ID: sessionID, SessionID: sessionID}
+			t := db.Target{Type: db.TargetTypeSession, ID: sessionID, SessionID: sessionID}
 			return m.showClearConfirm(t), nil
 		}
 	}
@@ -541,16 +541,22 @@ func (m Model) procListStateIdentity() *db.Target {
 	}
 	pane := node.Pane
 	if node.IsWindowHeader {
+		if pane.WindowID == "" {
+			return nil
+		}
 		t := db.Target{
-			Type:      "window",
+			Type:      db.TargetTypeWindow,
 			ID:        pane.WindowID,
 			SessionID: pane.SessionID,
 			WindowID:  pane.WindowID,
 		}
 		return &t
 	}
+	if pane.PaneID == "" {
+		return nil
+	}
 	t := db.Target{
-		Type:      "pane",
+		Type:      db.TargetTypePane,
 		ID:        pane.PaneID,
 		SessionID: pane.SessionID,
 		WindowID:  pane.WindowID,

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -9,34 +9,34 @@ import (
 
 func TestHighestPriorityPaneTarget_ReturnsHighestPriorityPane(t *testing.T) {
 	states := []db.ToolState{
-		{Target: "sess:0.0", Value: db.StateWorking},
-		{Target: "sess:1.0", Value: db.StateError}, // highest priority
-		{Target: "sess:2.0", Value: db.StateFlagged},
+		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
+		{Target: db.Target{Type: "pane", ID: "%2", SessionID: "$1"}, Value: db.StateError}, // highest priority
+		{Target: db.Target{Type: "pane", ID: "%3", SessionID: "$1"}, Value: db.StateFlagged},
 	}
-	got := highestPriorityPaneTarget("sess", states)
-	if got != "sess:1.0" {
-		t.Errorf("want sess:1.0 (error=highest), got %q", got)
+	got := highestPriorityPaneTarget("$1", states)
+	if got != "%2" {
+		t.Errorf("want %%2 (error=highest), got %q", got)
 	}
 }
 
 func TestHighestPriorityPaneTarget_IncludesDone(t *testing.T) {
 	// Done has priority=2; Working has priority=0; Done wins.
 	states := []db.ToolState{
-		{Target: "sess:0.0", Value: db.StateDone},
-		{Target: "sess:1.0", Value: db.StateWorking},
+		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateDone},
+		{Target: db.Target{Type: "pane", ID: "%2", SessionID: "$1"}, Value: db.StateWorking},
 	}
-	got := highestPriorityPaneTarget("sess", states)
-	if got != "sess:0.0" {
-		t.Errorf("want sess:0.0 (done beats working), got %q", got)
+	got := highestPriorityPaneTarget("$1", states)
+	if got != "%1" {
+		t.Errorf("want %%1 (done beats working), got %q", got)
 	}
 }
 
 func TestHighestPriorityPaneTarget_ReturnsEmptyWhenOnlyIdle(t *testing.T) {
 	states := []db.ToolState{
-		{Target: "sess:0.0", Value: db.StateIdle},
-		{Target: "sess:1.0", Value: db.StateIdle},
+		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateIdle},
+		{Target: db.Target{Type: "pane", ID: "%2", SessionID: "$1"}, Value: db.StateIdle},
 	}
-	got := highestPriorityPaneTarget("sess", states)
+	got := highestPriorityPaneTarget("$1", states)
 	if got != "" {
 		t.Errorf("want empty (only idle states), got %q", got)
 	}
@@ -44,52 +44,63 @@ func TestHighestPriorityPaneTarget_ReturnsEmptyWhenOnlyIdle(t *testing.T) {
 
 func TestHighestPriorityPaneTarget_IgnoresOtherSessions(t *testing.T) {
 	states := []db.ToolState{
-		{Target: "other:0.0", Value: db.StateWaiting},
-		{Target: "sess:0.0", Value: db.StateWorking},
+		{Target: db.Target{Type: "pane", ID: "%9", SessionID: "$9"}, Value: db.StateWaiting},
+		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
 	}
-	got := highestPriorityPaneTarget("sess", states)
-	if got != "sess:0.0" {
-		t.Errorf("want sess:0.0 (other session ignored), got %q", got)
+	got := highestPriorityPaneTarget("$1", states)
+	if got != "%1" {
+		t.Errorf("want %%1 (other session ignored), got %q", got)
+	}
+}
+
+func TestHighestPriorityPaneTarget_IgnoresSessionTargets(t *testing.T) {
+	states := []db.ToolState{
+		{Target: db.Target{Type: "session", ID: "$1", SessionID: "$1"}, Value: db.StateError},
+		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
+	}
+	got := highestPriorityPaneTarget("$1", states)
+	// session target should be skipped; only pane target matters
+	if got != "%1" {
+		t.Errorf("want %%1 (session target ignored), got %q", got)
 	}
 }
 
 func TestHighestPriorityPaneTarget_ReturnsEmptyForEmptyStates(t *testing.T) {
-	got := highestPriorityPaneTarget("sess", nil)
+	got := highestPriorityPaneTarget("$1", nil)
 	if got != "" {
 		t.Errorf("want empty, got %q", got)
 	}
 }
 
-func TestClearCurrentState_ClearsByPaneID(t *testing.T) {
+func TestClearCurrentState_ClearsByTargetID(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	// State was written when pane was at old position.
-	_ = d.StateSet("work:1.0", "claude", db.StateWorking, "", db.SourceTool, false, nil, "%5")
+	target := db.Target{Type: "pane", ID: "%5", SessionID: "$1", WindowID: "@1", PaneID: "%5"}
+	_ = d.StateSet(target, "claude", db.StateWorking, "", db.SourceTool, false, nil)
 
 	m := Model{db: d}
-	cmd := m.clearCurrentState("work:2.0", "%5") // resolved target + pane_id
+	cmd := m.clearCurrentState(target)
 	cmd()
 
-	st, _ := d.StateByTarget("work:1.0")
+	st, _ := d.StateByID(target)
 	if st != nil {
-		t.Errorf("state should be cleared by pane_id, got: %+v", st)
+		t.Errorf("state should be cleared by target ID, got: %+v", st)
 	}
 }
 
-func TestClearCurrentState_FallsBackToTarget(t *testing.T) {
+func TestClearCurrentState_NoopForMissingTarget(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	_ = d.StateSet("work:1.0", "claude", db.StateWorking, "", db.SourceTool, false, nil, "")
+	target := db.Target{Type: "pane", ID: "%99", SessionID: "$1", WindowID: "@1", PaneID: "%99"}
 
 	m := Model{db: d}
-	cmd := m.clearCurrentState("work:1.0", "") // no pane_id, falls back to target
-	cmd()
-
-	st, _ := d.StateByTarget("work:1.0")
-	if st != nil {
-		t.Errorf("state should be cleared by target, got: %+v", st)
+	cmd := m.clearCurrentState(target)
+	// Should not panic or error even when no state exists.
+	result := cmd()
+	if _, ok := result.(statesMsg); !ok {
+		t.Errorf("expected statesMsg, got %T", result)
 	}
 }
 

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestHighestPriorityPaneTarget_ReturnsHighestPriorityPane(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
-		{Target: db.Target{Type: "pane", ID: "%2", SessionID: "$1"}, Value: db.StateError}, // highest priority
-		{Target: db.Target{Type: "pane", ID: "%3", SessionID: "$1"}, Value: db.StateFlagged},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%2", SessionID: "$1"}, Value: db.StateError}, // highest priority
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%3", SessionID: "$1"}, Value: db.StateFlagged},
 	}
 	got := highestPriorityPaneTarget("$1", states)
 	if got != "%2" {
@@ -24,8 +24,8 @@ func TestHighestPriorityPaneTarget_ReturnsHighestPriorityPane(t *testing.T) {
 func TestHighestPriorityPaneTarget_IncludesDone(t *testing.T) {
 	// Done has priority=2; Working has priority=0; Done wins.
 	states := []db.ToolState{
-		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateDone},
-		{Target: db.Target{Type: "pane", ID: "%2", SessionID: "$1"}, Value: db.StateWorking},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1"}, Value: db.StateDone},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%2", SessionID: "$1"}, Value: db.StateWorking},
 	}
 	got := highestPriorityPaneTarget("$1", states)
 	if got != "%1" {
@@ -35,8 +35,8 @@ func TestHighestPriorityPaneTarget_IncludesDone(t *testing.T) {
 
 func TestHighestPriorityPaneTarget_ReturnsEmptyWhenOnlyIdle(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateIdle},
-		{Target: db.Target{Type: "pane", ID: "%2", SessionID: "$1"}, Value: db.StateIdle},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1"}, Value: db.StateIdle},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%2", SessionID: "$1"}, Value: db.StateIdle},
 	}
 	got := highestPriorityPaneTarget("$1", states)
 	if got != "" {
@@ -46,8 +46,8 @@ func TestHighestPriorityPaneTarget_ReturnsEmptyWhenOnlyIdle(t *testing.T) {
 
 func TestHighestPriorityPaneTarget_IgnoresOtherSessions(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: "pane", ID: "%9", SessionID: "$9"}, Value: db.StateWaiting},
-		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%9", SessionID: "$9"}, Value: db.StateWaiting},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
 	}
 	got := highestPriorityPaneTarget("$1", states)
 	if got != "%1" {
@@ -57,8 +57,8 @@ func TestHighestPriorityPaneTarget_IgnoresOtherSessions(t *testing.T) {
 
 func TestHighestPriorityPaneTarget_IgnoresSessionTargets(t *testing.T) {
 	states := []db.ToolState{
-		{Target: db.Target{Type: "session", ID: "$1", SessionID: "$1"}, Value: db.StateError},
-		{Target: db.Target{Type: "pane", ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
+		{Target: db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"}, Value: db.StateError},
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1"}, Value: db.StateWorking},
 	}
 	got := highestPriorityPaneTarget("$1", states)
 	// session target should be skipped; only pane target matters
@@ -78,7 +78,7 @@ func TestClearCurrentState_ClearsByTargetID(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	target := db.Target{Type: "pane", ID: "%5", SessionID: "$1", WindowID: "@1", PaneID: "%5"}
+	target := db.Target{Type: db.TargetTypePane, ID: "%5", SessionID: "$1", WindowID: "@1", PaneID: "%5"}
 	_ = d.StateSet(target, "claude", db.StateWorking, "", db.SourceTool, false, nil)
 
 	m := Model{db: d}
@@ -95,7 +95,7 @@ func TestClearCurrentState_NoopForMissingTarget(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	target := db.Target{Type: "pane", ID: "%99", SessionID: "$1", WindowID: "@1", PaneID: "%99"}
+	target := db.Target{Type: db.TargetTypePane, ID: "%99", SessionID: "$1", WindowID: "@1", PaneID: "%99"}
 
 	m := Model{db: d}
 	cmd := m.clearCurrentState(target)

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rtalexk/demux/internal/config"
 	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func TestHighestPriorityPaneTarget_ReturnsHighestPriorityPane(t *testing.T) {
@@ -129,5 +131,29 @@ func TestResolveFilterKey(t *testing.T) {
 				t.Errorf("filter: got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProcListStateIdentity_EmptyPaneIDReturnsNil(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	m := New(config.Default(), d)
+	m.procList.nodes = []ProcListNode{
+		{Pane: tmux.Pane{}}, // empty PaneID
+	}
+	m.procList.cursor = 0
+	if got := m.procListStateIdentity(); got != nil {
+		t.Errorf("expected nil for empty PaneID, got %+v", got)
+	}
+}
+
+func TestProcListStateIdentity_EmptyWindowIDReturnsNil(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	m := New(config.Default(), d)
+	m.procList.nodes = []ProcListNode{
+		{IsWindowHeader: true, Pane: tmux.Pane{}}, // empty WindowID
+	}
+	m.procList.cursor = 0
+	if got := m.procListStateIdentity(); got != nil {
+		t.Errorf("expected nil for empty WindowID, got %+v", got)
 	}
 }

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -150,24 +150,13 @@ func (m Model) handleQueryResultMsg(msg queryResultMsg) (Model, tea.Cmd) {
 	return m, nil
 }
 
-// buildNameToIDMap returns a map from session display name to stable session_id ($N).
-func buildNameToIDMap(panes []tmux.Pane) map[string]string {
-	m := make(map[string]string)
-	for _, p := range panes {
-		if p.SessionID != "" && m[p.Session] == "" {
-			m[p.Session] = p.SessionID
-		}
-	}
-	return m
-}
-
 func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 	m.panes = msg.panes
 	// Build display maps from fresh pane data.
 	m.paneIDMap = tmux.PaneIDToTargetMap(msg.panes)
 	m.windowIDMap = tmux.WindowIDToTargetMap(msg.panes)
 	m.sessionIDMap = tmux.SessionIDToNameMap(msg.panes)
-	m.nameToIDMap = buildNameToIDMap(msg.panes)
+	m.nameToIDMap = tmux.SessionNameToIDMap(msg.panes)
 	m.sidebar.SetNameToIDMap(m.nameToIDMap)
 	grouped := tmux.GroupBySessions(msg.panes)
 	merged := session.Merge(msg.panes, m.sessionsConfig.Entries)

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -151,31 +150,25 @@ func (m Model) handleQueryResultMsg(msg queryResultMsg) (Model, tea.Cmd) {
 	return m, nil
 }
 
-// resolveStateTargets returns a copy of states with each state's Target replaced
-// by the current "session:window.pane" from the live pane list when a pane_id
-// match is found. Unmatched or legacy states keep their stored Target.
-//
-// The design spec describes a lazy write-back (UPDATE stored target in DB when
-// the resolved value differs). That is deliberately omitted: Phase 4's StateSet
-// stale-delete covers the common case, and a long-lived pane in "working" state
-// will have its stored target corrected on the next state write.
-func resolveStateTargets(states []db.ToolState, panes []tmux.Pane) []db.ToolState {
-	paneIDMap := tmux.PaneIDToTargetMap(panes)
-	out := make([]db.ToolState, len(states))
-	for i, st := range states {
-		if st.PaneID != "" {
-			if resolved, ok := paneIDMap[st.PaneID]; ok {
-				st.Target = resolved
-			}
+// buildNameToIDMap returns a map from session display name to stable session_id ($N).
+func buildNameToIDMap(panes []tmux.Pane) map[string]string {
+	m := make(map[string]string)
+	for _, p := range panes {
+		if p.SessionID != "" && m[p.Session] == "" {
+			m[p.Session] = p.SessionID
 		}
-		out[i] = st
 	}
-	return out
+	return m
 }
 
 func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 	m.panes = msg.panes
-	m.states = resolveStateTargets(m.states, msg.panes) // re-resolve with fresh pane data
+	// Build display maps from fresh pane data.
+	m.paneIDMap = tmux.PaneIDToTargetMap(msg.panes)
+	m.windowIDMap = tmux.WindowIDToTargetMap(msg.panes)
+	m.sessionIDMap = tmux.SessionIDToNameMap(msg.panes)
+	m.nameToIDMap = buildNameToIDMap(msg.panes)
+	m.sidebar.SetNameToIDMap(m.nameToIDMap)
 	grouped := tmux.GroupBySessions(msg.panes)
 	merged := session.Merge(msg.panes, m.sessionsConfig.Entries)
 	m.sidebar.SetData(merged, m.states, m.gitInfo, m.cfg)
@@ -239,7 +232,7 @@ func (m Model) handleProcDataMsg(msg procDataMsg) (Model, tea.Cmd) {
 }
 
 func (m Model) handleStatesMsg(msg statesMsg) (Model, tea.Cmd) {
-	m.states = resolveStateTargets(msg.states, m.panes)
+	m.states = msg.states
 	m.procList.SetStates(m.states)
 	merged := session.Merge(m.panes, m.sessionsConfig.Entries)
 	m.sidebar.SetData(merged, m.states, m.gitInfo, m.cfg)
@@ -329,14 +322,6 @@ func (m *Model) applyNonAlertFocusMode(mode string, visibleRows int) {
 	}
 }
 
-func (m *Model) stateMap() map[string]db.ToolState {
-	out := make(map[string]db.ToolState, len(m.states))
-	for _, s := range m.states {
-		out[s.Target] = s
-	}
-	return out
-}
-
 func (m *Model) updateDetailFromSelection() {
 	if m.focus == panelSidebar {
 		node := m.sidebar.Selected()
@@ -384,17 +369,18 @@ func (m *Model) detailForSidebarNode(node SidebarNode) DetailModel {
 		winCount:       len(windows),
 		paneCount:      paneCount,
 		procCount:      countProcsUnderCWD(m.procs, m.cwdMap, sessionCWD),
-		sessionStates:  statesForSession(m.states, node.Session),
+		sessionStates:  statesForSession(m.states, m.nameToIDMap[node.Session]),
+		paneIDMap:      m.paneIDMap,
+		windowIDMap:    m.windowIDMap,
+		sessionIDMap:   m.sessionIDMap,
 	}
 }
 
-// statesForSession returns all ToolState records whose Target matches or is prefixed by
-// "session:" (i.e. targets belonging to that session).
-func statesForSession(states []db.ToolState, session string) []db.ToolState {
-	prefix := session + ":"
+// statesForSession returns all ToolState records belonging to the given session ID.
+func statesForSession(states []db.ToolState, sessionID string) []db.ToolState {
 	var out []db.ToolState
 	for _, st := range states {
-		if st.Target == session || strings.HasPrefix(st.Target, prefix) {
+		if st.Target.SessionID == sessionID {
 			out = append(out, st)
 		}
 	}

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -3,40 +3,27 @@ package tui
 import (
 	"testing"
 
-	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/tmux"
 )
 
-func TestResolveStateTargets_NilPanes(t *testing.T) {
-	states := []db.ToolState{
-		{Target: "work:0.0", PaneID: "%1"},
-		{Target: "other:1.0", PaneID: ""},
+func TestBuildNameToIDMap(t *testing.T) {
+	panes := []tmux.Pane{
+		{Session: "work", SessionID: "$1", WindowIndex: 0, PaneIndex: 0, PaneID: "%1"},
+		{Session: "work", SessionID: "$1", WindowIndex: 0, PaneIndex: 1, PaneID: "%2"},
+		{Session: "other", SessionID: "$2", WindowIndex: 0, PaneIndex: 0, PaneID: "%3"},
 	}
-
-	// Must not panic; no matches possible so targets are unchanged.
-	resolved := resolveStateTargets(states, nil)
-	if resolved[0].Target != "work:0.0" {
-		t.Errorf("unmatched pane_id target should be unchanged, got %q", resolved[0].Target)
+	m := buildNameToIDMap(panes)
+	if got := m["work"]; got != "$1" {
+		t.Errorf("work: want $1, got %q", got)
 	}
-	if resolved[1].Target != "other:1.0" {
-		t.Errorf("legacy target should be unchanged, got %q", resolved[1].Target)
+	if got := m["other"]; got != "$2" {
+		t.Errorf("other: want $2, got %q", got)
 	}
 }
 
-func TestResolveStateTargets_UpdatesMovedPane(t *testing.T) {
-	states := []db.ToolState{
-		{Target: "work:1.0", PaneID: "%3"},
-		{Target: "other:0.0", PaneID: ""},
-	}
-	panes := []tmux.Pane{
-		{Session: "work", WindowIndex: 2, PaneIndex: 0, PaneID: "%3"},
-	}
-
-	resolved := resolveStateTargets(states, panes)
-	if resolved[0].Target != "work:2.0" {
-		t.Errorf("want work:2.0, got %q", resolved[0].Target)
-	}
-	if resolved[1].Target != "other:0.0" {
-		t.Errorf("legacy target should be unchanged, got %q", resolved[1].Target)
+func TestBuildNameToIDMap_Empty(t *testing.T) {
+	m := buildNameToIDMap(nil)
+	if len(m) != 0 {
+		t.Errorf("want empty map, got %v", m)
 	}
 }

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/rtalexk/demux/internal/tmux"
 )
 
-func TestBuildNameToIDMap(t *testing.T) {
+func TestSessionNameToIDMap(t *testing.T) {
 	panes := []tmux.Pane{
 		{Session: "work", SessionID: "$1", WindowIndex: 0, PaneIndex: 0, PaneID: "%1"},
 		{Session: "work", SessionID: "$1", WindowIndex: 0, PaneIndex: 1, PaneID: "%2"},
 		{Session: "other", SessionID: "$2", WindowIndex: 0, PaneIndex: 0, PaneID: "%3"},
 	}
-	m := buildNameToIDMap(panes)
+	m := tmux.SessionNameToIDMap(panes)
 	if got := m["work"]; got != "$1" {
 		t.Errorf("work: want $1, got %q", got)
 	}
@@ -21,8 +21,8 @@ func TestBuildNameToIDMap(t *testing.T) {
 	}
 }
 
-func TestBuildNameToIDMap_Empty(t *testing.T) {
-	m := buildNameToIDMap(nil)
+func TestSessionNameToIDMap_Empty(t *testing.T) {
+	m := tmux.SessionNameToIDMap(nil)
 	if len(m) != 0 {
 		t.Errorf("want empty map, got %v", m)
 	}

--- a/internal/tui/proclist.go
+++ b/internal/tui/proclist.go
@@ -56,20 +56,18 @@ func (p *ProcListModel) SetStates(states []db.ToolState) {
 
 // stateForPane returns the state for the given pane, or nil.
 func (p ProcListModel) stateForPane(pane tmux.Pane) *db.ToolState {
-	key := pane.Target()
-	return activeStateFor(p.states, key)
+	return activeStateFor(p.states, "pane", pane.PaneID)
 }
 
-// stateForWindow returns the active state for a window-level target ("session:windowIndex"), or nil.
-func (p ProcListModel) stateForWindow(session string, windowIndex int) *db.ToolState {
-	key := fmt.Sprintf("%s:%d", session, windowIndex)
-	return activeStateFor(p.states, key)
+// stateForWindow returns the active state for a window-level target, or nil.
+func (p ProcListModel) stateForWindow(windowID string) *db.ToolState {
+	return activeStateFor(p.states, "window", windowID)
 }
 
-// activeStateFor returns the state matching target, or nil.
-func activeStateFor(states []db.ToolState, target string) *db.ToolState {
+// activeStateFor returns the state matching the target type and ID, or nil.
+func activeStateFor(states []db.ToolState, targetType, targetID string) *db.ToolState {
 	for i := range states {
-		if states[i].Target == target {
+		if states[i].Target.Type == targetType && states[i].Target.ID == targetID {
 			return &states[i]
 		}
 	}

--- a/internal/tui/proclist.go
+++ b/internal/tui/proclist.go
@@ -40,7 +40,7 @@ type ProcListModel struct {
 	primaryCWD     string
 	curSession     string
 	curWindow      int
-	collapsedPIDs  map[int32]bool // persists collapse state across SetWindowData calls
+	collapsedPIDs  map[int32]bool // persists collapse state across SetSessionData rebuilds
 	pendingSeekKey string         // node identity to restore cursor after next rebuild
 	inSessionMode  bool           // true when displaying all windows of a session
 	cfg            config.Config
@@ -56,16 +56,16 @@ func (p *ProcListModel) SetStates(states []db.ToolState) {
 
 // stateForPane returns the state for the given pane, or nil.
 func (p ProcListModel) stateForPane(pane tmux.Pane) *db.ToolState {
-	return activeStateFor(p.states, "pane", pane.PaneID)
+	return activeStateFor(p.states, db.TargetTypePane, pane.PaneID)
 }
 
 // stateForWindow returns the active state for a window-level target, or nil.
 func (p ProcListModel) stateForWindow(windowID string) *db.ToolState {
-	return activeStateFor(p.states, "window", windowID)
+	return activeStateFor(p.states, db.TargetTypeWindow, windowID)
 }
 
 // activeStateFor returns the state matching the target type and ID, or nil.
-func activeStateFor(states []db.ToolState, targetType, targetID string) *db.ToolState {
+func activeStateFor(states []db.ToolState, targetType db.TargetType, targetID string) *db.ToolState {
 	for i := range states {
 		if states[i].Target.Type == targetType && states[i].Target.ID == targetID {
 			return &states[i]
@@ -73,9 +73,6 @@ func activeStateFor(states []db.ToolState, targetType, targetID string) *db.Tool
 	}
 	return nil
 }
-
-// TODO: single-window mode (SetWindowData) must be removed — selecting individual
-// windows from the sidebar is no longer a feature.
 
 // paneDirectChildren returns the immediate child processes for a pane.
 // When PanePID is set it reads directly from the tree; otherwise it falls
@@ -116,7 +113,7 @@ func depth1Meta(pr proc.Process, tree map[int32][]proc.Process, collapsedPIDs ma
 // buildProcNodesForPane builds ProcListNode entries for a single pane.
 // It collects direct children of the pane's shell process (or CWD-matched
 // processes when PanePID is 0) and recurses into their subtrees, applying
-// the same collapse/aggregate logic used by SetWindowData and SetSessionData.
+// the same collapse/aggregate logic used by SetSessionData.
 func buildProcNodesForPane(pane tmux.Pane, procs []proc.Process, cwdMap map[int32]string, tree map[int32][]proc.Process, collapsedPIDs map[int32]bool, primaryCWD string) []ProcListNode {
 	children := paneDirectChildren(pane, procs, cwdMap, tree)
 	seen := make(map[int32]bool)
@@ -188,40 +185,6 @@ func (p *ProcListModel) appendPaneNodes(pane tmux.Pane, displayPane tmux.Pane, w
 	if len(p.nodes) == headerIdx+1 {
 		p.nodes = append(p.nodes, ProcListNode{IsIdle: true, Depth: 1})
 	}
-}
-
-// SetWindowData rebuilds the node list from pre-fetched data.
-// procs is the process snapshot, cwdMap maps PID to CWD (pre-fetched),
-// gitInfo is keyed by "session:windowIndex:paneIndex" for deviant panes.
-func (p *ProcListModel) SetWindowData(panes []tmux.Pane, session string, windowIndex int, procs []proc.Process, cwdMap map[int32]string, gitInfo map[string]git.Info, cfg config.Config) {
-	p.cfg = cfg
-	p.inSessionMode = false
-	grouped := tmux.GroupBySessions(panes)
-	windows := grouped[session]
-	p.primaryCWD = tmux.PrimaryPaneCWD(windows[0])
-	wPanes := windows[windowIndex]
-
-	tree := proc.BuildTree(procs)
-
-	if p.collapsedPIDs == nil {
-		p.collapsedPIDs = make(map[int32]bool)
-	}
-
-	windowChanged := session != p.curSession || windowIndex != p.curWindow
-	p.curSession = session
-	p.curWindow = windowIndex
-	p.nodes = nil
-	if windowChanged {
-		p.cursor = 0
-		p.offset = 0
-		p.collapsedPIDs = make(map[int32]bool) // reset so new window's PIDs default to collapsed
-	}
-
-	for _, pane := range sortPanes(wPanes) {
-		p.appendPaneNodes(pane, pane, p.primaryCWD, procs, cwdMap, tree, gitInfo)
-	}
-	assignTreePrefixes(p.nodes)
-	p.applyPendingSeek()
 }
 
 // SetSessionData rebuilds the node list for all windows of a session.

--- a/internal/tui/proclist.go
+++ b/internal/tui/proclist.go
@@ -28,7 +28,7 @@ type ProcListNode struct {
 	Collapsed   bool    // true when children are hidden
 	AggCPU      float64 // CPU% summed across parent + all descendants
 	AggMemRSS   uint64  // MemRSS summed across parent + all descendants
-	// tree drawing (set by assignTreePrefixes after SetWindowData)
+	// tree drawing (set by assignTreePrefixes after SetSessionData)
 	TreePrefix string // line-1 prefix, e.g. "  ├─ " or "  └─ "
 	StatPrefix string // line-2 (stats) prefix, e.g. "  │  " or "     "
 }

--- a/internal/tui/proclist_nav.go
+++ b/internal/tui/proclist_nav.go
@@ -53,7 +53,7 @@ func (p *ProcListModel) cursorNodeKey() string {
 }
 
 // applyPendingSeek moves the cursor to the node matching pendingSeekKey, then
-// clears the field. Called at the end of each SetWindowData / SetSessionData.
+// clears the field. Called at the end of each SetSessionData.
 func (p *ProcListModel) applyPendingSeek() {
 	if p.pendingSeekKey == "" {
 		return
@@ -315,7 +315,7 @@ func (p *ProcListModel) GotoBottom() {
 
 // ToggleCollapse flips the collapsed state of the cursor node if it is a
 // depth-1 process with children. Returns true if a toggle occurred.
-// The caller must re-call SetWindowData to rebuild nodes after a toggle.
+// The caller must re-call SetSessionData to rebuild nodes after a toggle.
 func (p *ProcListModel) ToggleCollapse() bool {
 	if p.cursor < 0 || p.cursor >= len(p.nodes) {
 		return false
@@ -332,7 +332,7 @@ func (p *ProcListModel) ToggleCollapse() bool {
 }
 
 // Expand expands the focused depth-1 process node if it has children and is collapsed.
-// Returns true if a change occurred; the caller must re-call SetWindowData.
+// Returns true if a change occurred; the caller must re-call SetSessionData.
 func (p *ProcListModel) Expand() bool {
 	if p.cursor < 0 || p.cursor >= len(p.nodes) {
 		return false
@@ -382,7 +382,7 @@ func (p *ProcListModel) collapseDeep() (int, bool) {
 
 // Collapse collapses the focused node. For depth-1 nodes with children it collapses
 // directly; for nodes at any deeper depth it walks up to the ancestor depth-1 node, moves
-// the cursor there, and collapses it. Returns true if a change occurred; the caller must re-call SetWindowData.
+// the cursor there, and collapses it. Returns true if a change occurred; the caller must re-call SetSessionData.
 func (p *ProcListModel) Collapse() bool {
 	if p.cursor < 0 || p.cursor >= len(p.nodes) {
 		return false
@@ -407,7 +407,7 @@ func (p *ProcListModel) Collapse() bool {
 }
 
 // ExpandAll expands all depth-1 process nodes that have children.
-// Returns true if any change occurred; the caller must re-call SetWindowData.
+// Returns true if any change occurred; the caller must re-call SetSessionData.
 // pendingSeekKey is set so that applyPendingSeek can restore focus after
 // the rebuild changes indices.
 func (p *ProcListModel) ExpandAll() bool {
@@ -429,8 +429,8 @@ func (p *ProcListModel) ExpandAll() bool {
 }
 
 // CollapseAll collapses all depth-1 process nodes that have children.
-// Returns true if any change occurred; the caller must re-call SetWindowData.
-// pendingSeekKey is set so that applyPendingSeek (called by SetWindowData) can
+// Returns true if any change occurred; the caller must re-call SetSessionData.
+// pendingSeekKey is set so that applyPendingSeek (called by SetSessionData) can
 // restore focus to the same logical node after the rebuild changes indices.
 func (p *ProcListModel) CollapseAll() bool {
 	if p.collapsedPIDs == nil {

--- a/internal/tui/proclist_render.go
+++ b/internal/tui/proclist_render.go
@@ -422,7 +422,7 @@ func (p ProcListModel) renderWindowHeader(node ProcListNode, selected bool, inne
 		pathStr = format.ShortenPath(node.Pane.CWD, p.cfg.PathAliases)
 	}
 
-	st := p.stateForWindow(node.Pane.Session, node.Pane.WindowIndex)
+	st := p.stateForWindow(node.Pane.WindowID)
 	if selected {
 		stateStr := p.selectedStateIndicator(st)
 		if stateStr != "" {

--- a/internal/tui/proclist_test.go
+++ b/internal/tui/proclist_test.go
@@ -463,7 +463,7 @@ func TestAggStats_WithChildren_IncludesDescendants(t *testing.T) {
 	}
 }
 
-// ---------- SetWindowData collapse defaults ----------
+// ---------- SetSessionData collapse defaults ----------
 
 func buildTestPane(panePID int32) tmux.Pane {
 	return tmux.Pane{
@@ -471,116 +471,6 @@ func buildTestPane(panePID int32) tmux.Pane {
 		WindowIndex: 0,
 		PaneIndex:   0,
 		PanePID:     panePID,
-	}
-}
-
-func TestSetWindowData_CollapseHidesChildren(t *testing.T) {
-	shell := proc.Process{PID: 200, PPID: 0, Name: "zsh"}
-	parent := proc.Process{PID: 201, PPID: 200, Name: "node"}
-	child := proc.Process{PID: 202, PPID: 201, Name: "esbuild"}
-	procs := []proc.Process{shell, parent, child}
-
-	pane := buildTestPane(200)
-	var m ProcListModel
-	m.SetWindowData(
-		[]tmux.Pane{pane}, "test", 0,
-		procs, map[int32]string{},
-		map[string]git.Info{}, config.Config{},
-	)
-
-	// esbuild (depth-2 child of node) should NOT appear — parent collapsed by default
-	for _, n := range m.nodes {
-		if n.Proc.PID == 202 {
-			t.Error("esbuild (depth-2 child) should be hidden when parent is collapsed by default")
-		}
-	}
-
-	// node (PID 201) should have HasChildren=true and Collapsed=true
-	var nodeProc *ProcListNode
-	for i := range m.nodes {
-		if m.nodes[i].Proc.PID == 201 {
-			nodeProc = &m.nodes[i]
-		}
-	}
-	if nodeProc == nil {
-		t.Fatal("node proc (PID 201) not found in node list")
-	}
-	if !nodeProc.HasChildren {
-		t.Error("expected HasChildren=true for node with child esbuild")
-	}
-	if !nodeProc.Collapsed {
-		t.Error("expected Collapsed=true by default")
-	}
-}
-
-func TestSetWindowData_ExpandedShowsChildren(t *testing.T) {
-	shell := proc.Process{PID: 300, PPID: 0, Name: "zsh"}
-	parent := proc.Process{PID: 301, PPID: 300, Name: "node"}
-	child := proc.Process{PID: 302, PPID: 301, Name: "esbuild"}
-	procs := []proc.Process{shell, parent, child}
-
-	pane := buildTestPane(300)
-	var m ProcListModel
-	// First call establishes the window and defaults PID 301 to collapsed.
-	m.SetWindowData(
-		[]tmux.Pane{pane}, "test", 0,
-		procs, map[int32]string{},
-		map[string]git.Info{}, config.Config{},
-	)
-	// Simulate a toggle — expand PID 301.
-	m.collapsedPIDs[301] = false
-	// Second call for the same window (windowChanged=false) — map is preserved.
-	m.SetWindowData(
-		[]tmux.Pane{pane}, "test", 0,
-		procs, map[int32]string{},
-		map[string]git.Info{}, config.Config{},
-	)
-
-	found := false
-	for _, n := range m.nodes {
-		if n.Proc.PID == 302 {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("esbuild (depth-2) should be visible when parent is expanded")
-	}
-}
-
-func TestSetWindowData_AggStats_SetOnCollapsedNode(t *testing.T) {
-	shell := proc.Process{PID: 400, PPID: 0, Name: "zsh"}
-	parent := proc.Process{PID: 401, PPID: 400, Name: "node", CPU: 1.0, MemRSS: 100}
-	child := proc.Process{PID: 402, PPID: 401, Name: "esbuild", CPU: 0.5, MemRSS: 50}
-	procs := []proc.Process{shell, parent, child}
-
-	pane := buildTestPane(400)
-	var m ProcListModel
-	m.SetWindowData(
-		[]tmux.Pane{pane}, "test", 0,
-		procs, map[int32]string{},
-		map[string]git.Info{}, config.Config{},
-	)
-
-	var nodeProc *ProcListNode
-	for i := range m.nodes {
-		if m.nodes[i].Proc.PID == 401 {
-			nodeProc = &m.nodes[i]
-		}
-	}
-	if nodeProc == nil {
-		t.Fatal("node proc (PID 401) not found")
-	}
-	if !nodeProc.HasChildren {
-		t.Error("expected HasChildren=true for node with child esbuild")
-	}
-	if !nodeProc.Collapsed {
-		t.Error("expected Collapsed=true by default")
-	}
-	if nodeProc.AggCPU != 1.5 {
-		t.Errorf("expected AggCPU=1.5, got %.2f", nodeProc.AggCPU)
-	}
-	if nodeProc.AggMemRSS != 150 {
-		t.Errorf("expected AggMemRSS=150, got %d", nodeProc.AggMemRSS)
 	}
 }
 
@@ -1392,20 +1282,21 @@ func TestSetSessionData_ResetsCursorOnSessionChange(t *testing.T) {
 	}
 }
 
-func TestSetSessionData_SetWindowDataClearsSessionMode(t *testing.T) {
-	pane := buildTestPane(100)
+func TestSetSessionData_ClearsInSessionModeOnRebuild(t *testing.T) {
 	var m ProcListModel
+	// Establish session mode via SetSessionData.
 	m.SetSessionData(buildSessionPanes(), "s",
 		nil, map[int32]string{}, map[string]git.Info{}, config.Config{},
 	)
 	if !m.inSessionMode {
-		t.Fatal("expected inSessionMode=true")
+		t.Fatal("expected inSessionMode=true after SetSessionData")
 	}
-	m.SetWindowData([]tmux.Pane{pane}, "test", 0,
+	// A second SetSessionData call for the same session should preserve session mode.
+	m.SetSessionData(buildSessionPanes(), "s",
 		nil, map[int32]string{}, map[string]git.Info{}, config.Config{},
 	)
-	if m.inSessionMode {
-		t.Error("expected inSessionMode=false after SetWindowData")
+	if !m.inSessionMode {
+		t.Error("expected inSessionMode=true after re-applying SetSessionData for same session")
 	}
 }
 

--- a/internal/tui/proclist_tree.go
+++ b/internal/tui/proclist_tree.go
@@ -44,7 +44,7 @@ func ancestorIsLastAtDepth(nodes []ProcListNode, pos, ancDepth int) bool {
 }
 
 // assignTreePrefixes fills TreePrefix and StatPrefix on every non-header node.
-// It must be called after p.nodes is fully built by SetWindowData or SetSessionData.
+// It must be called after p.nodes is fully built by SetSessionData.
 //
 // Connectors used:
 //

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -58,7 +58,8 @@ type SidebarModel struct {
 	offset        int // viewport scroll offset
 	visibleRows   int // last known visible row count; used by CursorDown/CursorUp
 	sessions      []session.Session
-	states        map[string]db.ToolState
+	states        []db.ToolState
+	nameToID      map[string]string // session display name → session_id ($N)
 	gitInfo       map[string]git.Info
 	cfg           config.Config
 	filter        SidebarFilter
@@ -74,13 +75,16 @@ type SidebarModel struct {
 
 func (s *SidebarModel) SetData(sessions []session.Session, states []db.ToolState, gitInfo map[string]git.Info, cfg config.Config) {
 	s.sessions = sessions
-	s.states = make(map[string]db.ToolState, len(states))
-	for _, st := range states {
-		s.states[st.Target] = st
-	}
+	s.states = states
 	s.gitInfo = gitInfo
 	s.cfg = cfg
 	s.rebuildNodes()
+}
+
+// SetNameToIDMap stores the mapping from session display name to stable session_id.
+// Called by the Model after each panes refresh.
+func (s *SidebarModel) SetNameToIDMap(m map[string]string) {
+	s.nameToID = m
 }
 
 // SetActiveSession records which tmux session the user is currently attached to.
@@ -153,20 +157,27 @@ func (s SidebarModel) ActiveFilter() SidebarFilter {
 
 // stateForSession returns the highest-priority ToolState for the session, or nil if none.
 func (s *SidebarModel) stateForSession(sess string) *db.ToolState {
-	prefix := sess + ":"
+	sessID := s.nameToID[sess]
 	var best *db.ToolState
 	found := false
 	bestPri := 0
-	for target, st := range s.states {
-		if target != sess && !strings.HasPrefix(target, prefix) {
+	for i := range s.states {
+		st := &s.states[i]
+		// Match by session_id when available; fall back to session-level target by name.
+		var matches bool
+		if sessID != "" {
+			matches = st.Target.SessionID == sessID
+		} else {
+			matches = st.Target.Type == "session" && st.Target.ID == sess
+		}
+		if !matches {
 			continue
 		}
 		pri := st.Value.Priority()
 		if !found || pri > bestPri {
 			found = true
 			bestPri = pri
-			st := st
-			best = &st
+			best = st
 		}
 	}
 	return best

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -159,7 +159,6 @@ func (s SidebarModel) ActiveFilter() SidebarFilter {
 func (s *SidebarModel) stateForSession(sess string) *db.ToolState {
 	sessID := s.nameToID[sess]
 	var best *db.ToolState
-	found := false
 	bestPri := 0
 	for i := range s.states {
 		st := &s.states[i]
@@ -174,8 +173,7 @@ func (s *SidebarModel) stateForSession(sess string) *db.ToolState {
 			continue
 		}
 		pri := st.Value.Priority()
-		if !found || pri > bestPri {
-			found = true
+		if best == nil || pri > bestPri {
 			bestPri = pri
 			best = st
 		}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -168,7 +168,7 @@ func (s *SidebarModel) stateForSession(sess string) *db.ToolState {
 		if sessID != "" {
 			matches = st.Target.SessionID == sessID
 		} else {
-			matches = st.Target.Type == "session" && st.Target.ID == sess
+			matches = st.Target.Type == db.TargetTypeSession && st.Target.ID == sess
 		}
 		if !matches {
 			continue

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -268,7 +268,7 @@ func TestRenderSession_truncatedNameWithIndicators_noOverflow(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "hf-garmin-credentials-integration", IsLive: true, Activity: activity},
 		},
-		states:  map[string]db.ToolState{},
+		states:  []db.ToolState{},
 		gitInfo: map[string]git.Info{},
 		cfg:     config.Config{Sidebar: config.SidebarConfig{ShowLastSeen: true}},
 	}
@@ -387,7 +387,7 @@ func TestSessionCount_Empty(t *testing.T) {
 func TestRebuildNodes_ZeroResultSearch(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta", "gamma"),
-		states:   map[string]db.ToolState{},
+		states:   []db.ToolState{},
 		// Non-nil empty slice = active search with no matches.
 		queryResult: query.Result{Sessions: []query.SessionMatch{}},
 	}
@@ -400,7 +400,7 @@ func TestRebuildNodes_ZeroResultSearch(t *testing.T) {
 func TestRender_NoResultsHint(t *testing.T) {
 	s := SidebarModel{
 		sessions:    makeSessions("alpha", "beta"),
-		states:      map[string]db.ToolState{},
+		states:      []db.ToolState{},
 		queryResult: query.Result{Sessions: []query.SessionMatch{}},
 	}
 	s.rebuildNodes()
@@ -413,7 +413,7 @@ func TestRender_NoResultsHint(t *testing.T) {
 func TestRebuildNodes_NoAlerts_AlphabeticalOrder(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("charlie", "alpha", "beta"),
-		states:   map[string]db.ToolState{},
+		states:   []db.ToolState{},
 	}
 	s.rebuildNodes()
 	var got []string
@@ -429,8 +429,8 @@ func TestRebuildNodes_NoAlerts_AlphabeticalOrder(t *testing.T) {
 func TestRebuildNodes_SessionWithStateSortsFirst(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
-		states: map[string]db.ToolState{
-			"beta:0.0": {Target: "beta:0.0", Value: db.StateWorking},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWorking},
 		},
 	}
 	s.rebuildNodes()
@@ -443,9 +443,9 @@ func TestRebuildNodes_HigherPriorityStateSortsFirst(t *testing.T) {
 	// error > working, so vem-main (error) must sort before dm-main (working)
 	s := SidebarModel{
 		sessions: makeSessions("dm-main", "vem-main"),
-		states: map[string]db.ToolState{
-			"dm-main:0.0":  {Target: "dm-main:0.0", Value: db.StateWorking},
-			"vem-main:0.0": {Target: "vem-main:0.0", Value: db.StateError},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "dm-main"}, Value: db.StateWorking},
+			{Target: db.Target{Type: "session", ID: "vem-main"}, Value: db.StateError},
 		},
 	}
 	s.rebuildNodes()
@@ -467,7 +467,7 @@ func TestRebuildNodes_LastSeenSort(t *testing.T) {
 			{DisplayName: "alpha", IsLive: true, Activity: older},
 			{DisplayName: "beta", IsLive: true, Activity: now},
 		},
-		states: map[string]db.ToolState{},
+		states: []db.ToolState{},
 		cfg:    config.Config{Sidebar: config.SidebarConfig{Sort: []string{"last_seen", "priority", "alphabetical"}}},
 	}
 	s.rebuildNodes()
@@ -489,7 +489,7 @@ func TestRebuildNodes_LastSeenSort_ThenAlpha(t *testing.T) {
 			{DisplayName: "alpha", IsLive: true, Activity: now},
 			{DisplayName: "beta", IsLive: true, Activity: now},
 		},
-		states: map[string]db.ToolState{},
+		states: []db.ToolState{},
 		// all same activity time → falls through to alpha
 		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"last_seen", "priority", "alphabetical"}}},
 	}
@@ -507,8 +507,8 @@ func TestRebuildNodes_LastSeenSort_ThenAlpha(t *testing.T) {
 func TestToggleAlertFilter_FilterOnHidesSessionsWithoutAlerts(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
-		states: map[string]db.ToolState{
-			"beta:0.0": {Target: "beta:0.0", Value: db.StateWorking},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWorking},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{}},
 	}
@@ -526,7 +526,7 @@ func TestToggleAlertFilter_FilterOnHidesSessionsWithoutAlerts(t *testing.T) {
 func TestSetFilter_AllFiltersToggle(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
-		states:   map[string]db.ToolState{},
+		states:   []db.ToolState{},
 		cfg:      config.Config{Sidebar: config.SidebarConfig{}},
 		filter:   FilterTmux,
 	}
@@ -561,8 +561,8 @@ func TestSetFilter_AllFiltersToggle(t *testing.T) {
 func TestToggleAlertFilter_ToggleOffRestoresAllSessions(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
-		states: map[string]db.ToolState{
-			"beta:0.0": {Target: "beta:0.0", Value: db.StateWorking},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWorking},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{}},
 	}
@@ -579,7 +579,7 @@ func TestToggleAlertFilter_ToggleOffRestoresAllSessions(t *testing.T) {
 func TestAlertFilterActive_ReportsCorrectState(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("a"),
-		states:   map[string]db.ToolState{},
+		states:   []db.ToolState{},
 		cfg:      config.Config{Sidebar: config.SidebarConfig{}},
 	}
 	if s.ActiveFilter() == FilterPriority {
@@ -594,7 +594,7 @@ func TestAlertFilterActive_ReportsCorrectState(t *testing.T) {
 func TestToggleAlertFilter_NoAlertedWindowFallback_CursorClamped(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("sess"),
-		states:   map[string]db.ToolState{},
+		states:   []db.ToolState{},
 		cfg:      config.Config{Sidebar: config.SidebarConfig{}},
 	}
 	s.cursor = 5
@@ -613,8 +613,8 @@ func TestFirstStateSession_ReturnsFirstWithState(t *testing.T) {
 			{DisplayName: "beta", IsLive: true},
 			{DisplayName: "gamma", IsLive: true},
 		},
-		states: map[string]db.ToolState{
-			"gamma": {Target: "gamma", Value: db.StateWaiting},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "gamma"}, Value: db.StateWaiting},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
 	}
@@ -632,9 +632,9 @@ func TestFirstStateSession_PrioritySort(t *testing.T) {
 			{DisplayName: "alpha", IsLive: true},
 			{DisplayName: "beta", IsLive: true},
 		},
-		states: map[string]db.ToolState{
-			"alpha": {Target: "alpha", Value: db.StateIdle},
-			"beta":  {Target: "beta", Value: db.StateError},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "alpha"}, Value: db.StateIdle},
+			{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateError},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"priority", "alphabetical"}}},
 	}
@@ -648,7 +648,7 @@ func TestFirstStateSession_PrioritySort(t *testing.T) {
 func TestFirstStateSession_NoneReturnsEmpty(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
-		states:   map[string]db.ToolState{},
+		states:   []db.ToolState{},
 		cfg:      config.Config{Sidebar: config.SidebarConfig{}},
 	}
 	s.rebuildNodes()
@@ -666,7 +666,7 @@ func TestFocusNode_SessionLevel(t *testing.T) {
 			{DisplayName: "alpha", IsLive: true},
 			{DisplayName: "beta", IsLive: true},
 		},
-		states: map[string]db.ToolState{},
+		states: []db.ToolState{},
 		cfg:    config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
 	}
 	s.rebuildNodes()
@@ -680,7 +680,7 @@ func TestFocusNode_SessionLevel(t *testing.T) {
 func TestFocusNode_NoMatch_LeavesCursorAt0(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha"),
-		states:   map[string]db.ToolState{},
+		states:   []db.ToolState{},
 	}
 	s.rebuildNodes()
 	s.FocusNode("nonexistent", 20)
@@ -740,8 +740,8 @@ func TestVisibleSessions_FilterPriority_HidesNoAlert(t *testing.T) {
 			{DisplayName: "alerted", IsLive: true},
 			{DisplayName: "clean", IsLive: true},
 		},
-		states: map[string]db.ToolState{
-			"alerted": {Target: "alerted", Value: db.StateError},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "alerted"}, Value: db.StateError},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -758,8 +758,8 @@ func TestFilterPriority_IncludesFlagged(t *testing.T) {
 			{DisplayName: "flagged", IsLive: true},
 			{DisplayName: "clean", IsLive: true},
 		},
-		states: map[string]db.ToolState{
-			"flagged": {Target: "flagged", Value: db.StateFlagged},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "flagged"}, Value: db.StateFlagged},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -776,8 +776,8 @@ func TestFilterPriority_ExcludesDone(t *testing.T) {
 			{DisplayName: "done-sess", IsLive: true},
 			{DisplayName: "clean", IsLive: true},
 		},
-		states: map[string]db.ToolState{
-			"done-sess": {Target: "done-sess", Value: db.StateDone},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "done-sess"}, Value: db.StateDone},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -796,8 +796,8 @@ func TestFilterPriority_IncludesWorkingWhenFlagSet(t *testing.T) {
 			{DisplayName: "working-sess", IsLive: true},
 			{DisplayName: "clean", IsLive: true},
 		},
-		states: map[string]db.ToolState{
-			"working-sess": {Target: "working-sess", Value: db.StateWorking},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "working-sess"}, Value: db.StateWorking},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{Tui: config.TuiConfig{AttentionFilterIncludeWorking: true}},
@@ -813,8 +813,8 @@ func TestFilterPriority_ExcludesWorkingByDefault(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "working-sess", IsLive: true},
 		},
-		states: map[string]db.ToolState{
-			"working-sess": {Target: "working-sess", Value: db.StateWorking},
+		states: []db.ToolState{
+			{Target: db.Target{Type: "session", ID: "working-sess"}, Value: db.StateWorking},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -956,7 +956,7 @@ func TestRenderSession_ShowsLastSeen(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "myses", IsLive: true, Activity: activity},
 		},
-		states:  map[string]db.ToolState{},
+		states:  []db.ToolState{},
 		gitInfo: map[string]git.Info{},
 		cfg: config.Config{
 			Sidebar: config.SidebarConfig{ShowLastSeen: true},
@@ -980,7 +980,7 @@ func TestRenderSession_HidesLastSeenWhenDisabled(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "xyz", IsLive: true, Activity: activity},
 		},
-		states:  map[string]db.ToolState{},
+		states:  []db.ToolState{},
 		gitInfo: map[string]git.Info{},
 		cfg: config.Config{
 			Sidebar: config.SidebarConfig{ShowLastSeen: false},
@@ -1186,7 +1186,7 @@ func TestRenderSession_ActiveSessionShowsIndicator(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "myapp", IsLive: true},
 		},
-		states:        map[string]db.ToolState{},
+		states:        []db.ToolState{},
 		gitInfo:       map[string]git.Info{},
 		cfg:           config.Config{Sidebar: config.SidebarConfig{ActiveSessionIcon: "►"}},
 		activeSession: "myapp",
@@ -1213,7 +1213,7 @@ func TestRenderSession_NonActiveSessionNoIndicator(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "myapp", IsLive: true},
 		},
-		states:        map[string]db.ToolState{},
+		states:        []db.ToolState{},
 		gitInfo:       map[string]git.Info{},
 		cfg:           config.Config{Sidebar: config.SidebarConfig{ActiveSessionIcon: "►"}},
 		activeSession: "other",
@@ -1236,7 +1236,7 @@ func TestRenderSession_ActiveSessionCustomIcon(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "myapp", IsLive: true},
 		},
-		states:        map[string]db.ToolState{},
+		states:        []db.ToolState{},
 		gitInfo:       map[string]git.Info{},
 		cfg:           config.Config{Sidebar: config.SidebarConfig{ActiveSessionIcon: "@"}},
 		activeSession: "myapp",
@@ -1259,7 +1259,7 @@ func TestRenderSession_ActiveSessionEmptyIconFallsBackToDefault(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "myapp", IsLive: true},
 		},
-		states:        map[string]db.ToolState{},
+		states:        []db.ToolState{},
 		gitInfo:       map[string]git.Info{},
 		cfg:           config.Config{Sidebar: config.SidebarConfig{ActiveSessionIcon: ""}},
 		activeSession: "myapp",
@@ -1286,7 +1286,7 @@ func TestRenderSession_ActiveSessionSelectedFocused(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "myapp", IsLive: true},
 		},
-		states:        map[string]db.ToolState{},
+		states:        []db.ToolState{},
 		gitInfo:       map[string]git.Info{},
 		cfg:           config.Config{Sidebar: config.SidebarConfig{ActiveSessionIcon: "►"}},
 		activeSession: "myapp",

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -429,8 +429,9 @@ func TestRebuildNodes_NoAlerts_AlphabeticalOrder(t *testing.T) {
 func TestRebuildNodes_SessionWithStateSortsFirst(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
+		nameToID: map[string]string{"alpha": "$1", "beta": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$2", SessionID: "$2"}, Value: db.StateWorking},
 		},
 	}
 	s.rebuildNodes()
@@ -443,9 +444,10 @@ func TestRebuildNodes_HigherPriorityStateSortsFirst(t *testing.T) {
 	// error > working, so vem-main (error) must sort before dm-main (working)
 	s := SidebarModel{
 		sessions: makeSessions("dm-main", "vem-main"),
+		nameToID: map[string]string{"dm-main": "$1", "vem-main": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "dm-main"}, Value: db.StateWorking},
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "vem-main"}, Value: db.StateError},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$2", SessionID: "$2"}, Value: db.StateError},
 		},
 	}
 	s.rebuildNodes()
@@ -507,8 +509,9 @@ func TestRebuildNodes_LastSeenSort_ThenAlpha(t *testing.T) {
 func TestToggleAlertFilter_FilterOnHidesSessionsWithoutAlerts(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
+		nameToID: map[string]string{"alpha": "$1", "beta": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$2", SessionID: "$2"}, Value: db.StateWorking},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{}},
 	}
@@ -561,8 +564,9 @@ func TestSetFilter_AllFiltersToggle(t *testing.T) {
 func TestToggleAlertFilter_ToggleOffRestoresAllSessions(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
+		nameToID: map[string]string{"alpha": "$1", "beta": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$2", SessionID: "$2"}, Value: db.StateWorking},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{}},
 	}
@@ -613,8 +617,9 @@ func TestFirstStateSession_ReturnsFirstWithState(t *testing.T) {
 			{DisplayName: "beta", IsLive: true},
 			{DisplayName: "gamma", IsLive: true},
 		},
+		nameToID: map[string]string{"alpha": "$1", "beta": "$2", "gamma": "$3"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "gamma"}, Value: db.StateWaiting},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$3", SessionID: "$3"}, Value: db.StateWaiting},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
 	}
@@ -632,9 +637,10 @@ func TestFirstStateSession_PrioritySort(t *testing.T) {
 			{DisplayName: "alpha", IsLive: true},
 			{DisplayName: "beta", IsLive: true},
 		},
+		nameToID: map[string]string{"alpha": "$1", "beta": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateIdle},
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateError},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"}, Value: db.StateIdle},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$2", SessionID: "$2"}, Value: db.StateError},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"priority", "alphabetical"}}},
 	}
@@ -740,8 +746,9 @@ func TestVisibleSessions_FilterPriority_HidesNoAlert(t *testing.T) {
 			{DisplayName: "alerted", IsLive: true},
 			{DisplayName: "clean", IsLive: true},
 		},
+		nameToID: map[string]string{"alerted": "$1", "clean": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "alerted"}, Value: db.StateError},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"}, Value: db.StateError},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -758,8 +765,9 @@ func TestFilterPriority_IncludesFlagged(t *testing.T) {
 			{DisplayName: "flagged", IsLive: true},
 			{DisplayName: "clean", IsLive: true},
 		},
+		nameToID: map[string]string{"flagged": "$1", "clean": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "flagged"}, Value: db.StateFlagged},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"}, Value: db.StateFlagged},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -776,8 +784,9 @@ func TestFilterPriority_ExcludesDone(t *testing.T) {
 			{DisplayName: "done-sess", IsLive: true},
 			{DisplayName: "clean", IsLive: true},
 		},
+		nameToID: map[string]string{"done-sess": "$1", "clean": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "done-sess"}, Value: db.StateDone},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"}, Value: db.StateDone},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -796,8 +805,9 @@ func TestFilterPriority_IncludesWorkingWhenFlagSet(t *testing.T) {
 			{DisplayName: "working-sess", IsLive: true},
 			{DisplayName: "clean", IsLive: true},
 		},
+		nameToID: map[string]string{"working-sess": "$1", "clean": "$2"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "working-sess"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"}, Value: db.StateWorking},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{Tui: config.TuiConfig{AttentionFilterIncludeWorking: true}},
@@ -813,8 +823,9 @@ func TestFilterPriority_ExcludesWorkingByDefault(t *testing.T) {
 		sessions: []session.Session{
 			{DisplayName: "working-sess", IsLive: true},
 		},
+		nameToID: map[string]string{"working-sess": "$1"},
 		states: []db.ToolState{
-			{Target: db.Target{Type: db.TargetTypeSession, ID: "working-sess"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"}, Value: db.StateWorking},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -430,7 +430,7 @@ func TestRebuildNodes_SessionWithStateSortsFirst(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWorking},
 		},
 	}
 	s.rebuildNodes()
@@ -444,8 +444,8 @@ func TestRebuildNodes_HigherPriorityStateSortsFirst(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("dm-main", "vem-main"),
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "dm-main"}, Value: db.StateWorking},
-			{Target: db.Target{Type: "session", ID: "vem-main"}, Value: db.StateError},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "dm-main"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "vem-main"}, Value: db.StateError},
 		},
 	}
 	s.rebuildNodes()
@@ -508,7 +508,7 @@ func TestToggleAlertFilter_FilterOnHidesSessionsWithoutAlerts(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWorking},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{}},
 	}
@@ -562,7 +562,7 @@ func TestToggleAlertFilter_ToggleOffRestoresAllSessions(t *testing.T) {
 	s := SidebarModel{
 		sessions: makeSessions("alpha", "beta"),
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateWorking},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{}},
 	}
@@ -614,7 +614,7 @@ func TestFirstStateSession_ReturnsFirstWithState(t *testing.T) {
 			{DisplayName: "gamma", IsLive: true},
 		},
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "gamma"}, Value: db.StateWaiting},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "gamma"}, Value: db.StateWaiting},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"alphabetical"}}},
 	}
@@ -633,8 +633,8 @@ func TestFirstStateSession_PrioritySort(t *testing.T) {
 			{DisplayName: "beta", IsLive: true},
 		},
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "alpha"}, Value: db.StateIdle},
-			{Target: db.Target{Type: "session", ID: "beta"}, Value: db.StateError},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateIdle},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "beta"}, Value: db.StateError},
 		},
 		cfg: config.Config{Sidebar: config.SidebarConfig{Sort: []string{"priority", "alphabetical"}}},
 	}
@@ -741,7 +741,7 @@ func TestVisibleSessions_FilterPriority_HidesNoAlert(t *testing.T) {
 			{DisplayName: "clean", IsLive: true},
 		},
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "alerted"}, Value: db.StateError},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "alerted"}, Value: db.StateError},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -759,7 +759,7 @@ func TestFilterPriority_IncludesFlagged(t *testing.T) {
 			{DisplayName: "clean", IsLive: true},
 		},
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "flagged"}, Value: db.StateFlagged},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "flagged"}, Value: db.StateFlagged},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -777,7 +777,7 @@ func TestFilterPriority_ExcludesDone(t *testing.T) {
 			{DisplayName: "clean", IsLive: true},
 		},
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "done-sess"}, Value: db.StateDone},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "done-sess"}, Value: db.StateDone},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},
@@ -797,7 +797,7 @@ func TestFilterPriority_IncludesWorkingWhenFlagSet(t *testing.T) {
 			{DisplayName: "clean", IsLive: true},
 		},
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "working-sess"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "working-sess"}, Value: db.StateWorking},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{Tui: config.TuiConfig{AttentionFilterIncludeWorking: true}},
@@ -814,7 +814,7 @@ func TestFilterPriority_ExcludesWorkingByDefault(t *testing.T) {
 			{DisplayName: "working-sess", IsLive: true},
 		},
 		states: []db.ToolState{
-			{Target: db.Target{Type: "session", ID: "working-sess"}, Value: db.StateWorking},
+			{Target: db.Target{Type: db.TargetTypeSession, ID: "working-sess"}, Value: db.StateWorking},
 		},
 		filter: FilterPriority,
 		cfg:    config.Config{},


### PR DESCRIPTION
## Summary

- **Schema redesign (migrateV8):** Replace single `target` string column (`session:window.pane`) with `target_type` + `target_id` backed by stable tmux IDs (`%N`, `@N`, `\$N`). Composite UNIQUE index on `(target_type, target_id)`.
- **Typed target API:** Add `db.Target` struct with `Type`, `ID`, and denormalized `SessionID`, `WindowID`, `PaneID`. Add `ParseTargetID()` to infer type from ID prefix. Add `Target.Format(paneMap, windowMap, sessionMap)` for display resolution. Replace all string-based lookups with `StateByID()`, `StateSet(target db.Target, ...)`, `StateDeleteBySession(sessionID)`.
- **tmux layer:** Add `Session` and `Window` structs; extend `Pane` with `SessionID`/`WindowID`; add `WindowIDToTargetMap()` and `SessionIDToNameMap()` helpers.
- **CLI layer:** Rename `--target` to `--target-id` accepting `%N/@N/\$N`; fix tmux hook snippet to pass all three stable IDs (`--pane-id`, `--window-id`, `--session-id`) so window- and session-level done states clear on focus; update GC to pass three live-ID maps; update session clear to use session IDs.
- **TUI layer:** Remove `resolveStateTargets` / string-prefix parsing; add `paneIDMap`/`windowIDMap`/`sessionIDMap` display maps to `DetailModel`; `targetDisplayStr` delegates to `Target.Format`; update sidebar `stateForSession` via `nameToIDMap`; rewrite keyboard handlers to construct and use `db.Target` directly.
- **Claude hooks (`~/.claude/settings.json`):** All hook commands migrated from `--target "\$T" --pane-id "\$TMUX_PANE"` to `--target-id "\$TMUX_PANE"`.

## Test Plan

- [x] `go test ./...` — 468 tests pass across 13 packages
- [ ] Start demux in a tmux session and confirm states are stored/cleared correctly for panes, windows, and sessions
- [ ] Rename or move a pane and verify the state follows the pane via stable `%N` ID
- [ ] Test `demux state set --target-id %N --state working` and `demux state clear --target-id %N`
- [ ] Verify TUI sidebar and detail view display correct human-readable targets after ID resolution
- [ ] Confirm GC correctly prunes orphaned states on `demux gc`
- [ ] Re-run `demux hooks init --tool tmux` and apply updated snippet to `~/.tmux.conf`; verify done states clear at pane, window, and session levels on focus change
