### PR TITLE
feat(tui): process management — action menu, environment reading, marquee animation, items panel, and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,7 +827,7 @@ The following `~/.claude/settings.json` configuration makes Claude update the de
         "hooks": [
           {
             "type": "command",
-            "command": "demux state set --target-id \"$TMUX_PANE\" --state working --tool claude --message \"subagent complete\" || demux event hook_error --hook SubagentStop --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
+            "command": "demux state set --target-id \"$TMUX_PANE\" --state working --tool claude --message \"subagent complete\" --if-state working || demux event hook_error --hook SubagentStop --tool claude --target-id \"$TMUX_PANE\" --message \"state set failed\"",
           },
         ],
       },

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -83,6 +83,14 @@ func applyPaneFocus(d *db.DB, paneID, windowID, sessionID string) error {
 			return err
 		}
 	}
+
+	// Keep pane parent IDs fresh so TUI navigation stays accurate after moves
+	// (e.g., break-pane, join-pane across sessions). Non-fatal: log and continue.
+	if paneID != "" && windowID != "" && sessionID != "" {
+		if err := d.StateRefreshParentIDs(paneID, windowID, sessionID); err != nil {
+			demuxlog.Error("pane_focus: refresh parent IDs failed", "pane_id", paneID, "err", err)
+		}
+	}
 	return nil
 }
 

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -177,16 +177,33 @@ func (r stateRow) Fields() []string {
 }
 
 // formatTarget resolves the display string for a Target from the live tmux maps.
-// Falls back to the raw stable ID if not found in maps.
+// When the primary ID is not in the live map (orphaned or moved pane/window),
+// falls back to stored parent IDs from the DB row before returning the raw ID.
 func formatTarget(t db.Target, paneIDMap, windowIDMap, sessionIDMap map[string]string) string {
 	switch t.Type {
 	case db.TargetTypePane:
 		if resolved, ok := paneIDMap[t.ID]; ok {
 			return resolved
 		}
+		// Pane not in live map; try parent IDs stored in DB row.
+		if t.WindowID != "" {
+			if winLabel, ok := windowIDMap[t.WindowID]; ok {
+				return winLabel + ".?"
+			}
+		}
+		if t.SessionID != "" {
+			if sessName, ok := sessionIDMap[t.SessionID]; ok {
+				return sessName + ":?"
+			}
+		}
 	case db.TargetTypeWindow:
 		if resolved, ok := windowIDMap[t.ID]; ok {
 			return resolved
+		}
+		if t.SessionID != "" {
+			if sessName, ok := sessionIDMap[t.SessionID]; ok {
+				return sessName + ":?"
+			}
 		}
 	case db.TargetTypeSession:
 		if resolved, ok := sessionIDMap[t.ID]; ok {

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -157,6 +157,19 @@ func (t Target) Format(paneMap, windowMap, sessionMap map[string]string) string 
 			}
 			return full
 		}
+		// Pane not in live map (orphaned or moved); use stored parent IDs as fallback.
+		if t.WindowID != "" {
+			if full := windowMap[t.WindowID]; full != "" {
+				if idx := strings.Index(full, ":"); idx >= 0 {
+					return "win" + full[idx+1:] + "·?"
+				}
+			}
+		}
+		if t.SessionID != "" {
+			if name := sessionMap[t.SessionID]; name != "" {
+				return name + ":?"
+			}
+		}
 		return t.ID
 	case TargetTypeWindow:
 		if full := windowMap[t.ID]; full != "" {
@@ -164,6 +177,12 @@ func (t Target) Format(paneMap, windowMap, sessionMap map[string]string) string 
 				return "win" + full[idx+1:]
 			}
 			return full
+		}
+		// Window not in live map; fall back to session name.
+		if t.SessionID != "" {
+			if name := sessionMap[t.SessionID]; name != "" {
+				return name + ":?"
+			}
 		}
 		return t.ID
 	case TargetTypeSession:
@@ -216,9 +235,9 @@ func (d *DB) StateSet(t Target, tool string, value StateValue, message string, s
 
 	// Read current record within the transaction.
 	var current *ToolState
-	row := tx.QueryRow(`SELECT tool, value, source FROM tool_states WHERE target_type = ? AND target_id = ?`, t.Type, t.ID)
+	row := tx.QueryRow(`SELECT tool, value, source, session_id FROM tool_states WHERE target_type = ? AND target_id = ?`, t.Type, t.ID)
 	var cur ToolState
-	err = row.Scan(&cur.Tool, &cur.Value, &cur.Source)
+	err = row.Scan(&cur.Tool, &cur.Value, &cur.Source, &cur.Target.SessionID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("read current state: %w", err)
 	}
@@ -228,7 +247,10 @@ func (d *DB) StateSet(t Target, tool string, value StateValue, message string, s
 
 	// No-op if value and tool are unchanged (avoids redundant DB writes from
 	// high-frequency hooks like PreToolUse firing working→working repeatedly).
-	if ifState == nil && current != nil && current.Value == value && current.Tool == tool {
+	// Exception: allow the write through when session_id is unset in the DB but
+	// the caller provides one — the upsert's COALESCE logic will populate it.
+	parentIDMissing := current != nil && current.Target.SessionID == "" && t.SessionID != ""
+	if ifState == nil && current != nil && current.Value == value && current.Tool == tool && !parentIDMissing {
 		demuxlog.Debug("state set skipped: no change", "target_type", t.Type, "target_id", t.ID, "tool", tool, "state", value)
 		return tx.Rollback()
 	}
@@ -346,6 +368,23 @@ func gcDeleteOrphaned(tx *sql.Tx, targetType TargetType, liveIDs map[string]bool
 		return 0, fmt.Errorf("gc orphaned %s: %w", targetType, err)
 	}
 	return res.RowsAffected()
+}
+
+// StateRefreshParentIDs updates session_id and window_id for a pane record when
+// the pane has moved (e.g., break-pane, move-pane to a different session or
+// window). Called on every pane_focus event so the DB stays in sync with the
+// live tmux layout without requiring an explicit state set.
+//
+// updated_at is intentionally left unchanged so state age display is unaffected.
+// No-op when no record exists for paneID or when the stored IDs already match.
+func (d *DB) StateRefreshParentIDs(paneID, windowID, sessionID string) error {
+	_, err := d.sql.Exec(`
+		UPDATE tool_states
+		SET session_id = ?, window_id = ?
+		WHERE target_type = 'pane' AND target_id = ?
+		  AND (session_id IS NOT ? OR window_id IS NOT ?)
+	`, sessionID, windowID, paneID, sessionID, windowID)
+	return err
 }
 
 // StateDeleteBySession removes all state records for the given session.

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -484,3 +484,90 @@ func TestStateSet_EmptySessionWindowPaneIDs(t *testing.T) {
 		t.Errorf("expected empty PaneID, got %q", st.Target.PaneID)
 	}
 }
+
+func TestStateRefreshParentIDs_Updates(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	if err := d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pane moved to a different session/window.
+	if err := d.StateRefreshParentIDs("%1", "@1", "$1"); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := d.StateByID(Target{Type: TargetTypePane, ID: "%1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if st.Target.SessionID != "$1" {
+		t.Errorf("expected SessionID $1, got %q", st.Target.SessionID)
+	}
+	if st.Target.WindowID != "@1" {
+		t.Errorf("expected WindowID @1, got %q", st.Target.WindowID)
+	}
+}
+
+func TestStateRefreshParentIDs_NoopWhenMatch(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	target := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	if err := d.StateSet(target, "claude", StateWorking, "", SourceTool, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// IDs already match; no update should occur.
+	if err := d.StateRefreshParentIDs("%1", "@0", "$0"); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := d.StateByID(Target{Type: TargetTypePane, ID: "%1"})
+	if st == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if st.Target.SessionID != "$0" || st.Target.WindowID != "@0" {
+		t.Errorf("IDs should be unchanged, got session=%q window=%q", st.Target.SessionID, st.Target.WindowID)
+	}
+}
+
+func TestStateRefreshParentIDs_NoopWhenNoRow(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	// No row exists for %99; should not error.
+	if err := d.StateRefreshParentIDs("%99", "@0", "$0"); err != nil {
+		t.Fatalf("expected no error for missing row, got: %v", err)
+	}
+}
+
+func TestStateSet_ParentIDMissing_WritesThrough(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	// Write initial state with empty session_id (simulates a failed resolveParentIDs).
+	bare := Target{Type: TargetTypePane, ID: "%1", SessionID: "", WindowID: "", PaneID: "%1"}
+	if err := d.StateSet(bare, "claude", StateWorking, "step 1", SourceTool, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second write has same value+tool but provides the session_id — must write through.
+	withIDs := Target{Type: TargetTypePane, ID: "%1", SessionID: "$0", WindowID: "@0", PaneID: "%1"}
+	if err := d.StateSet(withIDs, "claude", StateWorking, "step 1", SourceTool, false, nil); err != nil {
+		t.Fatalf("parentIDMissing write-through should not error: %v", err)
+	}
+
+	st, _ := d.StateByID(Target{Type: TargetTypePane, ID: "%1"})
+	if st == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if st.Target.SessionID != "$0" {
+		t.Errorf("expected SessionID $0 after write-through, got %q", st.Target.SessionID)
+	}
+}

--- a/internal/proc/environ_darwin.go
+++ b/internal/proc/environ_darwin.go
@@ -28,7 +28,7 @@ func environPlatform(pid int32) ([]string, error) {
 	parts := bytes.Split(data[4:], []byte{0})
 
 	// parts[0] = executable path (skip)
-	// parts[1..nargs] = argv[1..argc-1] (skip)
+	// parts[1..nargs-1] = argv[1..argc-1] (skip); parts[nargs] = null separator (absorbed by i<=nargs)
 	// parts[nargs+1..] = environment variables
 	var envs []string
 	for i, part := range parts {

--- a/internal/proc/environ_darwin.go
+++ b/internal/proc/environ_darwin.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package proc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// environPlatform reads the environment variables of a process on macOS by
+// parsing the kern.procargs2 sysctl output. The format is:
+//
+//	argc (int32) | exe_path\0 | argv[1]\0 ... argv[argc-1]\0 | env[0]\0 ... env[m]\0
+func environPlatform(pid int32) ([]string, error) {
+	data, err := unix.SysctlRaw("kern.procargs2", int(pid))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 4 {
+		return nil, nil
+	}
+
+	nargs := int(binary.LittleEndian.Uint32(data[:4]))
+	// Split the remainder on null bytes.
+	parts := bytes.Split(data[4:], []byte{0})
+
+	// parts[0] = executable path (skip)
+	// parts[1..nargs] = argv[1..argc-1] (skip)
+	// parts[nargs+1..] = environment variables
+	var envs []string
+	for i, part := range parts {
+		if i == 0 || i <= nargs {
+			continue // skip exe path and argv
+		}
+		s := string(part)
+		if s == "" || !strings.Contains(s, "=") {
+			continue // skip empty separators and non-env entries
+		}
+		envs = append(envs, s)
+	}
+	return envs, nil
+}

--- a/internal/proc/environ_linux.go
+++ b/internal/proc/environ_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package proc
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// environPlatform reads the environment variables of a process on Linux from
+// /proc/<pid>/environ (null-separated KEY=VALUE entries).
+func environPlatform(pid int32) ([]string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var envs []string
+	for _, s := range strings.Split(strings.TrimRight(string(data), "\x00"), "\x00") {
+		if s != "" {
+			envs = append(envs, s)
+		}
+	}
+	return envs, nil
+}

--- a/internal/proc/environ_other.go
+++ b/internal/proc/environ_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package proc
+
+import "errors"
+
+func environPlatform(_ int32) ([]string, error) {
+	return nil, errors.New("env: not supported on this platform")
+}

--- a/internal/proc/snapshot.go
+++ b/internal/proc/snapshot.go
@@ -94,11 +94,7 @@ func Kill(pid int32) error {
 // Environ returns the environment variables for the process with the given PID.
 // Returns an error if the process does not exist or access is denied.
 func Environ(pid int32) ([]string, error) {
-	p, err := gops.NewProcess(pid)
-	if err != nil {
-		return nil, fmt.Errorf("process %d: %w", pid, err)
-	}
-	return p.Environ()
+	return environPlatform(pid)
 }
 
 func BuildTree(procs []Process) map[int32][]Process {

--- a/internal/proc/snapshot.go
+++ b/internal/proc/snapshot.go
@@ -82,6 +82,25 @@ func (p Process) FriendlyName() string {
 	return base
 }
 
+// Kill sends SIGKILL to the process with the given PID.
+func Kill(pid int32) error {
+	p, err := gops.NewProcess(pid)
+	if err != nil {
+		return fmt.Errorf("process %d: %w", pid, err)
+	}
+	return p.Kill()
+}
+
+// Environ returns the environment variables for the process with the given PID.
+// Returns an error if the process does not exist or access is denied.
+func Environ(pid int32) ([]string, error) {
+	p, err := gops.NewProcess(pid)
+	if err != nil {
+		return nil, fmt.Errorf("process %d: %w", pid, err)
+	}
+	return p.Environ()
+}
+
 func BuildTree(procs []Process) map[int32][]Process {
 	tree := make(map[int32][]Process, len(procs))
 	for _, p := range procs {

--- a/internal/proc/snapshot_test.go
+++ b/internal/proc/snapshot_test.go
@@ -2,7 +2,6 @@ package proc_test
 
 import (
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/rtalexk/demux/internal/proc"
@@ -36,9 +35,6 @@ func TestKill_InvalidPID(t *testing.T) {
 }
 
 func TestEnviron_CurrentProcess(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("gopsutil Environ not implemented on macOS")
-	}
 	envs, err := proc.Environ(int32(os.Getpid()))
 	if err != nil {
 		t.Fatalf("Environ current process: %v", err)

--- a/internal/proc/snapshot_test.go
+++ b/internal/proc/snapshot_test.go
@@ -2,6 +2,7 @@ package proc_test
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/rtalexk/demux/internal/proc"
@@ -24,6 +25,33 @@ func TestSnapshot(t *testing.T) {
 	}
 	if !found {
 		t.Error("current process not found in snapshot")
+	}
+}
+
+func TestKill_InvalidPID(t *testing.T) {
+	err := proc.Kill(-999)
+	if err == nil {
+		t.Error("expected error killing invalid PID, got nil")
+	}
+}
+
+func TestEnviron_CurrentProcess(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("gopsutil Environ not implemented on macOS")
+	}
+	envs, err := proc.Environ(int32(os.Getpid()))
+	if err != nil {
+		t.Fatalf("Environ current process: %v", err)
+	}
+	if len(envs) == 0 {
+		t.Error("expected at least one env var for current process")
+	}
+}
+
+func TestEnviron_InvalidPID(t *testing.T) {
+	_, err := proc.Environ(-999)
+	if err == nil {
+		t.Error("expected error for invalid PID, got nil")
 	}
 }
 

--- a/internal/tui/action_menu.go
+++ b/internal/tui/action_menu.go
@@ -26,7 +26,6 @@ type SubPopupKind int
 const (
 	SubPopupNone SubPopupKind = iota
 	SubPopupKillConfirm
-	SubPopupFullCmd
 )
 
 // ActionItem is a single entry in the action menu.
@@ -38,12 +37,10 @@ type ActionItem struct {
 
 // ActionMenuModel holds the state for the action menu and its sub-popups.
 type ActionMenuModel struct {
-	items        []ActionItem
-	cursor       int
-	target       ProcListNode
-	subPopup     SubPopupKind
-	subLines     []string // content lines for scrollable sub-popups
-	subScrollOff int
+	items    []ActionItem
+	cursor   int
+	target   ProcListNode
+	subPopup SubPopupKind
 }
 
 // buildActionItems constructs the dynamic action list for a given process node.
@@ -51,7 +48,7 @@ type ActionMenuModel struct {
 func buildActionItems(node ProcListNode) []ActionItem {
 	items := []ActionItem{
 		{ActionKill, fmt.Sprintf("Kill process (%s)", node.Proc.FriendlyName()), "x"},
-		{ActionRestart, "Restart process", "r"},
+		{ActionRestart, "Re-run last cmd (Up+Enter)", "r"},
 		{ActionViewLogs, "View logs", "l"},
 		{ActionCopyPID, fmt.Sprintf("Copy PID (%d)", node.Proc.PID), "p"},
 	}
@@ -62,11 +59,11 @@ func buildActionItems(node ProcListNode) []ActionItem {
 		items = append(items, ActionItem{ActionCopyCWD, "Copy working directory", "w"})
 	}
 	if node.Port > 0 {
-		items = append(items, ActionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port), ""})
+		items = append(items, ActionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port), "o"})
 	}
 	items = append(items, ActionItem{ActionShowEnv, "Show environment", "d"})
 	if len([]rune(node.Proc.Cmdline)) > 60 {
-		items = append(items, ActionItem{ActionShowFullCmd, "Show full command", ""})
+		items = append(items, ActionItem{ActionShowFullCmd, "Show full command", "f"})
 	}
 	return items
 }
@@ -92,20 +89,6 @@ func (a *ActionMenuModel) Selected() *ActionItem {
 	}
 	it := a.items[a.cursor]
 	return &it
-}
-
-// SubScrollDown scrolls the sub-popup content down by one line.
-func (a *ActionMenuModel) SubScrollDown() {
-	if a.subScrollOff < len(a.subLines)-1 {
-		a.subScrollOff++
-	}
-}
-
-// SubScrollUp scrolls the sub-popup content up by one line.
-func (a *ActionMenuModel) SubScrollUp() {
-	if a.subScrollOff > 0 {
-		a.subScrollOff--
-	}
 }
 
 // Render returns the styled action menu popup string.
@@ -137,41 +120,4 @@ func (a ActionMenuModel) Render() string {
 func (a ActionMenuModel) RenderKillConfirm() string {
 	prompt := fmt.Sprintf("Kill %s (PID %d)?", a.target.Proc.FriendlyName(), a.target.Proc.PID)
 	return ConfirmModel{prompt: prompt}.Render()
-}
-
-// RenderSubPopup returns the styled sub-popup overlay for env vars or full command.
-// height is the number of visible content lines to show (0 = show all).
-func (a ActionMenuModel) RenderSubPopup(height int) string {
-	var title string
-	switch a.subPopup {
-	case SubPopupFullCmd:
-		title = fmt.Sprintf("Command: %s (%d)", a.target.Proc.FriendlyName(), a.target.Proc.PID)
-	default:
-		return ""
-	}
-
-	visible := a.subLines
-	if height > 0 && len(visible) > 0 {
-		start := a.subScrollOff
-		if start >= len(visible) {
-			start = 0
-		}
-		end := start + height
-		if end > len(visible) {
-			end = len(visible)
-		}
-		visible = visible[start:end]
-	}
-
-	var sb strings.Builder
-	sb.WriteString(title)
-	sb.WriteString("\n\n")
-	for _, l := range visible {
-		sb.WriteString("  ")
-		sb.WriteString(l)
-		sb.WriteString("\n")
-	}
-	sb.WriteString("\n")
-	sb.WriteString(hintStyle.Render("j / k") + " scroll   " + hintStyle.Render("Esc / q") + " back")
-	return confirmStyle.Render(sb.String())
 }

--- a/internal/tui/action_menu.go
+++ b/internal/tui/action_menu.go
@@ -31,8 +31,9 @@ const (
 
 // ActionItem is a single entry in the action menu.
 type ActionItem struct {
-	Kind  ActionKind
-	Label string
+	Kind     ActionKind
+	Label    string
+	Shortcut string // single-key shortcut shown in the menu (empty = none)
 }
 
 // ActionMenuModel holds the state for the action menu and its sub-popups.
@@ -49,23 +50,23 @@ type ActionMenuModel struct {
 // Only actions applicable to the node's context are included.
 func buildActionItems(node ProcListNode) []ActionItem {
 	items := []ActionItem{
-		{ActionKill, fmt.Sprintf("Kill process (%s)", node.Proc.FriendlyName())},
-		{ActionRestart, "Restart process"},
-		{ActionViewLogs, "View logs"},
-		{ActionCopyPID, fmt.Sprintf("Copy PID (%d)", node.Proc.PID)},
+		{ActionKill, fmt.Sprintf("Kill process (%s)", node.Proc.FriendlyName()), "K"},
+		{ActionRestart, "Restart process", "r"},
+		{ActionViewLogs, "View logs", "l"},
+		{ActionCopyPID, fmt.Sprintf("Copy PID (%d)", node.Proc.PID), "p"},
 	}
 	if node.Proc.Cmdline != "" {
-		items = append(items, ActionItem{ActionCopyCommand, "Copy command"})
+		items = append(items, ActionItem{ActionCopyCommand, "Copy command", "c"})
 	}
 	if node.Pane.CWD != "" {
-		items = append(items, ActionItem{ActionCopyCWD, "Copy working directory"})
+		items = append(items, ActionItem{ActionCopyCWD, "Copy working directory", "w"})
 	}
 	if node.Port > 0 {
-		items = append(items, ActionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port)})
+		items = append(items, ActionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port), ""})
 	}
-	items = append(items, ActionItem{ActionShowEnv, "Show environment"})
+	items = append(items, ActionItem{ActionShowEnv, "Show environment", "d"})
 	if len([]rune(node.Proc.Cmdline)) > 60 {
-		items = append(items, ActionItem{ActionShowFullCmd, "Show full command"})
+		items = append(items, ActionItem{ActionShowFullCmd, "Show full command", ""})
 	}
 	return items
 }
@@ -114,15 +115,21 @@ func (a ActionMenuModel) Render() string {
 	sb.WriteString(title)
 	sb.WriteString("\n\n")
 	for i, it := range a.items {
-		line := "  " + it.Label
+		prefix := "    " // 4 chars to match "[x] " width
+		if it.Shortcut != "" {
+			prefix = "[" + it.Shortcut + "] "
+		}
+		line := prefix + it.Label
 		if i == a.cursor {
-			line = selectedBG.Render(line)
+			line = selectedBG.Render("  " + line)
+		} else {
+			line = "  " + line
 		}
 		sb.WriteString(line)
 		sb.WriteString("\n")
 	}
 	sb.WriteString("\n")
-	sb.WriteString(hintStyle.Render("Enter") + " select   " + hintStyle.Render("Esc / q") + " close")
+	sb.WriteString(hintStyle.Render("Enter / shortcut") + " select   " + hintStyle.Render("Esc / q") + " close")
 	return confirmStyle.Render(sb.String())
 }
 

--- a/internal/tui/action_menu.go
+++ b/internal/tui/action_menu.go
@@ -3,10 +3,20 @@ package tui
 import (
 	"fmt"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // cmdlineLongThreshold is the rune length above which "Show full command" appears in the action menu.
 const cmdlineLongThreshold = 60
+
+// menuItemIndent is the leading whitespace applied to every menu row so that
+// selected rows (rendered with selectedBG) stay horizontally aligned.
+const menuItemIndent = "  "
+
+// menuItemTrailingPad is the extra width added to the selected-row highlight
+// so the background extends slightly past the longest item text.
+const menuItemTrailingPad = 2
 
 // ActionKind identifies an action in the action menu.
 type ActionKind int
@@ -15,9 +25,6 @@ const (
 	ActionKill ActionKind = iota
 	ActionRestart
 	ActionViewLogs
-	ActionCopyPID
-	ActionCopyCommand
-	ActionCopyCWD
 	ActionOpenBrowser
 	ActionShowEnv
 	ActionShowFullCmd
@@ -53,13 +60,6 @@ func buildActionItems(node ProcListNode) []ActionItem {
 		{ActionKill, fmt.Sprintf("Kill process (%s)", node.Proc.FriendlyName()), "x"},
 		{ActionRestart, "Re-run last cmd (Up+Enter)", "r"},
 		{ActionViewLogs, "View logs", "l"},
-		{ActionCopyPID, fmt.Sprintf("Copy PID (%d)", node.Proc.PID), "p"},
-	}
-	if node.Proc.Cmdline != "" {
-		items = append(items, ActionItem{ActionCopyCommand, "Copy command", "c"})
-	}
-	if node.Pane.CWD != "" {
-		items = append(items, ActionItem{ActionCopyCWD, "Copy working directory", "w"})
 	}
 	if node.Port > 0 {
 		items = append(items, ActionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port), "o"})
@@ -97,19 +97,30 @@ func (a *ActionMenuModel) Selected() *ActionItem {
 // Render returns the styled action menu popup string.
 func (a ActionMenuModel) Render() string {
 	title := fmt.Sprintf("Actions: %s (%d)", a.target.Proc.FriendlyName(), a.target.Proc.PID)
-	var sb strings.Builder
-	sb.WriteString(title)
-	sb.WriteString("\n\n")
+
+	type row struct{ prefix, label string }
+	rows := make([]row, len(a.items))
+	maxW := 0
 	for i, it := range a.items {
 		prefix := "    " // 4 chars to match "[x] " width
 		if it.Shortcut != "" {
 			prefix = "[" + it.Shortcut + "] "
 		}
-		line := prefix + it.Label
+		rows[i] = row{prefix, it.Label}
+		if w := lipgloss.Width(menuItemIndent + prefix + it.Label); w > maxW {
+			maxW = w
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(title)
+	sb.WriteString("\n\n")
+	for i, r := range rows {
+		line := r.prefix + r.label
 		if i == a.cursor {
-			line = selectedBG.Render("  " + line)
+			line = selectedBG.Width(maxW + menuItemTrailingPad).Render(menuItemIndent + line)
 		} else {
-			line = "  " + line
+			line = menuItemIndent + line
 		}
 		sb.WriteString(line)
 		sb.WriteString("\n")

--- a/internal/tui/action_menu.go
+++ b/internal/tui/action_menu.go
@@ -50,7 +50,7 @@ type ActionMenuModel struct {
 // Only actions applicable to the node's context are included.
 func buildActionItems(node ProcListNode) []ActionItem {
 	items := []ActionItem{
-		{ActionKill, fmt.Sprintf("Kill process (%s)", node.Proc.FriendlyName()), "K"},
+		{ActionKill, fmt.Sprintf("Kill process (%s)", node.Proc.FriendlyName()), "x"},
 		{ActionRestart, "Restart process", "r"},
 		{ActionViewLogs, "View logs", "l"},
 		{ActionCopyPID, fmt.Sprintf("Copy PID (%d)", node.Proc.PID), "p"},

--- a/internal/tui/action_menu.go
+++ b/internal/tui/action_menu.go
@@ -18,11 +18,15 @@ const menuItemIndent = "  "
 // so the background extends slightly past the longest item text.
 const menuItemTrailingPad = 2
 
-// ActionKind identifies an action in the action menu.
-type ActionKind int
+// menuItemNoShortcutPad is used as a fallback prefix when an action item has no shortcut,
+// to visually match the width of "[x] ".
+const menuItemNoShortcutPad = "    " // matches len("[x] ") width
+
+// actionKind identifies an action in the action menu.
+type actionKind int
 
 const (
-	ActionKill ActionKind = iota
+	ActionKill actionKind = iota
 	ActionRestart
 	ActionViewLogs
 	ActionOpenBrowser
@@ -30,63 +34,63 @@ const (
 	ActionShowFullCmd
 )
 
-// SubPopupKind identifies which sub-popup is currently open inside the action menu.
-type SubPopupKind int
+// subPopupKind identifies which sub-popup is currently open inside the action menu.
+type subPopupKind int
 
 const (
-	SubPopupNone SubPopupKind = iota
+	SubPopupNone subPopupKind = iota
 	SubPopupKillConfirm
 )
 
-// ActionItem is a single entry in the action menu.
-type ActionItem struct {
-	Kind     ActionKind
+// actionItem is a single entry in the action menu.
+type actionItem struct {
+	Kind     actionKind
 	Label    string
 	Shortcut string // single-key shortcut shown in the menu (empty = none)
 }
 
-// ActionMenuModel holds the state for the action menu and its sub-popups.
-type ActionMenuModel struct {
-	items    []ActionItem
+// actionMenuModel holds the state for the action menu and its sub-popups.
+type actionMenuModel struct {
+	items    []actionItem
 	cursor   int
 	target   ProcListNode
-	subPopup SubPopupKind
+	subPopup subPopupKind
 }
 
 // buildActionItems constructs the dynamic action list for a given process node.
 // Only actions applicable to the node's context are included.
-func buildActionItems(node ProcListNode) []ActionItem {
-	items := []ActionItem{
+func buildActionItems(node ProcListNode) []actionItem {
+	items := []actionItem{
 		{ActionKill, fmt.Sprintf("Kill process (%s)", node.Proc.FriendlyName()), "x"},
 		{ActionRestart, "Re-run last cmd (Up+Enter)", "r"},
 		{ActionViewLogs, "View logs", "l"},
 	}
 	if node.Port > 0 {
-		items = append(items, ActionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port), "o"})
+		items = append(items, actionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port), "o"})
 	}
-	items = append(items, ActionItem{ActionShowEnv, "Show environment", "d"})
+	items = append(items, actionItem{ActionShowEnv, "Show environment", "d"})
 	if len([]rune(node.Proc.Cmdline)) > cmdlineLongThreshold {
-		items = append(items, ActionItem{ActionShowFullCmd, "Show full command", "f"})
+		items = append(items, actionItem{ActionShowFullCmd, "Show full command", "f"})
 	}
 	return items
 }
 
 // MoveDown moves the cursor down by one, clamped at the last item.
-func (a *ActionMenuModel) MoveDown() {
+func (a *actionMenuModel) MoveDown() {
 	if a.cursor < len(a.items)-1 {
 		a.cursor++
 	}
 }
 
 // MoveUp moves the cursor up by one, clamped at zero.
-func (a *ActionMenuModel) MoveUp() {
+func (a *actionMenuModel) MoveUp() {
 	if a.cursor > 0 {
 		a.cursor--
 	}
 }
 
-// Selected returns the currently highlighted ActionItem, or nil when the list is empty.
-func (a *ActionMenuModel) Selected() *ActionItem {
+// Selected returns the currently highlighted actionItem, or nil when the list is empty.
+func (a *actionMenuModel) Selected() *actionItem {
 	if a.cursor < 0 || a.cursor >= len(a.items) {
 		return nil
 	}
@@ -95,14 +99,14 @@ func (a *ActionMenuModel) Selected() *ActionItem {
 }
 
 // Render returns the styled action menu popup string.
-func (a ActionMenuModel) Render() string {
+func (a actionMenuModel) Render() string {
 	title := fmt.Sprintf("Actions: %s (%d)", a.target.Proc.FriendlyName(), a.target.Proc.PID)
 
 	type row struct{ prefix, label string }
 	rows := make([]row, len(a.items))
 	maxW := 0
 	for i, it := range a.items {
-		prefix := "    " // 4 chars to match "[x] " width
+		prefix := menuItemNoShortcutPad
 		if it.Shortcut != "" {
 			prefix = "[" + it.Shortcut + "] "
 		}
@@ -131,7 +135,7 @@ func (a ActionMenuModel) Render() string {
 }
 
 // RenderKillConfirm returns the styled kill-confirmation sub-popup.
-func (a ActionMenuModel) RenderKillConfirm() string {
+func (a actionMenuModel) RenderKillConfirm() string {
 	prompt := fmt.Sprintf("Kill %s (PID %d)?", a.target.Proc.FriendlyName(), a.target.Proc.PID)
 	return ConfirmModel{prompt: prompt}.Render()
 }

--- a/internal/tui/action_menu.go
+++ b/internal/tui/action_menu.go
@@ -1,0 +1,173 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ActionKind identifies an action in the action menu.
+type ActionKind int
+
+const (
+	ActionKill ActionKind = iota
+	ActionRestart
+	ActionViewLogs
+	ActionCopyPID
+	ActionCopyCommand
+	ActionCopyCWD
+	ActionOpenBrowser
+	ActionShowEnv
+	ActionShowFullCmd
+)
+
+// SubPopupKind identifies which sub-popup is currently open inside the action menu.
+type SubPopupKind int
+
+const (
+	SubPopupNone SubPopupKind = iota
+	SubPopupKillConfirm
+	SubPopupEnvVars
+	SubPopupFullCmd
+)
+
+// ActionItem is a single entry in the action menu.
+type ActionItem struct {
+	Kind  ActionKind
+	Label string
+}
+
+// ActionMenuModel holds the state for the action menu and its sub-popups.
+type ActionMenuModel struct {
+	items        []ActionItem
+	cursor       int
+	target       ProcListNode
+	subPopup     SubPopupKind
+	subLines     []string // content lines for scrollable sub-popups
+	subScrollOff int
+}
+
+// buildActionItems constructs the dynamic action list for a given process node.
+// Only actions applicable to the node's context are included.
+func buildActionItems(node ProcListNode) []ActionItem {
+	items := []ActionItem{
+		{ActionKill, fmt.Sprintf("Kill process (%s)", node.Proc.FriendlyName())},
+		{ActionRestart, "Restart process"},
+		{ActionViewLogs, "View logs"},
+		{ActionCopyPID, fmt.Sprintf("Copy PID (%d)", node.Proc.PID)},
+	}
+	if node.Proc.Cmdline != "" {
+		items = append(items, ActionItem{ActionCopyCommand, "Copy command"})
+	}
+	if node.Pane.CWD != "" {
+		items = append(items, ActionItem{ActionCopyCWD, "Copy working directory"})
+	}
+	if node.Port > 0 {
+		items = append(items, ActionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port)})
+	}
+	items = append(items, ActionItem{ActionShowEnv, "Show environment"})
+	if len([]rune(node.Proc.Cmdline)) > 60 {
+		items = append(items, ActionItem{ActionShowFullCmd, "Show full command"})
+	}
+	return items
+}
+
+// MoveDown moves the cursor down by one, clamped at the last item.
+func (a *ActionMenuModel) MoveDown() {
+	if a.cursor < len(a.items)-1 {
+		a.cursor++
+	}
+}
+
+// MoveUp moves the cursor up by one, clamped at zero.
+func (a *ActionMenuModel) MoveUp() {
+	if a.cursor > 0 {
+		a.cursor--
+	}
+}
+
+// Selected returns the currently highlighted ActionItem, or nil when the list is empty.
+func (a *ActionMenuModel) Selected() *ActionItem {
+	if a.cursor < 0 || a.cursor >= len(a.items) {
+		return nil
+	}
+	it := a.items[a.cursor]
+	return &it
+}
+
+// SubScrollDown scrolls the sub-popup content down by one line.
+func (a *ActionMenuModel) SubScrollDown() {
+	if a.subScrollOff < len(a.subLines)-1 {
+		a.subScrollOff++
+	}
+}
+
+// SubScrollUp scrolls the sub-popup content up by one line.
+func (a *ActionMenuModel) SubScrollUp() {
+	if a.subScrollOff > 0 {
+		a.subScrollOff--
+	}
+}
+
+// Render returns the styled action menu popup string.
+func (a ActionMenuModel) Render() string {
+	title := fmt.Sprintf("Actions: %s (%d)", a.target.Proc.FriendlyName(), a.target.Proc.PID)
+	var sb strings.Builder
+	sb.WriteString(title)
+	sb.WriteString("\n\n")
+	for i, it := range a.items {
+		line := "  " + it.Label
+		if i == a.cursor {
+			line = selectedBG.Render(line)
+		}
+		sb.WriteString(line)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(hintStyle.Render("Enter") + " select   " + hintStyle.Render("Esc / q") + " close")
+	return confirmStyle.Render(sb.String())
+}
+
+// RenderKillConfirm returns the styled kill-confirmation sub-popup.
+func (a ActionMenuModel) RenderKillConfirm() string {
+	prompt := fmt.Sprintf("Kill %s (PID %d)?", a.target.Proc.FriendlyName(), a.target.Proc.PID)
+	return ConfirmModel{prompt: prompt}.Render()
+}
+
+// RenderSubPopup returns the styled sub-popup overlay for env vars or full command.
+// height is the number of visible content lines to show (0 = show all).
+func (a ActionMenuModel) RenderSubPopup(height int) string {
+	var title string
+	switch a.subPopup {
+	case SubPopupEnvVars:
+		title = fmt.Sprintf("Environment: %s (%d)", a.target.Proc.FriendlyName(), a.target.Proc.PID)
+	case SubPopupFullCmd:
+		title = fmt.Sprintf("Command: %s (%d)", a.target.Proc.FriendlyName(), a.target.Proc.PID)
+	default:
+		return ""
+	}
+
+	visible := a.subLines
+	if height > 0 && len(visible) > 0 {
+		start := a.subScrollOff
+		if start >= len(visible) {
+			start = 0
+		}
+		end := start + height
+		if end > len(visible) {
+			end = len(visible)
+		}
+		visible = visible[start:end]
+	}
+
+	var sb strings.Builder
+	sb.WriteString(title)
+	sb.WriteString("\n\n")
+	for _, l := range visible {
+		sb.WriteString("  ")
+		sb.WriteString(l)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(hintStyle.Render("j / k") + " scroll   " + hintStyle.Render("Esc / q") + " back")
+	return confirmStyle.Render(sb.String())
+}

--- a/internal/tui/action_menu.go
+++ b/internal/tui/action_menu.go
@@ -26,7 +26,6 @@ type SubPopupKind int
 const (
 	SubPopupNone SubPopupKind = iota
 	SubPopupKillConfirm
-	SubPopupEnvVars
 	SubPopupFullCmd
 )
 
@@ -138,8 +137,6 @@ func (a ActionMenuModel) RenderKillConfirm() string {
 func (a ActionMenuModel) RenderSubPopup(height int) string {
 	var title string
 	switch a.subPopup {
-	case SubPopupEnvVars:
-		title = fmt.Sprintf("Environment: %s (%d)", a.target.Proc.FriendlyName(), a.target.Proc.PID)
 	case SubPopupFullCmd:
 		title = fmt.Sprintf("Command: %s (%d)", a.target.Proc.FriendlyName(), a.target.Proc.PID)
 	default:

--- a/internal/tui/action_menu.go
+++ b/internal/tui/action_menu.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// cmdlineLongThreshold is the rune length above which "Show full command" appears in the action menu.
+const cmdlineLongThreshold = 60
+
 // ActionKind identifies an action in the action menu.
 type ActionKind int
 
@@ -62,7 +65,7 @@ func buildActionItems(node ProcListNode) []ActionItem {
 		items = append(items, ActionItem{ActionOpenBrowser, fmt.Sprintf("Open in browser (:%d)", node.Port), "o"})
 	}
 	items = append(items, ActionItem{ActionShowEnv, "Show environment", "d"})
-	if len([]rune(node.Proc.Cmdline)) > 60 {
+	if len([]rune(node.Proc.Cmdline)) > cmdlineLongThreshold {
 		items = append(items, ActionItem{ActionShowFullCmd, "Show full command", "f"})
 	}
 	return items

--- a/internal/tui/action_menu_test.go
+++ b/internal/tui/action_menu_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+)
+
+func TestBuildActionItems_AlwaysPresent(t *testing.T) {
+	node := ProcListNode{
+		Proc: proc.Process{PID: 42, Name: "node", Cmdline: "node server.js"},
+		Pane: tmux.Pane{CWD: "/home/user/app", PaneID: "%1"},
+	}
+	items := buildActionItems(node)
+	kinds := make(map[ActionKind]bool)
+	for _, it := range items {
+		kinds[it.Kind] = true
+	}
+	for _, required := range []ActionKind{ActionKill, ActionRestart, ActionViewLogs, ActionCopyPID} {
+		if !kinds[required] {
+			t.Errorf("expected action %v in items", required)
+		}
+	}
+}
+
+func TestBuildActionItems_ContextualPort(t *testing.T) {
+	node := ProcListNode{
+		Proc: proc.Process{PID: 1, Name: "node", Cmdline: "node server.js"},
+		Pane: tmux.Pane{PaneID: "%1"},
+		Port: 3000,
+	}
+	items := buildActionItems(node)
+	found := false
+	for _, it := range items {
+		if it.Kind == ActionOpenBrowser {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected ActionOpenBrowser when Port > 0")
+	}
+}
+
+func TestBuildActionItems_NoPortNoOpenBrowser(t *testing.T) {
+	node := ProcListNode{
+		Proc: proc.Process{PID: 1, Name: "go", Cmdline: "go build"},
+		Pane: tmux.Pane{PaneID: "%1"},
+		Port: 0,
+	}
+	items := buildActionItems(node)
+	for _, it := range items {
+		if it.Kind == ActionOpenBrowser {
+			t.Error("ActionOpenBrowser should not appear when Port == 0")
+		}
+	}
+}
+
+func TestBuildActionItems_NoCmdlineNoCopyCommand(t *testing.T) {
+	node := ProcListNode{
+		Proc: proc.Process{PID: 1, Name: "bash", Cmdline: ""},
+		Pane: tmux.Pane{PaneID: "%1"},
+	}
+	items := buildActionItems(node)
+	for _, it := range items {
+		if it.Kind == ActionCopyCommand {
+			t.Error("ActionCopyCommand should not appear when Cmdline is empty")
+		}
+	}
+}
+
+func TestBuildActionItems_NoCWDNoCopyCWD(t *testing.T) {
+	node := ProcListNode{
+		Proc: proc.Process{PID: 1, Name: "bash", Cmdline: "bash"},
+		Pane: tmux.Pane{PaneID: "%1", CWD: ""},
+	}
+	items := buildActionItems(node)
+	for _, it := range items {
+		if it.Kind == ActionCopyCWD {
+			t.Error("ActionCopyCWD should not appear when CWD is empty")
+		}
+	}
+}
+
+func TestActionMenuModel_Navigation(t *testing.T) {
+	m := ActionMenuModel{
+		items:  []ActionItem{{ActionKill, "Kill"}, {ActionRestart, "Restart"}, {ActionViewLogs, "Logs"}},
+		cursor: 0,
+	}
+	m.MoveDown()
+	if m.cursor != 1 {
+		t.Errorf("want cursor=1 after MoveDown, got %d", m.cursor)
+	}
+	m.MoveUp()
+	if m.cursor != 0 {
+		t.Errorf("want cursor=0 after MoveUp, got %d", m.cursor)
+	}
+	// MoveUp at top does not wrap
+	m.MoveUp()
+	if m.cursor != 0 {
+		t.Errorf("want cursor=0 (no wrap up), got %d", m.cursor)
+	}
+	// MoveDown at bottom does not wrap
+	m.cursor = 2
+	m.MoveDown()
+	if m.cursor != 2 {
+		t.Errorf("want cursor=2 (no wrap down), got %d", m.cursor)
+	}
+}
+
+func TestActionMenuModel_SelectedItem(t *testing.T) {
+	m := ActionMenuModel{
+		items:  []ActionItem{{ActionKill, "Kill"}, {ActionRestart, "Restart"}},
+		cursor: 1,
+	}
+	got := m.Selected()
+	if got == nil || got.Kind != ActionRestart {
+		t.Errorf("want ActionRestart, got %v", got)
+	}
+}
+
+func TestActionMenuModel_SubScroll(t *testing.T) {
+	m := ActionMenuModel{
+		subLines: []string{"a", "b", "c", "d"},
+	}
+	m.SubScrollDown()
+	if m.subScrollOff != 1 {
+		t.Errorf("want subScrollOff=1, got %d", m.subScrollOff)
+	}
+	m.SubScrollUp()
+	if m.subScrollOff != 0 {
+		t.Errorf("want subScrollOff=0 after SubScrollUp, got %d", m.subScrollOff)
+	}
+	// clamp at top
+	m.SubScrollUp()
+	if m.subScrollOff != 0 {
+		t.Errorf("want subScrollOff=0 (no wrap), got %d", m.subScrollOff)
+	}
+	// clamp at bottom
+	m.subScrollOff = 3
+	m.SubScrollDown()
+	if m.subScrollOff != 3 {
+		t.Errorf("want subScrollOff=3 (clamped at last), got %d", m.subScrollOff)
+	}
+}

--- a/internal/tui/action_menu_test.go
+++ b/internal/tui/action_menu_test.go
@@ -119,27 +119,3 @@ func TestActionMenuModel_SelectedItem(t *testing.T) {
 	}
 }
 
-func TestActionMenuModel_SubScroll(t *testing.T) {
-	m := ActionMenuModel{
-		subLines: []string{"a", "b", "c", "d"},
-	}
-	m.SubScrollDown()
-	if m.subScrollOff != 1 {
-		t.Errorf("want subScrollOff=1, got %d", m.subScrollOff)
-	}
-	m.SubScrollUp()
-	if m.subScrollOff != 0 {
-		t.Errorf("want subScrollOff=0 after SubScrollUp, got %d", m.subScrollOff)
-	}
-	// clamp at top
-	m.SubScrollUp()
-	if m.subScrollOff != 0 {
-		t.Errorf("want subScrollOff=0 (no wrap), got %d", m.subScrollOff)
-	}
-	// clamp at bottom
-	m.subScrollOff = 3
-	m.SubScrollDown()
-	if m.subScrollOff != 3 {
-		t.Errorf("want subScrollOff=3 (clamped at last), got %d", m.subScrollOff)
-	}
-}

--- a/internal/tui/action_menu_test.go
+++ b/internal/tui/action_menu_test.go
@@ -13,11 +13,11 @@ func TestBuildActionItems_AlwaysPresent(t *testing.T) {
 		Pane: tmux.Pane{CWD: "/home/user/app", PaneID: "%1"},
 	}
 	items := buildActionItems(node)
-	kinds := make(map[ActionKind]bool)
+	kinds := make(map[actionKind]bool)
 	for _, it := range items {
 		kinds[it.Kind] = true
 	}
-	for _, required := range []ActionKind{ActionKill, ActionRestart, ActionViewLogs} {
+	for _, required := range []actionKind{ActionKill, ActionRestart, ActionViewLogs} {
 		if !kinds[required] {
 			t.Errorf("expected action %v in items", required)
 		}
@@ -56,10 +56,9 @@ func TestBuildActionItems_NoPortNoOpenBrowser(t *testing.T) {
 	}
 }
 
-
 func TestActionMenuModel_Navigation(t *testing.T) {
-	m := ActionMenuModel{
-		items:  []ActionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}, {Kind: ActionViewLogs, Label: "Logs"}},
+	m := actionMenuModel{
+		items:  []actionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}, {Kind: ActionViewLogs, Label: "Logs"}},
 		cursor: 0,
 	}
 	m.MoveDown()
@@ -84,8 +83,8 @@ func TestActionMenuModel_Navigation(t *testing.T) {
 }
 
 func TestActionMenuModel_SelectedItem(t *testing.T) {
-	m := ActionMenuModel{
-		items:  []ActionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
+	m := actionMenuModel{
+		items:  []actionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
 		cursor: 1,
 	}
 	got := m.Selected()
@@ -93,4 +92,3 @@ func TestActionMenuModel_SelectedItem(t *testing.T) {
 		t.Errorf("want ActionRestart, got %v", got)
 	}
 }
-

--- a/internal/tui/action_menu_test.go
+++ b/internal/tui/action_menu_test.go
@@ -84,7 +84,7 @@ func TestBuildActionItems_NoCWDNoCopyCWD(t *testing.T) {
 
 func TestActionMenuModel_Navigation(t *testing.T) {
 	m := ActionMenuModel{
-		items:  []ActionItem{{ActionKill, "Kill"}, {ActionRestart, "Restart"}, {ActionViewLogs, "Logs"}},
+		items:  []ActionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}, {Kind: ActionViewLogs, Label: "Logs"}},
 		cursor: 0,
 	}
 	m.MoveDown()
@@ -110,7 +110,7 @@ func TestActionMenuModel_Navigation(t *testing.T) {
 
 func TestActionMenuModel_SelectedItem(t *testing.T) {
 	m := ActionMenuModel{
-		items:  []ActionItem{{ActionKill, "Kill"}, {ActionRestart, "Restart"}},
+		items:  []ActionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
 		cursor: 1,
 	}
 	got := m.Selected()

--- a/internal/tui/action_menu_test.go
+++ b/internal/tui/action_menu_test.go
@@ -17,7 +17,7 @@ func TestBuildActionItems_AlwaysPresent(t *testing.T) {
 	for _, it := range items {
 		kinds[it.Kind] = true
 	}
-	for _, required := range []ActionKind{ActionKill, ActionRestart, ActionViewLogs, ActionCopyPID} {
+	for _, required := range []ActionKind{ActionKill, ActionRestart, ActionViewLogs} {
 		if !kinds[required] {
 			t.Errorf("expected action %v in items", required)
 		}
@@ -56,31 +56,6 @@ func TestBuildActionItems_NoPortNoOpenBrowser(t *testing.T) {
 	}
 }
 
-func TestBuildActionItems_NoCmdlineNoCopyCommand(t *testing.T) {
-	node := ProcListNode{
-		Proc: proc.Process{PID: 1, Name: "bash", Cmdline: ""},
-		Pane: tmux.Pane{PaneID: "%1"},
-	}
-	items := buildActionItems(node)
-	for _, it := range items {
-		if it.Kind == ActionCopyCommand {
-			t.Error("ActionCopyCommand should not appear when Cmdline is empty")
-		}
-	}
-}
-
-func TestBuildActionItems_NoCWDNoCopyCWD(t *testing.T) {
-	node := ProcListNode{
-		Proc: proc.Process{PID: 1, Name: "bash", Cmdline: "bash"},
-		Pane: tmux.Pane{PaneID: "%1", CWD: ""},
-	}
-	items := buildActionItems(node)
-	for _, it := range items {
-		if it.Kind == ActionCopyCWD {
-			t.Error("ActionCopyCWD should not appear when CWD is empty")
-		}
-	}
-}
 
 func TestActionMenuModel_Navigation(t *testing.T) {
 	m := ActionMenuModel{

--- a/internal/tui/consts.go
+++ b/internal/tui/consts.go
@@ -1,0 +1,19 @@
+package tui
+
+import "time"
+
+const (
+	// minDetailH is the minimum height in rows for the detail panel.
+	minDetailH = 4
+
+	// Status bar display durations.
+	statusExpShort  = 2 * time.Second // transient confirmations (yank)
+	statusExpMedium = 3 * time.Second // async action results (procActionMsg)
+	statusExpLong   = 4 * time.Second // item errors (delete, editor)
+	statusExpError  = 5 * time.Second // launch/config errors
+
+	// Background timing.
+	marqueeTick            = 200 * time.Millisecond
+	searchDebounceInterval = 150 * time.Millisecond
+	procPollInterval       = 2 * time.Second
+)

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -60,7 +60,7 @@ func TestHelpRender_KeyBindings(t *testing.T) {
 		"G",         // goto bottom
 		"] / [",     // expand/collapse group
 		"} / {",     // expand/collapse all
-		"L",         // log popup (uppercase, was lowercase l)
+		"a",         // action menu
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in help output:\n%s", want, out)

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -51,6 +51,7 @@ type keyMap struct {
 	ProcEnter         keyDef // display-only: Enter for process list
 	ProcOpen          keyDef // display-only: o/ctrl+o for process list
 	ActionMenu        keyDef
+	KillProc          keyDef
 }
 
 var keys = keyMap{
@@ -103,6 +104,7 @@ var keys = keyMap{
 	ProcEnter:         keyDef{key.NewBinding(key.WithHelp("Enter", "toggle expand / collapse")), "Process list", 4},
 	ProcOpen:          keyDef{key.NewBinding(key.WithHelp("o / ctrl+o", "attach to pane")), "Process list", 5},
 	ActionMenu:        keyDef{key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "action menu")), "Process list", 6},
+	KillProc:          keyDef{key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "kill process (confirm)")), "Process list", 7},
 }
 
 // allKeyDefs returns the ordered list of keyDefs for help menu rendering.
@@ -120,6 +122,6 @@ func allKeyDefs() []keyDef {
 		keys.FilterTmux, keys.FilterAll, keys.FilterConfig, keys.FilterWorktree, keys.StateFilter, keys.WatchFilter,
 		// Process list
 		keys.JumpUpDown, keys.ExpandCollapse, keys.ExpandCollapseAll,
-		keys.ProcEnter, keys.ProcOpen, keys.ActionMenu,
+		keys.ProcEnter, keys.ProcOpen, keys.ActionMenu, keys.KillProc,
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -25,9 +25,6 @@ type keyMap struct {
 	Down              keyDef
 	Enter             keyDef
 	Esc               keyDef
-	Kill              keyDef
-	Restart           keyDef
-	Log               keyDef
 	JumpUpDown        keyDef // display-only combined entry
 	JumpUp            keyDef
 	JumpDown          keyDef
@@ -53,6 +50,7 @@ type keyMap struct {
 	ClearState        keyDef
 	ProcEnter         keyDef // display-only: Enter for process list
 	ProcOpen          keyDef // display-only: o/ctrl+o for process list
+	ActionMenu        keyDef
 }
 
 var keys = keyMap{
@@ -104,9 +102,7 @@ var keys = keyMap{
 	CollapseAll:       keyDef{key.NewBinding(key.WithKeys("{"), key.WithHelp("{", "collapse all")), "", 0},
 	ProcEnter:         keyDef{key.NewBinding(key.WithHelp("Enter", "toggle expand / collapse")), "Process list", 4},
 	ProcOpen:          keyDef{key.NewBinding(key.WithHelp("o / ctrl+o", "attach to pane")), "Process list", 5},
-	Kill:              keyDef{key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "kill process")), "Process list", 6},
-	Restart:           keyDef{key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "restart process")), "Process list", 7},
-	Log:               keyDef{key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "open log popup")), "Process list", 8},
+	ActionMenu:        keyDef{key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "action menu")), "Process list", 6},
 }
 
 // allKeyDefs returns the ordered list of keyDefs for help menu rendering.
@@ -124,6 +120,6 @@ func allKeyDefs() []keyDef {
 		keys.FilterTmux, keys.FilterAll, keys.FilterConfig, keys.FilterWorktree, keys.StateFilter, keys.WatchFilter,
 		// Process list
 		keys.JumpUpDown, keys.ExpandCollapse, keys.ExpandCollapseAll,
-		keys.ProcEnter, keys.ProcOpen, keys.Kill, keys.Restart, keys.Log,
+		keys.ProcEnter, keys.ProcOpen, keys.ActionMenu,
 	}
 }

--- a/internal/tui/marquee.go
+++ b/internal/tui/marquee.go
@@ -38,6 +38,7 @@ func (m Marquee) View(text string, width int) string {
 	}
 
 	runes := []rune(text)
+	// cycle is measured in rune count, not display columns (see Tick doc).
 	cycle := len(runes) + marqueeGap
 
 	// Build: text + gap + text  (sufficient for any offset+width window because width < len(runes))

--- a/internal/tui/marquee.go
+++ b/internal/tui/marquee.go
@@ -6,7 +6,7 @@ import (
 	runewidth "github.com/mattn/go-runewidth"
 )
 
-const marqueeGap = 4 // spaces inserted between end of text and its circular restart
+const marqueeGap = 8 // spaces inserted between end of text and its circular restart
 
 // Marquee scrolls text horizontally in a circular loop.
 // Embed in a model; call Tick() each marquee tick and Reset() when the target text changes.

--- a/internal/tui/marquee.go
+++ b/internal/tui/marquee.go
@@ -28,7 +28,7 @@ func (m *Marquee) Tick() {
 
 // View returns exactly width display columns of text starting at the current offset.
 // If text fits within width it is returned unchanged.
-// The circular sequence is: text + 4 spaces + text (repeating).
+// The circular sequence is: text + marqueeGap spaces + text (repeating).
 func (m Marquee) View(text string, width int) string {
 	if width <= 0 {
 		return ""

--- a/internal/tui/marquee.go
+++ b/internal/tui/marquee.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"strings"
+
+	runewidth "github.com/mattn/go-runewidth"
+)
+
+const marqueeGap = 4 // spaces inserted between end of text and its circular restart
+
+// Marquee scrolls text horizontally in a circular loop.
+// Embed in a model; call Tick() each marquee tick and Reset() when the target text changes.
+// View() is a value receiver — safe to call from value-receiver render functions.
+type Marquee struct {
+	offset int
+}
+
+// Reset sets the scroll position back to 0.
+func (m *Marquee) Reset() {
+	m.offset = 0
+}
+
+// Tick advances the scroll position by one rune.
+func (m *Marquee) Tick() {
+	m.offset++
+}
+
+// View returns exactly width display columns of text starting at the current offset.
+// If text fits within width it is returned unchanged.
+// The circular sequence is: text + 4 spaces + text (repeating).
+func (m Marquee) View(text string, width int) string {
+	if runewidth.StringWidth(text) <= width {
+		return text
+	}
+
+	runes := []rune(text)
+	cycle := len(runes) + marqueeGap
+
+	// Build: text + gap + text  (sufficient for any offset+width window because width < len(runes))
+	extended := make([]rune, 0, len(runes)*2+marqueeGap)
+	extended = append(extended, runes...)
+	for range marqueeGap {
+		extended = append(extended, ' ')
+	}
+	extended = append(extended, runes...)
+
+	start := m.offset % cycle
+
+	var out []rune
+	cols := 0
+	for i := start; i < len(extended) && cols < width; i++ {
+		w := runewidth.RuneWidth(extended[i])
+		if cols+w > width {
+			break
+		}
+		out = append(out, extended[i])
+		cols += w
+	}
+	if cols < width {
+		out = append(out, []rune(strings.Repeat(" ", width-cols))...)
+	}
+	return string(out)
+}

--- a/internal/tui/marquee.go
+++ b/internal/tui/marquee.go
@@ -26,6 +26,17 @@ func (m *Marquee) Tick() {
 	m.offset++
 }
 
+// TickTracked advances the marquee, resetting if cursor moved since the last tick.
+// Pass the current cursor and a pointer to the last-seen cursor value (owned by the caller).
+func (m *Marquee) TickTracked(cursor int, last *int) {
+	if cursor != *last {
+		m.Reset()
+		*last = cursor
+		return
+	}
+	m.Tick()
+}
+
 // View returns exactly width display columns of text starting at the current offset.
 // If text fits within width it is returned unchanged.
 // The circular sequence is: text + marqueeGap spaces + text (repeating).

--- a/internal/tui/marquee.go
+++ b/internal/tui/marquee.go
@@ -20,7 +20,8 @@ func (m *Marquee) Reset() {
 	m.offset = 0
 }
 
-// Tick advances the scroll position by one rune.
+// Tick advances the scroll position by one rune position.
+// Cycle length is measured in rune count, not display columns.
 func (m *Marquee) Tick() {
 	m.offset++
 }
@@ -29,6 +30,9 @@ func (m *Marquee) Tick() {
 // If text fits within width it is returned unchanged.
 // The circular sequence is: text + 4 spaces + text (repeating).
 func (m Marquee) View(text string, width int) string {
+	if width <= 0 {
+		return ""
+	}
 	if runewidth.StringWidth(text) <= width {
 		return text
 	}

--- a/internal/tui/marquee_test.go
+++ b/internal/tui/marquee_test.go
@@ -31,7 +31,7 @@ func TestMarqueeView_scroll(t *testing.T) {
 }
 
 func TestMarqueeView_gap(t *testing.T) {
-	// "ABCDEF" = 6 runes, gap = 4, cycle = 10
+	// "ABCDEF" = 6 runes, gap = 8, cycle = 14
 	// offset=6 → extended[6..8] are spaces
 	m := Marquee{offset: 6}
 	got := m.View("ABCDEF", 3)
@@ -41,8 +41,8 @@ func TestMarqueeView_gap(t *testing.T) {
 }
 
 func TestMarqueeView_wrap(t *testing.T) {
-	// offset=10 = one full cycle → back to start
-	m := Marquee{offset: 10}
+	// offset=14 = one full cycle → back to start
+	m := Marquee{offset: 14}
 	got := m.View("ABCDEF", 3)
 	if got != "ABC" {
 		t.Errorf("want %q, got %q", "ABC", got)

--- a/internal/tui/marquee_test.go
+++ b/internal/tui/marquee_test.go
@@ -1,0 +1,86 @@
+package tui
+
+import (
+	"testing"
+
+	runewidth "github.com/mattn/go-runewidth"
+)
+
+func TestMarqueeView_fits(t *testing.T) {
+	var m Marquee
+	got := m.View("hello", 10)
+	if got != "hello" {
+		t.Errorf("want %q, got %q", "hello", got)
+	}
+}
+
+func TestMarqueeView_offset0(t *testing.T) {
+	var m Marquee
+	got := m.View("ABCDEF", 3)
+	if got != "ABC" {
+		t.Errorf("want %q, got %q", "ABC", got)
+	}
+}
+
+func TestMarqueeView_scroll(t *testing.T) {
+	m := Marquee{offset: 1}
+	got := m.View("ABCDEF", 3)
+	if got != "BCD" {
+		t.Errorf("want %q, got %q", "BCD", got)
+	}
+}
+
+func TestMarqueeView_gap(t *testing.T) {
+	// "ABCDEF" = 6 runes, gap = 4, cycle = 10
+	// offset=6 → extended[6..8] are spaces
+	m := Marquee{offset: 6}
+	got := m.View("ABCDEF", 3)
+	if got != "   " {
+		t.Errorf("want 3 spaces, got %q", got)
+	}
+}
+
+func TestMarqueeView_wrap(t *testing.T) {
+	// offset=10 = one full cycle → back to start
+	m := Marquee{offset: 10}
+	got := m.View("ABCDEF", 3)
+	if got != "ABC" {
+		t.Errorf("want %q, got %q", "ABC", got)
+	}
+}
+
+func TestMarqueeView_exactWidth(t *testing.T) {
+	// offset=5 puts us into the gap; result must still be exactly width cols
+	m := Marquee{offset: 5}
+	got := m.View("HELLO", 4)
+	if cols := runewidth.StringWidth(got); cols != 4 {
+		t.Errorf("want 4 display cols, got %d (%q)", cols, got)
+	}
+}
+
+func TestMarqueeView_multibyte(t *testing.T) {
+	// '中' is 2 display columns; "中文字" = 6 cols, width=4 → 2 chars fit exactly
+	var m Marquee
+	got := m.View("中文字", 4)
+	if cols := runewidth.StringWidth(got); cols != 4 {
+		t.Errorf("want 4 display cols, got %d (%q)", cols, got)
+	}
+}
+
+func TestMarqueeReset(t *testing.T) {
+	m := Marquee{offset: 5}
+	m.Reset()
+	got := m.View("ABCDEF", 3)
+	if got != "ABC" {
+		t.Errorf("after Reset, want %q, got %q", "ABC", got)
+	}
+}
+
+func TestMarqueeTick(t *testing.T) {
+	var m Marquee
+	m.Tick()
+	got := m.View("ABCDEF", 3)
+	if got != "BCD" {
+		t.Errorf("after one Tick, want %q, got %q", "BCD", got)
+	}
+}

--- a/internal/tui/marquee_test.go
+++ b/internal/tui/marquee_test.go
@@ -84,3 +84,11 @@ func TestMarqueeTick(t *testing.T) {
 		t.Errorf("after one Tick, want %q, got %q", "BCD", got)
 	}
 }
+
+func TestMarqueeView_zeroWidth(t *testing.T) {
+	var m Marquee
+	got := m.View("ABCDEF", 0)
+	if got != "" {
+		t.Errorf("want empty string for width=0, got %q", got)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -127,7 +127,7 @@ type Model struct {
 	sidebar  SidebarModel
 	procList ProcListModel
 	detail   DetailModel
-	yank     YankModel
+	yank     yankModel
 	help     HelpModel
 
 	showYank    bool
@@ -158,7 +158,7 @@ type Model struct {
 	itemInput   ItemInputModel
 
 	showActionMenu bool
-	actionMenu     ActionMenuModel
+	actionMenu     actionMenuModel
 
 	sessionsConfig session.SessionsConfig
 	configDir      string
@@ -285,8 +285,7 @@ func (m Model) buildLayoutDims() layoutDims {
 	innerW := procW - 2
 	detailContent := m.detail.ContentLines(innerW)
 	detailH := detailContent + 2
-	minDetailH := 4
-	maxDetailH := contentH - 4
+	maxDetailH := contentH - minDetailH
 	if detailH < minDetailH {
 		detailH = minDetailH
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -322,7 +322,7 @@ func (m Model) buildProcTitle() string {
 		procTitleSuffix = "  "
 	}
 	title := " [l] " + bc + procTitleSuffix
-	if st := m.sidebar.stateForSession(bc); st != nil {
+	if st := m.sidebar.sessionTargetStateFor(bc); st != nil {
 		effective := *st
 		effective.Value = ageDrivenValue(*st, m.cfg.Tui.DoneIdleAfterSecs)
 		title += paneSepStyle.Render("────") + "  " + paneStateIndicator(&effective) + " "

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -85,9 +85,13 @@ type gitResultMsg struct {
 }
 
 type searchDebounceMsg struct{ gen int }
-type envResultMsg struct {
-	lines []string
-	err   error
+
+// openViewerMsg carries the path to a temp file that should be opened in a
+// read-only terminal viewer (nvim/vim/vi -R).
+// ftCmd is an optional ex-command passed via -c (e.g. "set ft=sh").
+type openViewerMsg struct {
+	path  string
+	ftCmd string
 }
 
 // procActionMsg carries the result of an async process action (kill, restart, etc.)
@@ -340,7 +344,7 @@ func (m Model) applyOverlay(base string) string {
 		switch m.actionMenu.subPopup {
 		case SubPopupKillConfirm:
 			return overlayCenter(m.actionMenu.RenderKillConfirm(), base, m.width, m.height)
-		case SubPopupEnvVars, SubPopupFullCmd:
+		case SubPopupFullCmd:
 			return overlayCenter(m.actionMenu.RenderSubPopup(20), base, m.width, m.height)
 		default:
 			return overlayCenter(m.actionMenu.Render(), base, m.width, m.height)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -142,6 +142,9 @@ type Model struct {
 	itemSession string
 	itemInput   ItemInputModel
 
+	showActionMenu bool
+	actionMenu     ActionMenuModel
+
 	sessionsConfig session.SessionsConfig
 	configDir      string
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -85,6 +85,16 @@ type gitResultMsg struct {
 }
 
 type searchDebounceMsg struct{ gen int }
+type envResultMsg struct {
+	lines []string
+	err   error
+}
+
+// procActionMsg carries the result of an async process action (kill, restart, etc.)
+// for display in the status bar.
+type procActionMsg struct {
+	status string
+}
 type queryResultMsg struct {
 	result query.Result
 	gen    int
@@ -326,6 +336,16 @@ func (m Model) applyOverlay(base string) string {
 	if m.showConfirm {
 		return overlayCenter(m.confirm.Render(), base, m.width, m.height)
 	}
+	if m.showActionMenu {
+		switch m.actionMenu.subPopup {
+		case SubPopupKillConfirm:
+			return overlayCenter(m.actionMenu.RenderKillConfirm(), base, m.width, m.height)
+		case SubPopupEnvVars, SubPopupFullCmd:
+			return overlayCenter(m.actionMenu.RenderSubPopup(20), base, m.width, m.height)
+		default:
+			return overlayCenter(m.actionMenu.Render(), base, m.width, m.height)
+		}
+	}
 	return base
 }
 
@@ -344,7 +364,7 @@ func (m Model) buildStatusBar(width int) string {
 	} else if m.focus == panelSidebar {
 		statusBar = "  Tab:cycle  j/k:nav  Enter:select  !:states  ?:help  q:quit"
 	} else {
-		statusBar = "  Tab:cycle  j/k:nav  J/K:jump  x:kill  r:restart  l:log  q:quit"
+		statusBar = "  Tab:cycle  j/k:nav  J/K:jump  a:actions  q:quit"
 	}
 
 	spinnerStr := ""

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -51,6 +51,7 @@ var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "�
 
 // Message types
 type tickMsg time.Time
+type marqueeTickMsg time.Time
 type panesMsg struct {
 	panes          []tmux.Pane
 	currentSession string // populated by CurrentTarget(); used for startup focus in Task 4
@@ -192,7 +193,7 @@ func New(cfg config.Config, database *db.DB) Model {
 func (m Model) Init() tea.Cmd {
 	// Fetch panes and states in parallel so the first sidebar render uses
 	// correct state-based sort. Tick and procs are deferred until panesMsg arrives.
-	return tea.Batch(m.fetchPanes(), m.fetchStates())
+	return tea.Batch(m.fetchPanes(), m.fetchStates(), marqueeCmd())
 }
 
 func (m Model) View() string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -341,14 +341,10 @@ func (m Model) applyOverlay(base string) string {
 		return overlayCenter(m.confirm.Render(), base, m.width, m.height)
 	}
 	if m.showActionMenu {
-		switch m.actionMenu.subPopup {
-		case SubPopupKillConfirm:
+		if m.actionMenu.subPopup == SubPopupKillConfirm {
 			return overlayCenter(m.actionMenu.RenderKillConfirm(), base, m.width, m.height)
-		case SubPopupFullCmd:
-			return overlayCenter(m.actionMenu.RenderSubPopup(20), base, m.width, m.height)
-		default:
-			return overlayCenter(m.actionMenu.Render(), base, m.width, m.height)
 		}
+		return overlayCenter(m.actionMenu.Render(), base, m.width, m.height)
 	}
 	return base
 }

--- a/internal/tui/model_compact_test.go
+++ b/internal/tui/model_compact_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/db"
 )
 
 func TestCompactView_OmitsProcList(t *testing.T) {
@@ -125,5 +126,73 @@ func TestCompactUpdate_FocusProcListIsNoop(t *testing.T) {
 
 	if updated.focus != panelSidebar {
 		t.Errorf("compact mode: pressing 'l' should not move focus off panelSidebar, got %v", updated.focus)
+	}
+}
+
+// setupModelWithSessionAndStates returns a Model with one sidebar session
+// "work" ($1) and the given states loaded.
+func setupModelWithSessionAndStates(states []db.ToolState) Model {
+	m := New(config.Default(), nil)
+	m.sidebar.nodes = []SidebarNode{{Session: "work"}}
+	m.sidebar.cursor = 0
+	m.sidebar.nameToID = map[string]string{"work": "$1"}
+	m.sidebar.states = states
+	return m
+}
+
+func TestBuildProcTitle_IgnoresPaneState(t *testing.T) {
+	// Pane state in session "$1" — must NOT appear in the Proclist title.
+	m := setupModelWithSessionAndStates([]db.ToolState{
+		{
+			Target:  db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1", PaneID: "%1"},
+			Value:   db.StateError,
+			Message: "PANE-STATE-MUST-NOT-APPEAR",
+		},
+	})
+
+	title := m.buildProcTitle()
+	if strings.Contains(title, "PANE-STATE-MUST-NOT-APPEAR") {
+		t.Error("buildProcTitle must not include pane state in session title")
+	}
+}
+
+func TestBuildProcTitle_ShowsSessionTargetState(t *testing.T) {
+	// Session-level state — MUST appear in the Proclist title.
+	m := setupModelWithSessionAndStates([]db.ToolState{
+		{
+			Target:  db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"},
+			Value:   db.StateWorking,
+			Message: "SESSION-STATE-MUST-APPEAR",
+		},
+	})
+
+	title := m.buildProcTitle()
+	if !strings.Contains(title, "SESSION-STATE-MUST-APPEAR") {
+		t.Errorf("buildProcTitle must show session-level state badge; title=%q", title)
+	}
+}
+
+func TestBuildProcTitle_PaneStateTakesPrecedenceButSessionTitleIgnoresIt(t *testing.T) {
+	// Pane has higher-priority state (error) than session (working).
+	// Sidebar would show error; title must only show the session-level working state.
+	m := setupModelWithSessionAndStates([]db.ToolState{
+		{
+			Target:  db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1", PaneID: "%1"},
+			Value:   db.StateError,
+			Message: "PANE-ERROR-MUST-NOT-APPEAR",
+		},
+		{
+			Target:  db.Target{Type: db.TargetTypeSession, ID: "$1", SessionID: "$1"},
+			Value:   db.StateWorking,
+			Message: "SESSION-WORKING-MUST-APPEAR",
+		},
+	})
+
+	title := m.buildProcTitle()
+	if strings.Contains(title, "PANE-ERROR-MUST-NOT-APPEAR") {
+		t.Error("buildProcTitle must not leak pane state into session title")
+	}
+	if !strings.Contains(title, "SESSION-WORKING-MUST-APPEAR") {
+		t.Errorf("buildProcTitle must show session-level state; title=%q", title)
 	}
 }

--- a/internal/tui/model_fetch.go
+++ b/internal/tui/model_fetch.go
@@ -18,7 +18,7 @@ func tick(interval time.Duration) tea.Cmd {
 }
 
 func marqueeCmd() tea.Cmd {
-	return tea.Tick(200*time.Millisecond, func(t time.Time) tea.Msg {
+	return tea.Tick(marqueeTick, func(t time.Time) tea.Msg {
 		return marqueeTickMsg(t)
 	})
 }
@@ -120,7 +120,7 @@ func (m Model) scheduleProcFetch() tea.Cmd {
 // scheduleDelayedProcFetch schedules a proc snapshot after 2s, tagged with the current generation.
 func (m Model) scheduleDelayedProcFetch() tea.Cmd {
 	fetch := makeProcFetch(m.procGen)
-	return tea.Tick(2*time.Second, func(_ time.Time) tea.Msg {
+	return tea.Tick(procPollInterval, func(_ time.Time) tea.Msg {
 		return fetch()
 	})
 }
@@ -138,7 +138,7 @@ func fetchGit(k, dir string, timeoutMs int) tea.Cmd {
 
 func debounceSearch(gen int) tea.Cmd {
 	return func() tea.Msg {
-		time.Sleep(150 * time.Millisecond)
+		time.Sleep(searchDebounceInterval)
 		return searchDebounceMsg{gen: gen}
 	}
 }

--- a/internal/tui/model_fetch.go
+++ b/internal/tui/model_fetch.go
@@ -17,6 +17,12 @@ func tick(interval time.Duration) tea.Cmd {
 	})
 }
 
+func marqueeCmd() tea.Cmd {
+	return tea.Tick(200*time.Millisecond, func(t time.Time) tea.Msg {
+		return marqueeTickMsg(t)
+	})
+}
+
 func resolveWindowSpecs(ids []string, templates map[string]session.WindowTemplate) []tmux.WindowSpec {
 	specs, unknown := session.ResolveWindowSpecs(ids, templates)
 	for _, id := range unknown {

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -698,11 +699,19 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 	case ActionViewLogs:
 		paneID := m.actionMenu.target.Pane.PaneID
 		m.showActionMenu = false
-		script := fmt.Sprintf("tmux capture-pane -t %s -p -S -32768 | less -R", paneID)
-		return m, tea.ExecProcess(
-			exec.Command("tmux", "display-popup", "-E", "-w", "80%", "-h", "80%", script),
-			func(err error) tea.Msg { return nil },
-		)
+		return m, func() tea.Msg {
+			out, err := exec.Command("tmux", "capture-pane", "-t", paneID, "-p", "-S", "-32768").Output()
+			if err != nil {
+				return procActionMsg{"logs: " + err.Error()}
+			}
+			f, err := os.CreateTemp("", "demux-logs-*.log")
+			if err != nil {
+				return procActionMsg{"logs: " + err.Error()}
+			}
+			_, _ = f.Write(out)
+			_ = f.Close()
+			return openViewerMsg{path: f.Name()}
+		}
 
 	case ActionCopyPID:
 		val := fmt.Sprintf("%d", m.actionMenu.target.Proc.PID)
@@ -746,9 +755,21 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 
 	case ActionShowEnv:
 		pid := m.actionMenu.target.Proc.PID
+		m.showActionMenu = false
 		return m, func() tea.Msg {
 			lines, err := proc.Environ(pid)
-			return envResultMsg{lines: lines, err: err}
+			if err != nil {
+				return procActionMsg{"env: " + err.Error()}
+			}
+			f, err := os.CreateTemp("", "demux-env-*.txt")
+			if err != nil {
+				return procActionMsg{"env: " + err.Error()}
+			}
+			for _, l := range lines {
+				_, _ = fmt.Fprintln(f, l)
+			}
+			_ = f.Close()
+			return openViewerMsg{path: f.Name(), ftCmd: "set ft=sh"}
 		}
 
 	case ActionShowFullCmd:

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -2,9 +2,9 @@ package tui
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -709,13 +709,11 @@ func (m Model) executeActionMenuItem() (Model, tea.Cmd) {
 			if err != nil {
 				return procActionMsg{"logs: " + err.Error()}
 			}
-			f, err := os.CreateTemp("", "demux-logs-*.log")
+			path, err := writeTempFile("demux-logs-*.log", out)
 			if err != nil {
 				return procActionMsg{"logs: " + err.Error()}
 			}
-			_, _ = f.Write(out)
-			_ = f.Close()
-			return openViewerMsg{path: f.Name()}
+			return openViewerMsg{path: path}
 		}
 
 	case ActionOpenBrowser:
@@ -746,28 +744,22 @@ func (m Model) executeActionMenuItem() (Model, tea.Cmd) {
 			if err != nil {
 				return procActionMsg{"env: " + err.Error()}
 			}
-			f, err := os.CreateTemp("", "demux-env-*.txt")
+			path, err := writeTempFile("demux-env-*.txt", []byte(strings.Join(lines, "\n")+"\n"))
 			if err != nil {
 				return procActionMsg{"env: " + err.Error()}
 			}
-			for _, l := range lines {
-				_, _ = fmt.Fprintln(f, l)
-			}
-			_ = f.Close()
-			return openViewerMsg{path: f.Name(), ftCmd: "set ft=sh"}
+			return openViewerMsg{path: path, ftCmd: "set ft=sh"}
 		}
 
 	case ActionShowFullCmd:
 		cmdline := m.actionMenu.target.Proc.Cmdline
 		m.showActionMenu = false
 		return m, func() tea.Msg {
-			f, err := os.CreateTemp("", "demux-cmd-*.txt")
+			path, err := writeTempFile("demux-cmd-*.txt", []byte(cmdline+"\n"))
 			if err != nil {
 				return procActionMsg{"cmd: " + err.Error()}
 			}
-			_, _ = fmt.Fprintln(f, cmdline)
-			_ = f.Close()
-			return openViewerMsg{path: f.Name()}
+			return openViewerMsg{path: path}
 		}
 	}
 	return m, nil

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -627,6 +627,22 @@ func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.actionMenu.subPopup != SubPopupNone {
 		return m.handleSubPopupKey(msg)
 	}
+	switch msg.String() {
+	case "K":
+		return m.executeActionByKind(ActionKill)
+	case "r":
+		return m.executeActionByKind(ActionRestart)
+	case "l":
+		return m.executeActionByKind(ActionViewLogs)
+	case "p":
+		return m.executeActionByKind(ActionCopyPID)
+	case "c":
+		return m.executeActionByKind(ActionCopyCommand)
+	case "w":
+		return m.executeActionByKind(ActionCopyCWD)
+	case "d":
+		return m.executeActionByKind(ActionShowEnv)
+	}
 	switch {
 	case key.Matches(msg, keys.Down.Binding):
 		m.actionMenu.MoveDown()
@@ -636,6 +652,18 @@ func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.executeActionMenuItem()
 	case msg.String() == "q", key.Matches(msg, keys.Esc.Binding):
 		m.showActionMenu = false
+	}
+	return m, nil
+}
+
+// executeActionByKind finds the item with the given kind and executes it.
+// No-op if the action is not present in the current menu (context-dependent items).
+func (m Model) executeActionByKind(kind ActionKind) (tea.Model, tea.Cmd) {
+	for i, item := range m.actionMenu.items {
+		if item.Kind == kind {
+			m.actionMenu.cursor = i
+			return m.executeActionMenuItem()
+		}
 	}
 	return m, nil
 }
@@ -788,6 +816,22 @@ func (m Model) openActionMenu() Model {
 	node := m.procList.SelectedNode()
 	if node == nil {
 		return m
+	}
+	// displayPane suppresses CWD when it matches the window CWD. Recover the real
+	// value from the live pane list so Copy Working Directory is always available.
+	if node.Pane.CWD == "" && node.Pane.PaneID != "" {
+		for _, p := range m.panes {
+			if p.PaneID == node.Pane.PaneID {
+				node.Pane.CWD = p.CWD
+				break
+			}
+		}
+	}
+	// For process nodes prefer the live async CWD (may differ from pane CWD).
+	if node.Proc.PID != 0 {
+		if cwd := m.cwdMap[node.Proc.PID]; cwd != "" {
+			node.Pane.CWD = cwd
+		}
 	}
 	m.actionMenu = ActionMenuModel{
 		items:  buildActionItems(*node),

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -1,11 +1,13 @@
 package tui
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/proc"
 	"github.com/rtalexk/demux/internal/query"
 	"github.com/rtalexk/demux/internal/session"
 	"github.com/rtalexk/demux/internal/tmux"
@@ -614,6 +616,82 @@ func (m Model) openSidebarSelected() (Model, tea.Cmd) {
 	}
 	sess := m.sidebar.FindSession(node.Session)
 	return m.launchOrSwitchSession(sess, node.Session)
+}
+
+// handleActionMenuKey routes keys when the action menu (or a sub-popup) is open.
+func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.actionMenu.subPopup != SubPopupNone {
+		return m.handleSubPopupKey(msg)
+	}
+	switch {
+	case key.Matches(msg, keys.Down.Binding):
+		m.actionMenu.MoveDown()
+	case key.Matches(msg, keys.Up.Binding):
+		m.actionMenu.MoveUp()
+	case key.Matches(msg, keys.Enter.Binding):
+		return m.executeActionMenuItem()
+	case msg.String() == "q", key.Matches(msg, keys.Esc.Binding):
+		m.showActionMenu = false
+	}
+	return m, nil
+}
+
+// handleSubPopupKey routes keys when a sub-popup is open inside the action menu.
+func (m Model) handleSubPopupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.actionMenu.subPopup == SubPopupKillConfirm {
+		switch msg.String() {
+		case "y", "enter":
+			pid := m.actionMenu.target.Proc.PID
+			m.showActionMenu = false
+			m.actionMenu.subPopup = SubPopupNone
+			return m, func() tea.Msg {
+				if err := proc.Kill(pid); err != nil {
+					return procActionMsg{fmt.Sprintf("kill %d: %v", pid, err)}
+				}
+				return procActionMsg{fmt.Sprintf("killed PID %d", pid)}
+			}
+		case "n":
+			m.actionMenu.subPopup = SubPopupNone
+			return m, nil
+		case "esc", "q":
+			m.actionMenu.subPopup = SubPopupNone
+			return m, nil
+		}
+		return m, nil
+	}
+	switch {
+	case key.Matches(msg, keys.Down.Binding):
+		m.actionMenu.SubScrollDown()
+	case key.Matches(msg, keys.Up.Binding):
+		m.actionMenu.SubScrollUp()
+	case msg.String() == "q", key.Matches(msg, keys.Esc.Binding):
+		m.actionMenu.subPopup = SubPopupNone
+		m.actionMenu.subLines = nil
+		m.actionMenu.subScrollOff = 0
+	}
+	return m, nil
+}
+
+// executeActionMenuItem executes the currently selected action menu item.
+// Individual action implementations are added in subsequent tasks.
+func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
+	item := m.actionMenu.Selected()
+	if item == nil {
+		return m, nil
+	}
+	switch item.Kind {
+	case ActionKill:
+		m.actionMenu.subPopup = SubPopupKillConfirm
+		return m, nil
+	case ActionShowEnv:
+		pid := m.actionMenu.target.Proc.PID
+		return m, func() tea.Msg {
+			lines, err := proc.Environ(pid)
+			return envResultMsg{lines: lines, err: err}
+		}
+	}
+	// Remaining actions (restart, logs, copy, browser, full cmd) wired in next tasks.
+	return m, nil
 }
 
 // openActionMenu opens the action menu for the currently selected process node.

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -19,6 +19,10 @@ import (
 const (
 	dirDown = 1
 	dirUp   = -1
+
+	// tmuxScrollbackLines is the number of lines passed to tmux capture-pane -S.
+	// Negative value = capture from that many lines above the visible area.
+	tmuxScrollbackLines = "-32768"
 )
 
 // resolveFilterKey maps a key message to a SidebarFilter.
@@ -485,12 +489,7 @@ func (m Model) handleProcListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.confirm = ConfirmModel{
 				prompt: fmt.Sprintf("Kill %s (PID %d)?", name, pid),
 			}
-			m.confirmCmd = func() tea.Msg {
-				if err := proc.Kill(pid); err != nil {
-					return procActionMsg{fmt.Sprintf("kill %d: %v", pid, err)}
-				}
-				return procActionMsg{fmt.Sprintf("killed PID %d", pid)}
-			}
+			m.confirmCmd = killProcCmd(pid)
 			m.showConfirm = true
 			return m, nil
 		}
@@ -637,30 +636,30 @@ func (m Model) openSidebarSelected() (Model, tea.Cmd) {
 	return m.launchOrSwitchSession(sess, node.Session)
 }
 
+// killProcCmd returns a tea.Cmd that sends SIGKILL to pid and reports the result
+// via procActionMsg. Shared by the direct-x handler and the action-menu kill path.
+func killProcCmd(pid int32) tea.Cmd {
+	return func() tea.Msg {
+		if err := proc.Kill(pid); err != nil {
+			return procActionMsg{fmt.Sprintf("kill %d: %v", pid, err)}
+		}
+		return procActionMsg{fmt.Sprintf("killed PID %d", pid)}
+	}
+}
+
 // handleActionMenuKey routes keys when the action menu (or a sub-popup) is open.
 func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.actionMenu.subPopup != SubPopupNone {
 		return m.handleSubPopupKey(msg)
 	}
-	switch msg.String() {
-	case "x":
-		return m.executeActionByKind(ActionKill)
-	case "r":
-		return m.executeActionByKind(ActionRestart)
-	case "l":
-		return m.executeActionByKind(ActionViewLogs)
-	case "p":
-		return m.executeActionByKind(ActionCopyPID)
-	case "c":
-		return m.executeActionByKind(ActionCopyCommand)
-	case "w":
-		return m.executeActionByKind(ActionCopyCWD)
-	case "d":
-		return m.executeActionByKind(ActionShowEnv)
-	case "o":
-		return m.executeActionByKind(ActionOpenBrowser)
-	case "f":
-		return m.executeActionByKind(ActionShowFullCmd)
+	// Dispatch single-key shortcuts defined on each ActionItem. This avoids
+	// duplicating the shortcut mapping here and in buildActionItems.
+	pressed := msg.String()
+	for i, item := range m.actionMenu.items {
+		if item.Shortcut != "" && item.Shortcut == pressed {
+			m.actionMenu.cursor = i
+			return m.executeActionMenuItem()
+		}
 	}
 	switch {
 	case key.Matches(msg, keys.Down.Binding):
@@ -675,40 +674,19 @@ func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// executeActionByKind finds the item with the given kind and executes it.
-// No-op if the action is not present in the current menu (context-dependent items).
-func (m Model) executeActionByKind(kind ActionKind) (tea.Model, tea.Cmd) {
-	for i, item := range m.actionMenu.items {
-		if item.Kind == kind {
-			m.actionMenu.cursor = i
-			return m.executeActionMenuItem()
-		}
-	}
-	return m, nil
-}
-
 // handleSubPopupKey routes keys when a sub-popup is open inside the action menu.
 func (m Model) handleSubPopupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.actionMenu.subPopup == SubPopupKillConfirm {
+	switch m.actionMenu.subPopup {
+	case SubPopupKillConfirm:
 		switch msg.String() {
 		case "y", "enter":
 			pid := m.actionMenu.target.Proc.PID
 			m.showActionMenu = false
 			m.actionMenu.subPopup = SubPopupNone
-			return m, func() tea.Msg {
-				if err := proc.Kill(pid); err != nil {
-					return procActionMsg{fmt.Sprintf("kill %d: %v", pid, err)}
-				}
-				return procActionMsg{fmt.Sprintf("killed PID %d", pid)}
-			}
-		case "n":
+			return m, killProcCmd(pid)
+		case "n", "esc", "q":
 			m.actionMenu.subPopup = SubPopupNone
-			return m, nil
-		case "esc", "q":
-			m.actionMenu.subPopup = SubPopupNone
-			return m, nil
 		}
-		return m, nil
 	}
 	return m, nil
 }
@@ -737,7 +715,7 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 		paneID := m.actionMenu.target.Pane.PaneID
 		m.showActionMenu = false
 		return m, func() tea.Msg {
-			out, err := exec.Command("tmux", "capture-pane", "-t", paneID, "-p", "-S", "-32768").Output()
+			out, err := exec.Command("tmux", "capture-pane", "-t", paneID, "-p", "-S", tmuxScrollbackLines).Output()
 			if err != nil {
 				return procActionMsg{"logs: " + err.Error()}
 			}

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -50,6 +50,10 @@ func (m Model) handleNormalModeDefault(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.searchGen++
 		return m, nil
 	}
+	// 'a' is context-sensitive: action menu in proclist, FilterAll in sidebar.
+	if msg.String() == "a" && m.focus == panelProcList {
+		return m.openActionMenu(), nil
+	}
 	if newFilter, ok := resolveFilterKey(msg); ok {
 		sidebarVisibleRows := m.height - statusBarH - borderOverhead - searchBoxH
 		if sidebarVisibleRows < 1 {
@@ -491,12 +495,6 @@ func (m Model) handleProcListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if t := m.procListStateIdentity(); t != nil {
 			return m.showClearConfirm(*t), nil
 		}
-	case key.Matches(msg, keys.Kill.Binding):
-		// TODO: confirmation prompt
-	case key.Matches(msg, keys.Restart.Binding):
-		// TODO: restart via tmux send-keys Up Enter
-	case key.Matches(msg, keys.Log.Binding):
-		// TODO: tmux popup with scrollback
 	}
 	m.procList.clampOffset(procH - 2) // procH includes border; pass inner content height
 	m.updateDetailFromSelection()
@@ -616,4 +614,20 @@ func (m Model) openSidebarSelected() (Model, tea.Cmd) {
 	}
 	sess := m.sidebar.FindSession(node.Session)
 	return m.launchOrSwitchSession(sess, node.Session)
+}
+
+// openActionMenu opens the action menu for the currently selected process node.
+// No-op when the cursor is not on a selectable process node.
+func (m Model) openActionMenu() Model {
+	node := m.procList.SelectedNode()
+	if node == nil {
+		return m
+	}
+	m.actionMenu = ActionMenuModel{
+		items:  buildActionItems(*node),
+		cursor: 0,
+		target: *node,
+	}
+	m.showActionMenu = true
+	return m
 }

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -692,7 +692,6 @@ func (m Model) handleSubPopupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // executeActionMenuItem executes the currently selected action menu item.
-// Individual action implementations are added in subsequent tasks.
 func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 	item := m.actionMenu.Selected()
 	if item == nil {
@@ -707,8 +706,10 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 		paneID := m.actionMenu.target.Pane.PaneID
 		m.showActionMenu = false
 		return m, func() tea.Msg {
-			_ = exec.Command("tmux", "send-keys", "-t", paneID, "Up", "Enter").Run()
-			return nil
+			if err := exec.Command("tmux", "send-keys", "-t", paneID, "Up", "Enter").Run(); err != nil {
+				return procActionMsg{"restart failed: " + err.Error()}
+			}
+			return procActionMsg{"restart sent to " + paneID}
 		}
 
 	case ActionViewLogs:
@@ -739,9 +740,11 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 				cmd = exec.Command("open", url)
 			case "linux":
 				cmd = exec.Command("xdg-open", url)
+			default:
+				return procActionMsg{"open browser: unsupported on " + runtime.GOOS}
 			}
-			if cmd != nil {
-				_ = cmd.Run()
+			if err := cmd.Run(); err != nil {
+				return procActionMsg{"open browser: " + err.Error()}
 			}
 			return nil
 		}
@@ -786,6 +789,9 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 func (m Model) openActionMenu() Model {
 	node := m.procList.SelectedNode()
 	if node == nil {
+		return m
+	}
+	if node.IsPaneHeader || node.IsWindowHeader || node.Proc.PID == 0 {
 		return m
 	}
 	// displayPane suppresses CWD when it matches the window CWD. Recover the real

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -728,30 +728,6 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 			return openViewerMsg{path: f.Name()}
 		}
 
-	case ActionCopyPID:
-		val := fmt.Sprintf("%d", m.actionMenu.target.Proc.PID)
-		m.showActionMenu = false
-		return m, func() tea.Msg {
-			_ = CopyToClipboard(val)
-			return procActionMsg{"copied PID " + val}
-		}
-
-	case ActionCopyCommand:
-		val := m.actionMenu.target.Proc.Cmdline
-		m.showActionMenu = false
-		return m, func() tea.Msg {
-			_ = CopyToClipboard(val)
-			return procActionMsg{"copied command"}
-		}
-
-	case ActionCopyCWD:
-		val := m.actionMenu.target.Pane.CWD
-		m.showActionMenu = false
-		return m, func() tea.Msg {
-			_ = CopyToClipboard(val)
-			return procActionMsg{"copied working directory"}
-		}
-
 	case ActionOpenBrowser:
 		port := m.actionMenu.target.Port
 		m.showActionMenu = false

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -2,6 +2,9 @@ package tui
 
 import (
 	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -683,14 +686,78 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 	case ActionKill:
 		m.actionMenu.subPopup = SubPopupKillConfirm
 		return m, nil
+
+	case ActionRestart:
+		paneID := m.actionMenu.target.Pane.PaneID
+		m.showActionMenu = false
+		return m, func() tea.Msg {
+			_ = exec.Command("tmux", "send-keys", "-t", paneID, "Up", "Enter").Run()
+			return nil
+		}
+
+	case ActionViewLogs:
+		paneID := m.actionMenu.target.Pane.PaneID
+		m.showActionMenu = false
+		script := fmt.Sprintf("tmux capture-pane -t %s -p -S -32768 | less -R", paneID)
+		return m, tea.ExecProcess(
+			exec.Command("tmux", "display-popup", "-E", "-w", "80%", "-h", "80%", script),
+			func(err error) tea.Msg { return nil },
+		)
+
+	case ActionCopyPID:
+		val := fmt.Sprintf("%d", m.actionMenu.target.Proc.PID)
+		m.showActionMenu = false
+		return m, func() tea.Msg {
+			_ = CopyToClipboard(val)
+			return procActionMsg{"copied PID " + val}
+		}
+
+	case ActionCopyCommand:
+		val := m.actionMenu.target.Proc.Cmdline
+		m.showActionMenu = false
+		return m, func() tea.Msg {
+			_ = CopyToClipboard(val)
+			return procActionMsg{"copied command"}
+		}
+
+	case ActionCopyCWD:
+		val := m.actionMenu.target.Pane.CWD
+		m.showActionMenu = false
+		return m, func() tea.Msg {
+			_ = CopyToClipboard(val)
+			return procActionMsg{"copied working directory"}
+		}
+
+	case ActionOpenBrowser:
+		port := m.actionMenu.target.Port
+		m.showActionMenu = false
+		return m, func() tea.Msg {
+			url := fmt.Sprintf("http://localhost:%d", port)
+			var cmd *exec.Cmd
+			switch runtime.GOOS {
+			case "darwin":
+				cmd = exec.Command("open", url)
+			default:
+				cmd = exec.Command("xdg-open", url)
+			}
+			_ = cmd.Run()
+			return nil
+		}
+
 	case ActionShowEnv:
 		pid := m.actionMenu.target.Proc.PID
 		return m, func() tea.Msg {
 			lines, err := proc.Environ(pid)
 			return envResultMsg{lines: lines, err: err}
 		}
+
+	case ActionShowFullCmd:
+		lines := strings.Fields(m.actionMenu.target.Proc.Cmdline)
+		m.actionMenu.subPopup = SubPopupFullCmd
+		m.actionMenu.subLines = lines
+		m.actionMenu.subScrollOff = 0
+		return m, nil
 	}
-	// Remaining actions (restart, logs, copy, browser, full cmd) wired in next tasks.
 	return m, nil
 }
 

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -658,6 +657,10 @@ func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.executeActionByKind(ActionCopyCWD)
 	case "d":
 		return m.executeActionByKind(ActionShowEnv)
+	case "o":
+		return m.executeActionByKind(ActionOpenBrowser)
+	case "f":
+		return m.executeActionByKind(ActionShowFullCmd)
 	}
 	switch {
 	case key.Matches(msg, keys.Down.Binding):
@@ -706,16 +709,6 @@ func (m Model) handleSubPopupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, nil
-	}
-	switch {
-	case key.Matches(msg, keys.Down.Binding):
-		m.actionMenu.SubScrollDown()
-	case key.Matches(msg, keys.Up.Binding):
-		m.actionMenu.SubScrollUp()
-	case msg.String() == "q", key.Matches(msg, keys.Esc.Binding):
-		m.actionMenu.subPopup = SubPopupNone
-		m.actionMenu.subLines = nil
-		m.actionMenu.subScrollOff = 0
 	}
 	return m, nil
 }
@@ -790,10 +783,12 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 			switch runtime.GOOS {
 			case "darwin":
 				cmd = exec.Command("open", url)
-			default:
+			case "linux":
 				cmd = exec.Command("xdg-open", url)
 			}
-			_ = cmd.Run()
+			if cmd != nil {
+				_ = cmd.Run()
+			}
 			return nil
 		}
 
@@ -817,11 +812,17 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 		}
 
 	case ActionShowFullCmd:
-		lines := strings.Fields(m.actionMenu.target.Proc.Cmdline)
-		m.actionMenu.subPopup = SubPopupFullCmd
-		m.actionMenu.subLines = lines
-		m.actionMenu.subScrollOff = 0
-		return m, nil
+		cmdline := m.actionMenu.target.Proc.Cmdline
+		m.showActionMenu = false
+		return m, func() tea.Msg {
+			f, err := os.CreateTemp("", "demux-cmd-*.txt")
+			if err != nil {
+				return procActionMsg{"cmd: " + err.Error()}
+			}
+			_, _ = fmt.Fprintln(f, cmdline)
+			_ = f.Close()
+			return openViewerMsg{path: f.Name()}
+		}
 	}
 	return m, nil
 }

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -23,6 +23,9 @@ const (
 	// tmuxScrollbackLines is the number of lines passed to tmux capture-pane -S.
 	// Negative value = capture from that many lines above the visible area.
 	tmuxScrollbackLines = "-32768"
+
+	// clearConfirmTargetReserve accounts for the "  target: " label (10 chars), border (1), and padding (1).
+	clearConfirmTargetReserve = 12
 )
 
 // resolveFilterKey maps a key message to a SidebarFilter.
@@ -214,14 +217,14 @@ func (m Model) handleSearchInputUpdate(msg tea.KeyMsg) (Model, tea.Cmd) {
 func (m Model) launchConfigSession(sess *session.Session) (Model, tea.Cmd) {
 	if err := tmux.NewSession(sess.DisplayName, sess.Config.Path); err != nil {
 		m.statusMsg = "launch failed: " + err.Error()
-		m.statusExp = time.Now().Add(5 * time.Second)
+		m.statusExp = time.Now().Add(statusExpError)
 		m.sidebar.SetLaunchErr(err.Error())
 		return m, nil
 	}
 	if specs := resolveWindowSpecs(sess.Config.Windows, m.sessionsConfig.WindowTemplates); len(specs) > 0 {
 		if err := tmux.CreateSessionWindows(sess.DisplayName, sess.Config.Path, specs); err != nil {
 			m.statusMsg = "window setup failed: " + err.Error()
-			m.statusExp = time.Now().Add(5 * time.Second)
+			m.statusExp = time.Now().Add(statusExpError)
 		}
 	}
 	m.sidebar.ClearLaunchErr()
@@ -369,22 +372,8 @@ func (m Model) handleSidebarKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // procListDimensions computes procH and detailH for the current model state.
 func (m Model) procListDimensions() (procH, detailH int) {
-	contentH := m.height - 1
-	innerW := m.width - m.cfg.Sidebar.Width - 2
-	if innerW < 1 {
-		innerW = 1
-	}
-	detailContent := m.detail.ContentLines(innerW)
-	detailH = detailContent + 2
-	if detailH < 4 {
-		detailH = 4
-	}
-	maxDetailH := contentH - 4
-	if detailH > maxDetailH {
-		detailH = maxDetailH
-	}
-	procH = contentH - detailH
-	return procH, detailH
+	dims := m.buildLayoutDims()
+	return dims.procH, dims.detailH
 }
 
 // afterCollapse performs the shared post-toggle update after an expand/collapse operation:
@@ -602,7 +591,7 @@ func (m Model) clearCurrentState(t db.Target) tea.Cmd {
 // showClearConfirm opens the confirmation overlay for clearing the state of target.
 func (m Model) showClearConfirm(t db.Target) Model {
 	st := activeStateFor(m.states, t.Type, t.ID)
-	maxTargetLen := m.width/2 - 12 // leave room for label + border + padding
+	maxTargetLen := m.width/2 - clearConfirmTargetReserve
 	if maxTargetLen < 20 {
 		maxTargetLen = 20
 	}
@@ -648,11 +637,11 @@ func killProcCmd(pid int32) tea.Cmd {
 }
 
 // handleActionMenuKey routes keys when the action menu (or a sub-popup) is open.
-func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m Model) handleActionMenuKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	if m.actionMenu.subPopup != SubPopupNone {
 		return m.handleSubPopupKey(msg)
 	}
-	// Dispatch single-key shortcuts defined on each ActionItem. This avoids
+	// Dispatch single-key shortcuts defined on each actionItem. This avoids
 	// duplicating the shortcut mapping here and in buildActionItems.
 	pressed := msg.String()
 	for i, item := range m.actionMenu.items {
@@ -675,7 +664,7 @@ func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // handleSubPopupKey routes keys when a sub-popup is open inside the action menu.
-func (m Model) handleSubPopupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m Model) handleSubPopupKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	switch m.actionMenu.subPopup {
 	case SubPopupKillConfirm:
 		switch msg.String() {
@@ -692,7 +681,7 @@ func (m Model) handleSubPopupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // executeActionMenuItem executes the currently selected action menu item.
-func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
+func (m Model) executeActionMenuItem() (Model, tea.Cmd) {
 	item := m.actionMenu.Selected()
 	if item == nil {
 		return m, nil
@@ -746,7 +735,7 @@ func (m Model) executeActionMenuItem() (tea.Model, tea.Cmd) {
 			if err := cmd.Run(); err != nil {
 				return procActionMsg{"open browser: " + err.Error()}
 			}
-			return nil
+			return procActionMsg{"opened browser"}
 		}
 
 	case ActionShowEnv:
@@ -810,7 +799,7 @@ func (m Model) openActionMenu() Model {
 			node.Pane.CWD = cwd
 		}
 	}
-	m.actionMenu = ActionMenuModel{
+	m.actionMenu = actionMenuModel{
 		items:  buildActionItems(*node),
 		cursor: 0,
 		target: *node,

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -479,6 +479,22 @@ func (m Model) handleProcListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch {
+	case msg.String() == "x":
+		if node := m.procList.SelectedNode(); node != nil && node.Proc.PID != 0 {
+			pid := node.Proc.PID
+			name := node.Proc.FriendlyName()
+			m.confirm = ConfirmModel{
+				prompt: fmt.Sprintf("Kill %s (PID %d)?", name, pid),
+			}
+			m.confirmCmd = func() tea.Msg {
+				if err := proc.Kill(pid); err != nil {
+					return procActionMsg{fmt.Sprintf("kill %d: %v", pid, err)}
+				}
+				return procActionMsg{fmt.Sprintf("killed PID %d", pid)}
+			}
+			m.showConfirm = true
+			return m, nil
+		}
 	case key.Matches(msg, keys.Open.Binding):
 		nm, cmd := m.handleProcListOpen()
 		nm.procList.clampOffset(procH - 2)
@@ -628,7 +644,7 @@ func (m Model) handleActionMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleSubPopupKey(msg)
 	}
 	switch msg.String() {
-	case "K":
+	case "x":
 		return m.executeActionByKind(ActionKill)
 	case "r":
 		return m.executeActionByKind(ActionRestart)

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -195,7 +195,7 @@ func TestActionMenu_NavigateDown(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
 	m.actionMenu = ActionMenuModel{
-		items:  []ActionItem{{ActionKill, "Kill"}, {ActionRestart, "Restart"}},
+		items:  []ActionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
 		cursor: 0,
 	}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
@@ -209,7 +209,7 @@ func TestActionMenu_NavigateUp(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
 	m.actionMenu = ActionMenuModel{
-		items:  []ActionItem{{ActionKill, "Kill"}, {ActionRestart, "Restart"}},
+		items:  []ActionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
 		cursor: 1,
 	}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
@@ -222,7 +222,7 @@ func TestActionMenu_NavigateUp(t *testing.T) {
 func TestActionMenu_EscCloses(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{items: []ActionItem{{ActionKill, "Kill"}}}
+	m.actionMenu = ActionMenuModel{items: []ActionItem{{Kind: ActionKill, Label: "Kill"}}}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	got := result.(Model)
 	if got.showActionMenu {
@@ -233,7 +233,7 @@ func TestActionMenu_EscCloses(t *testing.T) {
 func TestActionMenu_QCloses(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{items: []ActionItem{{ActionKill, "Kill"}}}
+	m.actionMenu = ActionMenuModel{items: []ActionItem{{Kind: ActionKill, Label: "Kill"}}}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	got := result.(Model)
 	if got.showActionMenu {
@@ -241,11 +241,81 @@ func TestActionMenu_QCloses(t *testing.T) {
 	}
 }
 
+func TestActionMenu_ShortcutK_TriggersKill(t *testing.T) {
+	m := newTestModel(t)
+	m.showActionMenu = true
+	m.actionMenu = ActionMenuModel{
+		items: []ActionItem{
+			{Kind: ActionKill, Label: "Kill", Shortcut: "K"},
+			{Kind: ActionRestart, Label: "Restart", Shortcut: "r"},
+		},
+		cursor: 1, // cursor starts on Restart
+		target: ProcListNode{Proc: proc.Process{PID: 42, Name: "node"}, Pane: tmux.Pane{PaneID: "%1"}},
+	}
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")})
+	got := result.(Model)
+	// K should jump cursor to Kill (index 0) and open kill confirm sub-popup
+	if got.actionMenu.subPopup != SubPopupKillConfirm {
+		t.Errorf("expected SubPopupKillConfirm after 'K', got %v", got.actionMenu.subPopup)
+	}
+	if got.actionMenu.cursor != 0 {
+		t.Errorf("expected cursor=0 (Kill item) after 'K', got %d", got.actionMenu.cursor)
+	}
+}
+
+func TestActionMenu_ShortcutForMissingAction_IsNoop(t *testing.T) {
+	m := newTestModel(t)
+	m.showActionMenu = true
+	// Menu has only Kill — pressing 'c' (CopyCommand, not in list) should be a no-op.
+	m.actionMenu = ActionMenuModel{
+		items:  []ActionItem{{Kind: ActionKill, Label: "Kill", Shortcut: "k"}},
+		cursor: 0,
+	}
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	got := result.(Model)
+	if !got.showActionMenu {
+		t.Error("expected menu to remain open after no-op shortcut")
+	}
+	if got.actionMenu.cursor != 0 {
+		t.Errorf("expected cursor unchanged at 0, got %d", got.actionMenu.cursor)
+	}
+}
+
+func TestOpenActionMenu_RecoversSuppressedCWD(t *testing.T) {
+	m := New(config.Default(), nil)
+	// Simulate a pane whose CWD was suppressed in displayPane (matches window CWD).
+	m.panes = []tmux.Pane{
+		{PaneID: "%1", Session: "s", CWD: "/real/cwd"},
+	}
+	m.procList.nodes = []ProcListNode{
+		{
+			IsPaneHeader: true,
+			Pane:         tmux.Pane{PaneID: "%1", Session: "s", CWD: ""}, // suppressed
+		},
+	}
+	m.procList.cursor = 0
+	m.focus = panelProcList
+
+	got := m.openActionMenu()
+	found := false
+	for _, it := range got.actionMenu.items {
+		if it.Kind == ActionCopyCWD {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected ActionCopyCWD in menu after CWD recovery from m.panes")
+	}
+	if got.actionMenu.target.Pane.CWD != "/real/cwd" {
+		t.Errorf("expected target CWD=/real/cwd, got %q", got.actionMenu.target.Pane.CWD)
+	}
+}
+
 func TestActionMenu_SubPopup_EscReturnsToMenu(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
 	m.actionMenu = ActionMenuModel{
-		items:    []ActionItem{{ActionKill, "Kill"}},
+		items:    []ActionItem{{Kind: ActionKill, Label: "Kill"}},
 		subPopup: SubPopupFullCmd,
 		subLines: []string{"node", "server.js"},
 	}

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -194,8 +194,8 @@ func TestHandleKey_ActionMenu_DoesNotOpenOnA_InSidebar(t *testing.T) {
 func TestActionMenu_NavigateDown(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{
-		items:  []ActionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
+	m.actionMenu = actionMenuModel{
+		items:  []actionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
 		cursor: 0,
 	}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
@@ -208,8 +208,8 @@ func TestActionMenu_NavigateDown(t *testing.T) {
 func TestActionMenu_NavigateUp(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{
-		items:  []ActionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
+	m.actionMenu = actionMenuModel{
+		items:  []actionItem{{Kind: ActionKill, Label: "Kill"}, {Kind: ActionRestart, Label: "Restart"}},
 		cursor: 1,
 	}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
@@ -222,7 +222,7 @@ func TestActionMenu_NavigateUp(t *testing.T) {
 func TestActionMenu_EscCloses(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{items: []ActionItem{{Kind: ActionKill, Label: "Kill"}}}
+	m.actionMenu = actionMenuModel{items: []actionItem{{Kind: ActionKill, Label: "Kill"}}}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	got := result.(Model)
 	if got.showActionMenu {
@@ -233,7 +233,7 @@ func TestActionMenu_EscCloses(t *testing.T) {
 func TestActionMenu_QCloses(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{items: []ActionItem{{Kind: ActionKill, Label: "Kill"}}}
+	m.actionMenu = actionMenuModel{items: []actionItem{{Kind: ActionKill, Label: "Kill"}}}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	got := result.(Model)
 	if got.showActionMenu {
@@ -244,8 +244,8 @@ func TestActionMenu_QCloses(t *testing.T) {
 func TestActionMenu_ShortcutX_TriggersKill(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{
-		items: []ActionItem{
+	m.actionMenu = actionMenuModel{
+		items: []actionItem{
 			{Kind: ActionKill, Label: "Kill", Shortcut: "x"},
 			{Kind: ActionRestart, Label: "Restart", Shortcut: "r"},
 		},
@@ -301,8 +301,8 @@ func TestActionMenu_ShortcutForMissingAction_IsNoop(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
 	// Menu has only Kill — pressing 'c' (CopyCommand, not in list) should be a no-op.
-	m.actionMenu = ActionMenuModel{
-		items:  []ActionItem{{Kind: ActionKill, Label: "Kill", Shortcut: "k"}},
+	m.actionMenu = actionMenuModel{
+		items:  []actionItem{{Kind: ActionKill, Label: "Kill", Shortcut: "k"}},
 		cursor: 0,
 	}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
@@ -367,8 +367,8 @@ func TestOpenActionMenu_NoopOnWindowHeader(t *testing.T) {
 func TestExecuteActionMenuItem_Restart_ErrorReturnsProcActionMsg(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{
-		items:  []ActionItem{{Kind: ActionRestart, Label: "Restart", Shortcut: "r"}},
+	m.actionMenu = actionMenuModel{
+		items:  []actionItem{{Kind: ActionRestart, Label: "Restart", Shortcut: "r"}},
 		cursor: 0,
 		target: ProcListNode{
 			Proc: proc.Process{PID: 42, Name: "node"},
@@ -392,8 +392,8 @@ func TestExecuteActionMenuItem_Restart_ErrorReturnsProcActionMsg(t *testing.T) {
 func TestActionMenu_SubPopup_EscReturnsToMenu(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
-	m.actionMenu = ActionMenuModel{
-		items:    []ActionItem{{Kind: ActionKill, Label: "Kill"}},
+	m.actionMenu = actionMenuModel{
+		items:    []actionItem{{Kind: ActionKill, Label: "Kill"}},
 		subPopup: SubPopupKillConfirm,
 	}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -246,8 +246,8 @@ func TestActionMenu_SubPopup_EscReturnsToMenu(t *testing.T) {
 	m.showActionMenu = true
 	m.actionMenu = ActionMenuModel{
 		items:    []ActionItem{{ActionKill, "Kill"}},
-		subPopup: SubPopupEnvVars,
-		subLines: []string{"FOO=bar"},
+		subPopup: SubPopupFullCmd,
+		subLines: []string{"node", "server.js"},
 	}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	got := result.(Model)

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -350,8 +350,7 @@ func TestActionMenu_SubPopup_EscReturnsToMenu(t *testing.T) {
 	m.showActionMenu = true
 	m.actionMenu = ActionMenuModel{
 		items:    []ActionItem{{Kind: ActionKill, Label: "Kill"}},
-		subPopup: SubPopupFullCmd,
-		subLines: []string{"node", "server.js"},
+		subPopup: SubPopupKillConfirm,
 	}
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	got := result.(Model)

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -241,25 +241,59 @@ func TestActionMenu_QCloses(t *testing.T) {
 	}
 }
 
-func TestActionMenu_ShortcutK_TriggersKill(t *testing.T) {
+func TestActionMenu_ShortcutX_TriggersKill(t *testing.T) {
 	m := newTestModel(t)
 	m.showActionMenu = true
 	m.actionMenu = ActionMenuModel{
 		items: []ActionItem{
-			{Kind: ActionKill, Label: "Kill", Shortcut: "K"},
+			{Kind: ActionKill, Label: "Kill", Shortcut: "x"},
 			{Kind: ActionRestart, Label: "Restart", Shortcut: "r"},
 		},
 		cursor: 1, // cursor starts on Restart
 		target: ProcListNode{Proc: proc.Process{PID: 42, Name: "node"}, Pane: tmux.Pane{PaneID: "%1"}},
 	}
-	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")})
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
 	got := result.(Model)
-	// K should jump cursor to Kill (index 0) and open kill confirm sub-popup
+	// x should jump cursor to Kill (index 0) and open kill confirm sub-popup
 	if got.actionMenu.subPopup != SubPopupKillConfirm {
-		t.Errorf("expected SubPopupKillConfirm after 'K', got %v", got.actionMenu.subPopup)
+		t.Errorf("expected SubPopupKillConfirm after 'x', got %v", got.actionMenu.subPopup)
 	}
 	if got.actionMenu.cursor != 0 {
-		t.Errorf("expected cursor=0 (Kill item) after 'K', got %d", got.actionMenu.cursor)
+		t.Errorf("expected cursor=0 (Kill item) after 'x', got %d", got.actionMenu.cursor)
+	}
+}
+
+func TestProcList_X_OpensKillConfirm(t *testing.T) {
+	m := newTestModel(t)
+	m.focus = panelProcList
+	m.procList.nodes = []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneID: "%1", Session: "s"}},
+		{Proc: proc.Process{PID: 77, Name: "node", Cmdline: "node server.js"}, Depth: 1, Pane: tmux.Pane{PaneID: "%1"}},
+	}
+	m.procList.cursor = 1
+
+	result, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	got := result.(Model)
+	if !got.showConfirm {
+		t.Error("expected showConfirm=true after 'x' on process node")
+	}
+	if got.confirmCmd == nil {
+		t.Error("expected confirmCmd to be set")
+	}
+}
+
+func TestProcList_X_NoopOnPaneHeader(t *testing.T) {
+	m := newTestModel(t)
+	m.focus = panelProcList
+	m.procList.nodes = []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneID: "%1", Session: "s"}},
+	}
+	m.procList.cursor = 0
+
+	result, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	got := result.(Model)
+	if got.showConfirm {
+		t.Error("expected showConfirm=false when 'x' pressed on pane header (no process)")
 	}
 }
 

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -317,14 +317,14 @@ func TestActionMenu_ShortcutForMissingAction_IsNoop(t *testing.T) {
 
 func TestOpenActionMenu_RecoversSuppressedCWD(t *testing.T) {
 	m := New(config.Default(), nil)
-	// Simulate a pane whose CWD was suppressed in displayPane (matches window CWD).
+	// Simulate a process node whose CWD was suppressed in displayPane (matches window CWD).
 	m.panes = []tmux.Pane{
 		{PaneID: "%1", Session: "s", CWD: "/real/cwd"},
 	}
 	m.procList.nodes = []ProcListNode{
 		{
-			IsPaneHeader: true,
-			Pane:         tmux.Pane{PaneID: "%1", Session: "s", CWD: ""}, // suppressed
+			Proc: proc.Process{PID: 42, Name: "node"},
+			Pane: tmux.Pane{PaneID: "%1", Session: "s", CWD: ""}, // suppressed
 		},
 	}
 	m.procList.cursor = 0
@@ -333,6 +333,59 @@ func TestOpenActionMenu_RecoversSuppressedCWD(t *testing.T) {
 	got := m.openActionMenu()
 	if got.actionMenu.target.Pane.CWD != "/real/cwd" {
 		t.Errorf("expected target CWD=/real/cwd, got %q", got.actionMenu.target.Pane.CWD)
+	}
+}
+
+func TestOpenActionMenu_NoopOnPaneHeader(t *testing.T) {
+	m := New(config.Default(), nil)
+	m.procList.nodes = []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneID: "%1", Session: "s"}},
+	}
+	m.procList.cursor = 0
+	m.focus = panelProcList
+
+	got := m.openActionMenu()
+	if got.showActionMenu {
+		t.Error("expected showActionMenu=false for pane header node")
+	}
+}
+
+func TestOpenActionMenu_NoopOnWindowHeader(t *testing.T) {
+	m := New(config.Default(), nil)
+	m.procList.nodes = []ProcListNode{
+		{IsWindowHeader: true, Pane: tmux.Pane{PaneID: "%1"}},
+	}
+	m.procList.cursor = 0
+	m.focus = panelProcList
+
+	got := m.openActionMenu()
+	if got.showActionMenu {
+		t.Error("expected showActionMenu=false for window header node")
+	}
+}
+
+func TestExecuteActionMenuItem_Restart_ErrorReturnsProcActionMsg(t *testing.T) {
+	m := newTestModel(t)
+	m.showActionMenu = true
+	m.actionMenu = ActionMenuModel{
+		items:  []ActionItem{{Kind: ActionRestart, Label: "Restart", Shortcut: "r"}},
+		cursor: 0,
+		target: ProcListNode{
+			Proc: proc.Process{PID: 42, Name: "node"},
+			Pane: tmux.Pane{PaneID: "DEFINITELY-INVALID-PANE-ID-demux-test-xyz"},
+		},
+	}
+
+	_, cmd := m.executeActionMenuItem()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from restart action")
+	}
+	msg := cmd()
+	if msg == nil {
+		t.Fatal("expected procActionMsg on tmux failure, got nil")
+	}
+	if _, ok := msg.(procActionMsg); !ok {
+		t.Errorf("expected procActionMsg, got %T: %v", msg, msg)
 	}
 }
 

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -6,8 +6,14 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/rtalexk/demux/internal/config"
 	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/proc"
 	"github.com/rtalexk/demux/internal/tmux"
 )
+
+func newTestModel(t *testing.T) Model {
+	t.Helper()
+	return New(config.Config{}, nil)
+}
 
 func TestHighestPriorityPaneTarget_ReturnsHighestPriorityPane(t *testing.T) {
 	states := []db.ToolState{
@@ -155,5 +161,32 @@ func TestProcListStateIdentity_EmptyWindowIDReturnsNil(t *testing.T) {
 	m.procList.cursor = 0
 	if got := m.procListStateIdentity(); got != nil {
 		t.Errorf("expected nil for empty WindowID, got %+v", got)
+	}
+}
+
+func TestHandleKey_ActionMenu_OpensOnA_InProcList(t *testing.T) {
+	m := newTestModel(t)
+	m.focus = panelProcList
+	m.procList.nodes = []ProcListNode{
+		{IsPaneHeader: true, Pane: tmux.Pane{PaneID: "%1", Session: "s"}},
+		{Proc: proc.Process{PID: 99, Name: "node", Cmdline: "node server.js"}, Depth: 1, Pane: tmux.Pane{PaneID: "%1"}},
+	}
+	m.procList.cursor = 1
+
+	result, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	got := result.(Model)
+	if !got.showActionMenu {
+		t.Error("expected showActionMenu=true after pressing 'a' in proclist")
+	}
+}
+
+func TestHandleKey_ActionMenu_DoesNotOpenOnA_InSidebar(t *testing.T) {
+	m := newTestModel(t)
+	m.focus = panelSidebar
+
+	result, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	got := result.(Model)
+	if got.showActionMenu {
+		t.Error("expected showActionMenu=false when 'a' pressed in sidebar focus")
 	}
 }

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -331,15 +331,6 @@ func TestOpenActionMenu_RecoversSuppressedCWD(t *testing.T) {
 	m.focus = panelProcList
 
 	got := m.openActionMenu()
-	found := false
-	for _, it := range got.actionMenu.items {
-		if it.Kind == ActionCopyCWD {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("expected ActionCopyCWD in menu after CWD recovery from m.panes")
-	}
 	if got.actionMenu.target.Pane.CWD != "/real/cwd" {
 		t.Errorf("expected target CWD=/real/cwd, got %q", got.actionMenu.target.Pane.CWD)
 	}

--- a/internal/tui/model_keys_test.go
+++ b/internal/tui/model_keys_test.go
@@ -190,3 +190,71 @@ func TestHandleKey_ActionMenu_DoesNotOpenOnA_InSidebar(t *testing.T) {
 		t.Error("expected showActionMenu=false when 'a' pressed in sidebar focus")
 	}
 }
+
+func TestActionMenu_NavigateDown(t *testing.T) {
+	m := newTestModel(t)
+	m.showActionMenu = true
+	m.actionMenu = ActionMenuModel{
+		items:  []ActionItem{{ActionKill, "Kill"}, {ActionRestart, "Restart"}},
+		cursor: 0,
+	}
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	got := result.(Model)
+	if got.actionMenu.cursor != 1 {
+		t.Errorf("want cursor=1 after j, got %d", got.actionMenu.cursor)
+	}
+}
+
+func TestActionMenu_NavigateUp(t *testing.T) {
+	m := newTestModel(t)
+	m.showActionMenu = true
+	m.actionMenu = ActionMenuModel{
+		items:  []ActionItem{{ActionKill, "Kill"}, {ActionRestart, "Restart"}},
+		cursor: 1,
+	}
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	got := result.(Model)
+	if got.actionMenu.cursor != 0 {
+		t.Errorf("want cursor=0 after k, got %d", got.actionMenu.cursor)
+	}
+}
+
+func TestActionMenu_EscCloses(t *testing.T) {
+	m := newTestModel(t)
+	m.showActionMenu = true
+	m.actionMenu = ActionMenuModel{items: []ActionItem{{ActionKill, "Kill"}}}
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	got := result.(Model)
+	if got.showActionMenu {
+		t.Error("expected showActionMenu=false after Esc")
+	}
+}
+
+func TestActionMenu_QCloses(t *testing.T) {
+	m := newTestModel(t)
+	m.showActionMenu = true
+	m.actionMenu = ActionMenuModel{items: []ActionItem{{ActionKill, "Kill"}}}
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	got := result.(Model)
+	if got.showActionMenu {
+		t.Error("expected showActionMenu=false after q")
+	}
+}
+
+func TestActionMenu_SubPopup_EscReturnsToMenu(t *testing.T) {
+	m := newTestModel(t)
+	m.showActionMenu = true
+	m.actionMenu = ActionMenuModel{
+		items:    []ActionItem{{ActionKill, "Kill"}},
+		subPopup: SubPopupEnvVars,
+		subLines: []string{"FOO=bar"},
+	}
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	got := result.(Model)
+	if !got.showActionMenu {
+		t.Error("expected showActionMenu=true (action menu stays open after sub-popup close)")
+	}
+	if got.actionMenu.subPopup != SubPopupNone {
+		t.Errorf("expected subPopup=None after Esc, got %v", got.actionMenu.subPopup)
+	}
+}

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -57,7 +57,25 @@ func (m Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleQueryResultMsg(msg)
 	case searchDebounceMsg:
 		return m.handleSearchDebounceMsg(msg)
+	case envResultMsg:
+		return m.handleEnvResultMsg(msg)
+	case procActionMsg:
+		m.statusMsg = msg.status
+		m.statusExp = time.Now().Add(3 * time.Second)
+		return m, nil
 	}
+	return m, nil
+}
+
+func (m Model) handleEnvResultMsg(msg envResultMsg) (Model, tea.Cmd) {
+	if msg.err != nil {
+		m.statusMsg = "env: " + msg.err.Error()
+		m.statusExp = time.Now().Add(4 * time.Second)
+		return m, nil
+	}
+	m.actionMenu.subPopup = SubPopupEnvVars
+	m.actionMenu.subLines = msg.lines
+	m.actionMenu.subScrollOff = 0
 	return m, nil
 }
 
@@ -80,6 +98,10 @@ func (m Model) handleOverlays(msg tea.Msg) (Model, tea.Cmd, bool) {
 	if m.showConfirm {
 		mo, cmd := m.handleConfirmOverlay(msg)
 		return mo, cmd, true
+	}
+	if m.showActionMenu {
+		mo, cmd := m.handleActionMenuKey(msg.(tea.KeyMsg))
+		return mo.(Model), cmd, true
 	}
 	return m, nil, false
 }

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -543,7 +543,21 @@ func (m Model) handleItemsMsg(msg itemsMsg) (Model, tea.Cmd) {
 	if msg.session != m.itemSession {
 		return m, nil // stale response
 	}
-	m.itemList = msg.items
+	// Sort todos before notes, preserving relative insertion order within each kind.
+	// The renderer groups by kind visually; keeping the flat list in the same order
+	// ensures cursor navigation matches what the user sees.
+	sorted := make([]db.Item, 0, len(msg.items))
+	for _, it := range msg.items {
+		if it.Kind == db.KindTodo {
+			sorted = append(sorted, it)
+		}
+	}
+	for _, it := range msg.items {
+		if it.Kind != db.KindTodo {
+			sorted = append(sorted, it)
+		}
+	}
+	m.itemList = sorted
 	if m.itemCursor >= len(m.itemList) {
 		if len(m.itemList) > 0 {
 			m.itemCursor = len(m.itemList) - 1
@@ -610,16 +624,22 @@ func (m Model) updateYank(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if key.Matches(msg, keys.Enter.Binding) {
 			val := m.yank.SelectedValue()
-			CopyToClipboard(val)
+			if err := clipboardFunc(val); err != nil {
+				m.statusMsg = "copy failed: " + err.Error()
+			} else {
+				m.statusMsg = "yanked: " + val
+			}
 			m.showYank = false
-			m.statusMsg = "yanked: " + val
 			m.statusExp = time.Now().Add(2 * time.Second)
 			return m, nil
 		}
 		if f, ok := m.yank.FieldByKey(msg.String()); ok {
-			CopyToClipboard(f.Value)
+			if err := clipboardFunc(f.Value); err != nil {
+				m.statusMsg = "copy failed: " + err.Error()
+			} else {
+				m.statusMsg = "yanked: " + f.Value
+			}
 			m.showYank = false
-			m.statusMsg = "yanked: " + f.Value
 			m.statusExp = time.Now().Add(2 * time.Second)
 			return m, nil
 		}

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rtalexk/demux/internal/query"
 	"github.com/rtalexk/demux/internal/session"
 	"github.com/rtalexk/demux/internal/tmux"
+	"strings"
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -192,6 +193,7 @@ func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 	m.sessionIDMap = tmux.SessionIDToNameMap(msg.panes)
 	m.nameToIDMap = tmux.SessionNameToIDMap(msg.panes)
 	m.sidebar.SetNameToIDMap(m.nameToIDMap)
+	healStateSessionIDs(m.states, m.paneIDMap, m.nameToIDMap)
 	grouped := tmux.GroupBySessions(msg.panes)
 	merged := session.Merge(msg.panes, m.sessionsConfig.Entries)
 	m.sidebar.SetData(merged, m.states, m.gitInfo, m.cfg)
@@ -256,6 +258,7 @@ func (m Model) handleProcDataMsg(msg procDataMsg) (Model, tea.Cmd) {
 
 func (m Model) handleStatesMsg(msg statesMsg) (Model, tea.Cmd) {
 	m.states = msg.states
+	healStateSessionIDs(m.states, m.paneIDMap, m.nameToIDMap)
 	m.procList.SetStates(m.states)
 	merged := session.Merge(m.panes, m.sessionsConfig.Entries)
 	m.sidebar.SetData(merged, m.states, m.gitInfo, m.cfg)
@@ -408,6 +411,35 @@ func statesForSession(states []db.ToolState, sessionID string) []db.ToolState {
 		}
 	}
 	return out
+}
+
+// healStateSessionIDs reconciles pane state records whose session_id is empty or
+// stale in the DB against the live paneIDMap + nameToIDMap. This corrects records
+// where resolveParentIDs failed at write time (e.g. SQLITE_BUSY) or where the
+// pane was joined into a new session after the state was written.
+//
+// Mutations are in-memory only; the DB is not touched here. StateRefreshParentIDs
+// (called from pane_focus events) persists corrections back to SQLite lazily.
+func healStateSessionIDs(states []db.ToolState, paneIDMap, nameToIDMap map[string]string) {
+	for i := range states {
+		if states[i].Target.Type != db.TargetTypePane {
+			continue
+		}
+		label, ok := paneIDMap[states[i].Target.ID]
+		if !ok {
+			continue // pane not in live map; leave as-is
+		}
+		colonIdx := strings.Index(label, ":")
+		if colonIdx <= 0 {
+			continue
+		}
+		sessName := label[:colonIdx]
+		sessID := nameToIDMap[sessName]
+		if sessID == "" || states[i].Target.SessionID == sessID {
+			continue // already correct
+		}
+		states[i].Target.SessionID = sessID
+	}
 }
 
 // countProcsUnderCWD counts processes whose working directory is sessionCWD or a descendant.

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -94,6 +94,19 @@ func findViewer() []string {
 	return []string{"vi", "-R"}
 }
 
+// writeTempFile creates a temp file named by pattern, writes content into it,
+// and returns the path. The caller is responsible for removal (handleOpenViewerMsg
+// removes it after the viewer exits).
+func writeTempFile(pattern string, content []byte) (string, error) {
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", err
+	}
+	_, _ = f.Write(content)
+	_ = f.Close()
+	return f.Name(), nil
+}
+
 // handleOverlays routes key messages to full-screen overlay handlers.
 // Returns (model, cmd, true) if the message was consumed by an overlay.
 // Non-key messages fall through so background updates (ticks, state fetches)

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -65,7 +65,7 @@ func (m Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleOpenViewerMsg(msg)
 	case procActionMsg:
 		m.statusMsg = msg.status
-		m.statusExp = time.Now().Add(3 * time.Second)
+		m.statusExp = time.Now().Add(statusExpMedium)
 		return m, nil
 	}
 	return m, nil
@@ -108,7 +108,7 @@ func (m Model) handleOverlays(msg tea.Msg) (Model, tea.Cmd, bool) {
 	}
 	if m.showYank {
 		mo, cmd := m.updateYank(msg)
-		return mo.(Model), cmd, true
+		return mo, cmd, true
 	}
 	if m.showConfirm {
 		mo, cmd := m.handleConfirmOverlay(msg)
@@ -116,7 +116,7 @@ func (m Model) handleOverlays(msg tea.Msg) (Model, tea.Cmd, bool) {
 	}
 	if m.showActionMenu {
 		mo, cmd := m.handleActionMenuKey(msg.(tea.KeyMsg))
-		return mo.(Model), cmd, true
+		return mo, cmd, true
 	}
 	return m, nil, false
 }
@@ -325,7 +325,7 @@ func (m *Model) populateYankFields() {
 			if selNode.Port > 0 {
 				portStr = fmt.Sprintf("%d", selNode.Port)
 			}
-			m.yank.SetFields([]YankField{
+			m.yank.SetFields([]yankField{
 				{Key: "p", Label: "PID", Value: fmt.Sprint(pr.PID)},
 				{Key: "n", Label: "name", Value: pr.Name},
 				{Key: "c", Label: "cmdline", Value: pr.Cmdline},
@@ -337,7 +337,7 @@ func (m *Model) populateYankFields() {
 	}
 	// session node from sidebar
 	if node := m.sidebar.Selected(); node != nil {
-		m.yank.SetFields([]YankField{
+		m.yank.SetFields([]yankField{
 			{Key: "n", Label: "session", Value: node.Session},
 			{Key: "t", Label: "target", Value: node.Session},
 		}, "Yank: "+node.Session)
@@ -572,7 +572,7 @@ func (m Model) handleItemDeleteConfirmed(msg itemDeleteConfirmedMsg) (Model, tea
 	if err := m.db.ItemDelete(msg.id); err != nil {
 		demuxlog.Error("item delete failed", "id", msg.id, "err", err)
 		m.statusMsg = "error deleting item: " + err.Error()
-		m.statusExp = time.Now().Add(4 * time.Second)
+		m.statusExp = time.Now().Add(statusExpLong)
 	} else {
 		demuxlog.Info("item deleted", "id", msg.id, "session", msg.session)
 	}
@@ -583,14 +583,14 @@ func (m Model) handleItemEditorDoneMsg(msg itemEditorDoneMsg) (Model, tea.Cmd) {
 	if msg.err != nil {
 		demuxlog.Error("editor exited with error", "err", msg.err)
 		m.statusMsg = "editor error: " + msg.err.Error()
-		m.statusExp = time.Now().Add(4 * time.Second)
+		m.statusExp = time.Now().Add(statusExpLong)
 		return m, nil
 	}
 	if msg.tempFile != "" {
 		if err := syncItemsFromFile(m.db, msg.session, msg.tempFile); err != nil {
 			demuxlog.Error("item editor sync failed", "err", err)
 			m.statusMsg = "error syncing editor changes: " + err.Error()
-			m.statusExp = time.Now().Add(4 * time.Second)
+			m.statusExp = time.Now().Add(statusExpLong)
 		} else {
 			demuxlog.Info("editor changes synced", "session", msg.session)
 		}
@@ -615,7 +615,7 @@ func (m *Model) detailForProcNode(node ProcListNode) DetailModel {
 	}
 }
 
-func (m Model) updateYank(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m Model) updateYank(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		if key.Matches(msg, keys.Esc.Binding) || msg.String() == "q" {
@@ -630,7 +630,7 @@ func (m Model) updateYank(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusMsg = "yanked: " + val
 			}
 			m.showYank = false
-			m.statusExp = time.Now().Add(2 * time.Second)
+			m.statusExp = time.Now().Add(statusExpShort)
 			return m, nil
 		}
 		if f, ok := m.yank.FieldByKey(msg.String()); ok {
@@ -640,7 +640,7 @@ func (m Model) updateYank(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusMsg = "yanked: " + f.Value
 			}
 			m.showYank = false
-			m.statusExp = time.Now().Add(2 * time.Second)
+			m.statusExp = time.Now().Add(statusExpShort)
 			return m, nil
 		}
 		switch msg.String() {

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -17,7 +18,6 @@ import (
 	"github.com/rtalexk/demux/internal/query"
 	"github.com/rtalexk/demux/internal/session"
 	"github.com/rtalexk/demux/internal/tmux"
-	"strings"
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -57,8 +58,8 @@ func (m Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleQueryResultMsg(msg)
 	case searchDebounceMsg:
 		return m.handleSearchDebounceMsg(msg)
-	case envResultMsg:
-		return m.handleEnvResultMsg(msg)
+	case openViewerMsg:
+		return m.handleOpenViewerMsg(msg)
 	case procActionMsg:
 		m.statusMsg = msg.status
 		m.statusExp = time.Now().Add(3 * time.Second)
@@ -67,16 +68,27 @@ func (m Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) handleEnvResultMsg(msg envResultMsg) (Model, tea.Cmd) {
-	if msg.err != nil {
-		m.statusMsg = "env: " + msg.err.Error()
-		m.statusExp = time.Now().Add(4 * time.Second)
-		return m, nil
+func (m Model) handleOpenViewerMsg(msg openViewerMsg) (Model, tea.Cmd) {
+	args := findViewer()
+	if msg.ftCmd != "" {
+		args = append(args, "-c", msg.ftCmd)
 	}
-	m.actionMenu.subPopup = SubPopupEnvVars
-	m.actionMenu.subLines = msg.lines
-	m.actionMenu.subScrollOff = 0
-	return m, nil
+	args = append(args, msg.path)
+	return m, tea.ExecProcess(exec.Command(args[0], args[1:]...), func(err error) tea.Msg {
+		_ = os.Remove(msg.path)
+		return nil
+	})
+}
+
+// findViewer returns the command+args for the best available read-only viewer:
+// nvim, vim, or vi (all accept -R for read-only mode).
+func findViewer() []string {
+	for _, ed := range []string{"nvim", "vim", "vi"} {
+		if _, err := exec.LookPath(ed); err == nil {
+			return []string{ed, "-R"}
+		}
+	}
+	return []string{"vi", "-R"}
 }
 
 // handleOverlays routes key messages to full-screen overlay handlers.

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -319,7 +319,7 @@ func (m *Model) populateYankFields() {
 				{Key: "c", Label: "cmdline", Value: pr.Cmdline},
 				{Key: "d", Label: "CWD", Value: cwd},
 				{Key: "o", Label: "port", Value: portStr},
-			})
+			}, fmt.Sprintf("Yank: %s (%d)", pr.Name, pr.PID))
 			return
 		}
 	}
@@ -328,7 +328,7 @@ func (m *Model) populateYankFields() {
 		m.yank.SetFields([]YankField{
 			{Key: "n", Label: "session", Value: node.Session},
 			{Key: "t", Label: "target", Value: node.Session},
-		})
+		}, "Yank: "+node.Session)
 	}
 }
 
@@ -601,6 +601,13 @@ func (m Model) updateYank(msg tea.Msg) (tea.Model, tea.Cmd) {
 			CopyToClipboard(val)
 			m.showYank = false
 			m.statusMsg = "yanked: " + val
+			m.statusExp = time.Now().Add(2 * time.Second)
+			return m, nil
+		}
+		if f, ok := m.yank.FieldByKey(msg.String()); ok {
+			CopyToClipboard(f.Value)
+			m.showYank = false
+			m.statusMsg = "yanked: " + f.Value
 			m.statusExp = time.Now().Add(2 * time.Second)
 			return m, nil
 		}

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -37,6 +37,8 @@ func (m Model) handleMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tickMsg:
 		return m.handleTickMsg(msg)
+	case marqueeTickMsg:
+		return m.handleMarqueeTickMsg()
 	case panesMsg:
 		return m.handlePanesMsg(msg)
 	case procDataMsg:
@@ -166,6 +168,16 @@ func (m Model) handleTickMsg(_ tickMsg) (Model, tea.Cmd) {
 		m.statusMsg = ""
 	}
 	return m, tea.Batch(tick(time.Duration(m.cfg.RefreshIntervalMs)*time.Millisecond), m.fetchPanes(), m.fetchStates(), m.fetchWatches(), m.fetchItemSessions())
+}
+
+func (m Model) handleMarqueeTickMsg() (Model, tea.Cmd) {
+	if m.focus == panelSidebar {
+		m.sidebar.TickMarquee()
+	}
+	if m.showYank {
+		m.yank.TickMarquee()
+	}
+	return m, marqueeCmd()
 }
 
 func (m Model) handleQueryResultMsg(msg queryResultMsg) (Model, tea.Cmd) {

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -96,7 +96,7 @@ func TestUpdateYank_Enter_CopyError_ShowsFailedStatus(t *testing.T) {
 
 	m := New(config.Default(), nil)
 	m.showYank = true
-	m.yank.SetFields([]YankField{
+	m.yank.SetFields([]yankField{
 		{Key: "s", Label: "session", Value: "work"},
 	}, "Copy")
 

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"testing"
 
+	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/tmux"
 )
 
@@ -25,5 +26,61 @@ func TestSessionNameToIDMap_Empty(t *testing.T) {
 	m := tmux.SessionNameToIDMap(nil)
 	if len(m) != 0 {
 		t.Errorf("want empty map, got %v", m)
+	}
+}
+
+func TestHealStateSessionIDs_UpdatesSessionID(t *testing.T) {
+	states := []db.ToolState{
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$0"}},
+	}
+	paneIDMap := map[string]string{"%1": "work:%1"}
+	nameToIDMap := map[string]string{"work": "$1"}
+
+	healStateSessionIDs(states, paneIDMap, nameToIDMap)
+
+	if states[0].Target.SessionID != "$1" {
+		t.Errorf("expected SessionID $1, got %q", states[0].Target.SessionID)
+	}
+}
+
+func TestHealStateSessionIDs_NoopWhenAlreadyCorrect(t *testing.T) {
+	states := []db.ToolState{
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%1", SessionID: "$1"}},
+	}
+	paneIDMap := map[string]string{"%1": "work:%1"}
+	nameToIDMap := map[string]string{"work": "$1"}
+
+	healStateSessionIDs(states, paneIDMap, nameToIDMap)
+
+	if states[0].Target.SessionID != "$1" {
+		t.Errorf("session ID should be unchanged, got %q", states[0].Target.SessionID)
+	}
+}
+
+func TestHealStateSessionIDs_IgnoresNonPane(t *testing.T) {
+	states := []db.ToolState{
+		{Target: db.Target{Type: db.TargetTypeWindow, ID: "@1", SessionID: "$0"}},
+	}
+	paneIDMap := map[string]string{"@1": "work:@1"}
+	nameToIDMap := map[string]string{"work": "$1"}
+
+	healStateSessionIDs(states, paneIDMap, nameToIDMap)
+
+	if states[0].Target.SessionID != "$0" {
+		t.Errorf("non-pane entry should be unchanged, got %q", states[0].Target.SessionID)
+	}
+}
+
+func TestHealStateSessionIDs_IgnoresUnknownPane(t *testing.T) {
+	states := []db.ToolState{
+		{Target: db.Target{Type: db.TargetTypePane, ID: "%99", SessionID: "$0"}},
+	}
+	paneIDMap := map[string]string{} // %99 not in live map
+	nameToIDMap := map[string]string{"work": "$1"}
+
+	healStateSessionIDs(states, paneIDMap, nameToIDMap)
+
+	if states[0].Target.SessionID != "$0" {
+		t.Errorf("unknown pane should be unchanged, got %q", states[0].Target.SessionID)
 	}
 }

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -1,8 +1,12 @@
 package tui
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rtalexk/demux/internal/config"
 	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/tmux"
 )
@@ -82,5 +86,79 @@ func TestHealStateSessionIDs_IgnoresUnknownPane(t *testing.T) {
 
 	if states[0].Target.SessionID != "$0" {
 		t.Errorf("unknown pane should be unchanged, got %q", states[0].Target.SessionID)
+	}
+}
+
+func TestUpdateYank_Enter_CopyError_ShowsFailedStatus(t *testing.T) {
+	old := clipboardFunc
+	clipboardFunc = func(string) error { return errors.New("clipboard unavailable") }
+	defer func() { clipboardFunc = old }()
+
+	m := New(config.Default(), nil)
+	m.showYank = true
+	m.yank.SetFields([]YankField{
+		{Key: "s", Label: "session", Value: "work"},
+	}, "Copy")
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := result.(Model)
+	if !strings.HasPrefix(got.statusMsg, "copy failed:") {
+		t.Errorf("want 'copy failed:...' status, got %q", got.statusMsg)
+	}
+}
+
+func TestHandleItemsMsg_SortsTodosBeforeNotes(t *testing.T) {
+	m := New(config.Default(), nil)
+	m.itemsMode = true
+	m.itemSession = "work"
+
+	// Items in DB insertion order: todo, note, todo
+	items := []db.Item{
+		{ID: 1, Kind: db.KindTodo, Body: "first todo"},
+		{ID: 2, Kind: db.KindNote, Body: "a note"},
+		{ID: 3, Kind: db.KindTodo, Body: "second todo"},
+	}
+
+	m, _ = m.handleItemsMsg(itemsMsg{session: "work", items: items})
+
+	if len(m.itemList) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(m.itemList))
+	}
+	if m.itemList[0].Body != "first todo" {
+		t.Errorf("index 0: want 'first todo', got %q", m.itemList[0].Body)
+	}
+	if m.itemList[1].Body != "second todo" {
+		t.Errorf("index 1: want 'second todo', got %q (second todo must follow first todo)", m.itemList[1].Body)
+	}
+	if m.itemList[2].Body != "a note" {
+		t.Errorf("index 2: want 'a note', got %q (notes must follow todos)", m.itemList[2].Body)
+	}
+}
+
+func TestHandleItemsMsg_NavigationReachesSecondTodo(t *testing.T) {
+	m := New(config.Default(), nil)
+	m.itemsMode = true
+	m.itemSession = "work"
+
+	// Todo, note interleaved in DB order — second todo must be reachable with one j press.
+	items := []db.Item{
+		{ID: 1, Kind: db.KindTodo, Body: "first todo"},
+		{ID: 2, Kind: db.KindNote, Body: "a note"},
+		{ID: 3, Kind: db.KindTodo, Body: "second todo"},
+	}
+	m, _ = m.handleItemsMsg(itemsMsg{session: "work", items: items})
+	m.itemCursor = 0
+
+	got, _ := m.handleItemsKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+
+	if got.itemCursor != 1 {
+		t.Fatalf("expected cursor=1 after j, got %d", got.itemCursor)
+	}
+	if got.itemList[got.itemCursor].Kind != db.KindTodo {
+		t.Errorf("cursor should land on todo after j, got kind=%v body=%q",
+			got.itemList[got.itemCursor].Kind, got.itemList[got.itemCursor].Body)
+	}
+	if got.itemList[got.itemCursor].Body != "second todo" {
+		t.Errorf("want 'second todo' selected, got %q", got.itemList[got.itemCursor].Body)
 	}
 }

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -53,24 +53,26 @@ type SidebarNode struct {
 }
 
 type SidebarModel struct {
-	nodes         []SidebarNode
-	cursor        int
-	offset        int // viewport scroll offset
-	visibleRows   int // last known visible row count; used by CursorDown/CursorUp
-	sessions      []session.Session
-	states        []db.ToolState
-	nameToID      map[string]string // session display name → session_id ($N)
-	gitInfo       map[string]git.Info
-	cfg           config.Config
-	filter        SidebarFilter
-	prevSession   string // selected session before last filter switch; restored on toggle-off
-	filterHint    string
-	queryResult   query.Result
-	launchErr     string // shown inline when last launch attempt failed
-	activeSession string // tmux session the user is currently attached to
-	watches       map[string]struct{}
-	itemSessions  map[string]struct{} // sessions with open (unchecked) TODOs
-	noteSessions  map[string]struct{} // sessions with at least one note
+	nodes             []SidebarNode
+	cursor            int
+	offset            int // viewport scroll offset
+	visibleRows       int // last known visible row count; used by CursorDown/CursorUp
+	sessions          []session.Session
+	states            []db.ToolState
+	nameToID          map[string]string // session display name → session_id ($N)
+	gitInfo           map[string]git.Info
+	cfg               config.Config
+	filter            SidebarFilter
+	prevSession       string // selected session before last filter switch; restored on toggle-off
+	filterHint        string
+	queryResult       query.Result
+	launchErr         string // shown inline when last launch attempt failed
+	activeSession     string // tmux session the user is currently attached to
+	watches           map[string]struct{}
+	itemSessions      map[string]struct{} // sessions with open (unchecked) TODOs
+	noteSessions      map[string]struct{} // sessions with at least one note
+	marquee           Marquee
+	lastMarqueeCursor int
 }
 
 func (s *SidebarModel) SetData(sessions []session.Session, states []db.ToolState, gitInfo map[string]git.Info, cfg config.Config) {
@@ -781,7 +783,12 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 	if maxName < minRowWidth {
 		maxName = minRowWidth
 	}
-	nameStr := truncateSessionName(node.Session, maxName)
+	var nameStr string
+	if selected && focused && runewidth.StringWidth(node.Session) > maxName {
+		nameStr = s.marquee.View(node.Session, maxName)
+	} else {
+		nameStr = truncateSessionName(node.Session, maxName)
+	}
 
 	// Compute gap: active session gets the directional indicator; others get a space.
 	gap := " "
@@ -1072,4 +1079,16 @@ func (s SidebarModel) Selected() *SidebarNode {
 	}
 	n := s.nodes[s.cursor]
 	return &n
+}
+
+// TickMarquee advances the sidebar marquee by one step.
+// Automatically resets to offset 0 when the cursor has moved since the last tick,
+// producing a brief pause at the start of each new selection before scrolling begins.
+func (s *SidebarModel) TickMarquee() {
+	if s.cursor != s.lastMarqueeCursor {
+		s.marquee.Reset()
+		s.lastMarqueeCursor = s.cursor
+		return
+	}
+	s.marquee.Tick()
 }

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -157,6 +157,36 @@ func (s SidebarModel) ActiveFilter() SidebarFilter {
 	return s.filter
 }
 
+// sessionTargetStateFor returns the highest-priority ToolState whose target IS the
+// session itself (TargetTypeSession). Pane and window states are excluded. Use this
+// for the Proclist title where only session-level annotations should be displayed.
+func (s *SidebarModel) sessionTargetStateFor(sess string) *db.ToolState {
+	sessID := s.nameToID[sess]
+	var best *db.ToolState
+	bestPri := 0
+	for i := range s.states {
+		st := &s.states[i]
+		if st.Target.Type != db.TargetTypeSession {
+			continue
+		}
+		var matches bool
+		if sessID != "" {
+			matches = st.Target.SessionID == sessID
+		} else {
+			matches = st.Target.ID == sess
+		}
+		if !matches {
+			continue
+		}
+		pri := st.Value.Priority()
+		if best == nil || pri > bestPri {
+			bestPri = pri
+			best = st
+		}
+	}
+	return best
+}
+
 // stateForSession returns the highest-priority ToolState for the session, or nil if none.
 func (s *SidebarModel) stateForSession(sess string) *db.ToolState {
 	sessID := s.nameToID[sess]

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -1112,13 +1112,8 @@ func (s SidebarModel) Selected() *SidebarNode {
 }
 
 // TickMarquee advances the sidebar marquee by one step.
-// Automatically resets to offset 0 when the cursor has moved since the last tick,
-// producing a brief pause at the start of each new selection before scrolling begins.
+// Resets to offset 0 when the cursor has moved since the last tick,
+// producing a brief pause at each new selection before scrolling begins.
 func (s *SidebarModel) TickMarquee() {
-	if s.cursor != s.lastMarqueeCursor {
-		s.marquee.Reset()
-		s.lastMarqueeCursor = s.cursor
-		return
-	}
-	s.marquee.Tick()
+	s.marquee.TickTracked(s.cursor, &s.lastMarqueeCursor)
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -33,7 +33,6 @@ var (
 	// Overlays
 	helpStyle     lipgloss.Style
 	helpDescStyle lipgloss.Style
-	yankStyle     lipgloss.Style
 	confirmStyle  lipgloss.Style
 
 	// Sidebar text
@@ -99,7 +98,6 @@ func initStyles(t Theme, procs config.ProcessesConfig, ignoredProcs []string) {
 
 	helpStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession).Padding(1, 2)
 	helpDescStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
-	yankStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession).Padding(1, 2)
 	confirmStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(t.ColorSession).Padding(1, 1)
 
 	sessionStyle = lipgloss.NewStyle().Bold(true).Foreground(t.ColorSession)

--- a/internal/tui/yank.go
+++ b/internal/tui/yank.go
@@ -10,21 +10,21 @@ import (
 	runewidth "github.com/mattn/go-runewidth"
 )
 
-type YankField struct {
+type yankField struct {
 	Key   string
 	Label string
 	Value string
 }
 
-type YankModel struct {
-	fields            []YankField
+type yankModel struct {
+	fields            []yankField
 	cursor            int
 	title             string
 	marquee           Marquee
 	lastMarqueeCursor int
 }
 
-func (y *YankModel) SetFields(fields []YankField, title string) {
+func (y *yankModel) SetFields(fields []yankField, title string) {
 	y.fields = fields
 	y.cursor = 0
 	y.title = title
@@ -33,22 +33,17 @@ func (y *YankModel) SetFields(fields []YankField, title string) {
 }
 
 // TickMarquee advances the yank marquee by one step, resetting on cursor change.
-func (y *YankModel) TickMarquee() {
-	if y.cursor != y.lastMarqueeCursor {
-		y.marquee.Reset()
-		y.lastMarqueeCursor = y.cursor
-		return
-	}
-	y.marquee.Tick()
+func (y *yankModel) TickMarquee() {
+	y.marquee.TickTracked(y.cursor, &y.lastMarqueeCursor)
 }
 
-func (y YankModel) FieldByKey(k string) (YankField, bool) {
+func (y yankModel) FieldByKey(k string) (yankField, bool) {
 	for _, f := range y.fields {
 		if f.Key == k {
 			return f, true
 		}
 	}
-	return YankField{}, false
+	return yankField{}, false
 }
 
 const yankValueMaxWidth = 60
@@ -57,7 +52,7 @@ const yankValueMaxWidth = 60
 // Values within yankValueMaxWidth are returned as-is.
 // For the cursor row, an overflowing value is shown as a scrolling marquee window.
 // For non-cursor rows, an overflowing value is statically truncated.
-func (y YankModel) displayValue(fieldIdx int, f YankField) string {
+func (y yankModel) displayValue(fieldIdx int, f yankField) string {
 	if runewidth.StringWidth(f.Value) <= yankValueMaxWidth {
 		return f.Value
 	}
@@ -77,7 +72,7 @@ func (y YankModel) displayValue(fieldIdx int, f YankField) string {
 	return string(runes[:lo]) + ellipsis
 }
 
-func (y YankModel) Render() string {
+func (y yankModel) Render() string {
 	dvs := make([]string, len(y.fields))
 	maxW := 0
 	for i, f := range y.fields {
@@ -105,19 +100,19 @@ func (y YankModel) Render() string {
 	return confirmStyle.Render(sb.String())
 }
 
-func (y *YankModel) MoveUp() {
+func (y *yankModel) MoveUp() {
 	if y.cursor > 0 {
 		y.cursor--
 	}
 }
 
-func (y *YankModel) MoveDown() {
+func (y *yankModel) MoveDown() {
 	if y.cursor < len(y.fields)-1 {
 		y.cursor++
 	}
 }
 
-func (y YankModel) SelectedValue() string {
+func (y yankModel) SelectedValue() string {
 	if y.cursor < len(y.fields) {
 		return y.fields[y.cursor].Value
 	}
@@ -126,9 +121,9 @@ func (y YankModel) SelectedValue() string {
 
 // clipboardFunc is the function used to copy text to the clipboard.
 // Overridable in tests.
-var clipboardFunc = CopyToClipboard
+var clipboardFunc = copyToClipboard
 
-func CopyToClipboard(text string) error {
+func copyToClipboard(text string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":

--- a/internal/tui/yank.go
+++ b/internal/tui/yank.go
@@ -72,10 +72,11 @@ func (y YankModel) displayValue(fieldIdx int, f YankField) string {
 }
 
 func (y YankModel) Render() string {
+	dvs := make([]string, len(y.fields))
 	maxW := 0
 	for i, f := range y.fields {
-		dv := y.displayValue(i, f)
-		if w := lipgloss.Width(menuItemIndent + fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, dv)); w > maxW {
+		dvs[i] = y.displayValue(i, f)
+		if w := lipgloss.Width(menuItemIndent + fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, dvs[i])); w > maxW {
 			maxW = w
 		}
 	}
@@ -84,8 +85,7 @@ func (y YankModel) Render() string {
 	sb.WriteString(y.title)
 	sb.WriteString("\n\n")
 	for i, f := range y.fields {
-		dv := y.displayValue(i, f)
-		line := fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, dv)
+		line := fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, dvs[i])
 		if i == y.cursor {
 			line = selectedBG.Width(maxW + menuItemTrailingPad).Render(menuItemIndent + line)
 		} else {

--- a/internal/tui/yank.go
+++ b/internal/tui/yank.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	runewidth "github.com/mattn/go-runewidth"
 )
 
 type YankField struct {
@@ -16,15 +17,29 @@ type YankField struct {
 }
 
 type YankModel struct {
-	fields []YankField
-	cursor int
-	title  string
+	fields            []YankField
+	cursor            int
+	title             string
+	marquee           Marquee
+	lastMarqueeCursor int
 }
 
 func (y *YankModel) SetFields(fields []YankField, title string) {
 	y.fields = fields
 	y.cursor = 0
 	y.title = title
+	y.marquee.Reset()
+	y.lastMarqueeCursor = 0
+}
+
+// TickMarquee advances the yank marquee by one step, resetting on cursor change.
+func (y *YankModel) TickMarquee() {
+	if y.cursor != y.lastMarqueeCursor {
+		y.marquee.Reset()
+		y.lastMarqueeCursor = y.cursor
+		return
+	}
+	y.marquee.Tick()
 }
 
 func (y YankModel) FieldByKey(k string) (YankField, bool) {
@@ -36,10 +51,31 @@ func (y YankModel) FieldByKey(k string) (YankField, bool) {
 	return YankField{}, false
 }
 
+const yankValueMaxWidth = 60
+
+// displayValue returns the display string for field f at position fieldIdx.
+// Values within yankValueMaxWidth are returned as-is.
+// For the cursor row, an overflowing value is shown as a scrolling marquee window.
+// For non-cursor rows, an overflowing value is statically truncated.
+func (y YankModel) displayValue(fieldIdx int, f YankField) string {
+	if runewidth.StringWidth(f.Value) <= yankValueMaxWidth {
+		return f.Value
+	}
+	if fieldIdx == y.cursor {
+		return y.marquee.View(f.Value, yankValueMaxWidth)
+	}
+	runes := []rune(f.Value)
+	for runewidth.StringWidth(string(runes)) > yankValueMaxWidth-1 {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes) + ellipsis
+}
+
 func (y YankModel) Render() string {
 	maxW := 0
-	for _, f := range y.fields {
-		if w := lipgloss.Width(menuItemIndent + fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, f.Value)); w > maxW {
+	for i, f := range y.fields {
+		dv := y.displayValue(i, f)
+		if w := lipgloss.Width(menuItemIndent + fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, dv)); w > maxW {
 			maxW = w
 		}
 	}
@@ -48,7 +84,8 @@ func (y YankModel) Render() string {
 	sb.WriteString(y.title)
 	sb.WriteString("\n\n")
 	for i, f := range y.fields {
-		line := fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, f.Value)
+		dv := y.displayValue(i, f)
+		line := fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, dv)
 		if i == y.cursor {
 			line = selectedBG.Width(maxW + menuItemTrailingPad).Render(menuItemIndent + line)
 		} else {

--- a/internal/tui/yank.go
+++ b/internal/tui/yank.go
@@ -65,10 +65,16 @@ func (y YankModel) displayValue(fieldIdx int, f YankField) string {
 		return y.marquee.View(f.Value, yankValueMaxWidth)
 	}
 	runes := []rune(f.Value)
-	for runewidth.StringWidth(string(runes)) > yankValueMaxWidth-1 {
-		runes = runes[:len(runes)-1]
+	lo, hi := 0, len(runes)
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if runewidth.StringWidth(string(runes[:mid])) <= yankValueMaxWidth-1 {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
 	}
-	return string(runes) + ellipsis
+	return string(runes[:lo]) + ellipsis
 }
 
 func (y YankModel) Render() string {
@@ -117,6 +123,10 @@ func (y YankModel) SelectedValue() string {
 	}
 	return ""
 }
+
+// clipboardFunc is the function used to copy text to the clipboard.
+// Overridable in tests.
+var clipboardFunc = CopyToClipboard
 
 func CopyToClipboard(text string) error {
 	var cmd *exec.Cmd

--- a/internal/tui/yank.go
+++ b/internal/tui/yank.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 type YankField struct {
@@ -16,23 +18,48 @@ type YankField struct {
 type YankModel struct {
 	fields []YankField
 	cursor int
+	title  string
 }
 
-func (y *YankModel) SetFields(fields []YankField) {
+func (y *YankModel) SetFields(fields []YankField, title string) {
 	y.fields = fields
 	y.cursor = 0
+	y.title = title
+}
+
+func (y YankModel) FieldByKey(k string) (YankField, bool) {
+	for _, f := range y.fields {
+		if f.Key == k {
+			return f, true
+		}
+	}
+	return YankField{}, false
 }
 
 func (y YankModel) Render() string {
-	var lines []string
+	maxW := 0
+	for _, f := range y.fields {
+		if w := lipgloss.Width(menuItemIndent + fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, f.Value)); w > maxW {
+			maxW = w
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(y.title)
+	sb.WriteString("\n\n")
 	for i, f := range y.fields {
 		line := fmt.Sprintf("[%s] %-12s %s", f.Key, f.Label, f.Value)
 		if i == y.cursor {
-			line = selectedBG.Render(line)
+			line = selectedBG.Width(maxW + menuItemTrailingPad).Render(menuItemIndent + line)
+		} else {
+			line = menuItemIndent + line
 		}
-		lines = append(lines, line)
+		sb.WriteString(line)
+		sb.WriteString("\n")
 	}
-	return yankStyle.Render(strings.Join(lines, "\n"))
+	sb.WriteString("\n")
+	sb.WriteString(hintStyle.Render("Enter / shortcut") + " copy   " + hintStyle.Render("Esc / q") + " close")
+	return confirmStyle.Render(sb.String())
 }
 
 func (y *YankModel) MoveUp() {


### PR DESCRIPTION
## Summary

This PR introduces a **process management action menu** for the TUI, enabling per-process contextual actions directly from the process list. It also adds platform-specific environment variable reading, a marquee animation component for overflowing text, an items panel navigation fix, and a collection of bug fixes and polish improvements discovered during code review.

---

## New Features

### Action Menu (`a` key in the process list panel)
A context-sensitive popup menu that appears over the selected process, offering:

| Action | Description |
|--------|-------------|
| **Kill** | Sends SIGKILL to the process (with confirmation popover) |
| **Restart** | Sends `Up` + `Enter` to the pane to rerun the last command |
| **View Logs** | Opens `/tmp/demux-<pane>*.log` in a read-only `nvim` viewer |
| **Copy Working Dir** | Copies the process CWD to the clipboard |
| **Copy Env Var** | Opens a yank popup with all environment variables for the process |
| **Open in Browser** | Detects a listening port and opens it in the system browser |
| **Show Full Command** | Opens the full command line in a read-only `nvim` viewer |

The menu is guarded against pane header nodes, window header nodes, and PID=0 placeholder rows. Errors from restart and browser-open actions surface in the status bar.

### Platform-Specific Environment Variable Reading
New `internal/proc/environ_*.go` files read each process's environment via:
- **Darwin:** `/proc`-style parsing of `sysctl KERN_PROCARGS2` kern argument block
- **Linux:** `/proc/<pid>/environ` null-byte-delimited parsing
- **Other:** returns empty (no-op, no failure)

Environment variables are fetched asynchronously and displayed in the Copy Env Var yank popup.

### Marquee Animation Component
New `internal/tui/marquee.go` implements a circular scroll animation for text that overflows its display column. Used in:
- Session name in the Yank popup header (when the session name overflows)
- Command line value in the Yank popup (when the full command overflows)

Ticks fire at 200 ms via `marqueeTickMsg`. The component exposes a pure `View(text, width)` method with no side effects.

### Yank Menu Redesign
The copy-to-clipboard flow was moved from individual action menu items into a unified Yank popup, with labeled fields and shortcut key navigation. The popup title and first-field value both animate with the marquee when they overflow.

### State ID Healing
During `panesMsg` processing, stale `session_id` values in persisted pane states are corrected using the live pane map. This prevents mismatched state display after tmux session renames or restarts.

---

## Bug Fixes

### Proclist Title Leaking Pane States (Bug #1)
`buildProcTitle` was calling `stateForSession` which uses `SessionID` bubble-up and returns the highest-priority state across all target types (panes, windows, session). The proclist title should only show session-level annotations.

**Fix:** Added `sessionTargetStateFor` method to `SidebarModel` that filters to `TargetTypeSession` only. Sidebar continues using `stateForSession` (bubble-up); proclist title uses `sessionTargetStateFor` (session-only).

### Items Panel Navigation Skipping Todos (Bug #2)
The items panel renderer groups todos and notes visually, but the flat `itemList` was stored in DB insertion order. When notes appeared between todos in the DB, cursor navigation skipped items because the flat index didn't match the visual position.

**Fix:** `handleItemsMsg` now performs a stable two-pass sort: collect todos first (preserving insertion order within the group), then notes. The flat list always matches the visual grouping.

### Subagent-Stop Hook Race Condition (Bug #3)
The `SubagentStop` Claude Code hook was racing with the `Stop` hook. When Claude dispatches multiple parallel agents, multiple `SubagentStop` shell processes queue up. If the OS schedules `Stop`'s command first, it writes `done/"task complete"`. A late `SubagentStop` then writes `working/"subagent complete"` — bypassing both the dedup check (values differ) and the lock switch (`done` is not locked) — leaving the pane stuck in `working` state forever.

**Fix:** Added `--if-state working` guard to the `SubagentStop` hook command. SubagentStop is now a no-op if the state has already advanced to `done`.

### Clipboard Error Surfacing
Previously, `CopyToClipboard` errors were silently dropped. Errors now surface as `"copy failed: <reason>"` in the status bar.

---

## Refactoring & Polish

- **Yank truncation:** O(n) character-by-character truncation replaced with O(log n) binary search over rune widths.
- **`clipboardFunc` injection:** Clipboard function is now a package-level variable (`var clipboardFunc = CopyToClipboard`) enabling test overrides without build tags.
- **Kill shortcut:** Changed from `K` to `x` to reduce accidental kills; kill flow now requires a confirmation popover.
- **Full-command viewer:** `ActionShowFullCmd` routes through `nvim -R` via the external viewer path instead of an inline sub-popup.
- **Action menu:** Eliminated magic literals and duplicated logic; `buildActionItems` is the single source of truth for available items.
- **`displayValue` caching:** `YankModel.Render` computes `displayValue` once per render instead of inline in two places.

---

## Tests Added

| File | New Tests |
|------|-----------|
| `model_compact_test.go` | `TestBuildProcTitle_IgnoresPaneState`, `TestBuildProcTitle_ShowsSessionTargetState`, `TestBuildProcTitle_PaneStateTakesPrecedenceButSessionTitleIgnoresIt` |
| `model_update_test.go` | `TestHandleItemsMsg_SortsTodosBeforeNotes`, `TestHandleItemsMsg_NavigationReachesSecondTodo`, `TestUpdateYank_Enter_CopyError_ShowsFailedStatus` |
| `model_keys_test.go` | `TestOpenActionMenu_NoopOnPaneHeader`, `TestOpenActionMenu_NoopOnWindowHeader`, `TestExecuteActionMenuItem_Restart_ErrorReturnsProcActionMsg` |
| `marquee_test.go` | Marquee View, tick, width guard, cycle behavior |
| `action_menu_test.go` | Menu navigation, kill confirm, sub-popup escape, browser open |
| `states_test.go` | `StateRefreshParentIDs`, `parentIDMissing` edge cases |
| `model_update_test.go` | `TestHealStateSessionIDs_*` (4 cases) |

---

## Test Plan

- [ ] Run `go test ./...` — all tests pass
- [ ] Open demux TUI, navigate to a process, press `a` — action menu appears with process name in title
- [ ] Press `a` on a pane header or window header row — no menu opens
- [ ] Select **Kill** → confirmation popover appears → confirm → process is killed
- [ ] Select **Copy Env Var** → yank popup shows env vars; long values animate with marquee
- [ ] Open a session with a long name; press `y` → session name animates in yank popup header
- [ ] Open items panel for a session with interleaved todos and notes — second todo is reachable with `j`
- [ ] Trigger a multi-agent Claude task; verify pane state returns to `done` after all subagents finish (not stuck at `working/"subagent complete"`)
- [ ] In proclist title: confirm state badge shows only when session has a session-level state, not when only pane states exist