### PR TITLE
fix(session): expand tilde in session paths

### DIFF
--- a/internal/session/load.go
+++ b/internal/session/load.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -43,6 +44,7 @@ func LoadConfigSessions(configDir string) (SessionsConfig, error) {
 				fmt.Fprintf(os.Stderr, "demux: skipping session with missing name/path in %s\n", name)
 				continue
 			}
+			e.Path = expandTilde(e.Path)
 			dn := e.DisplayName()
 			if i, ok := seen[dn]; ok {
 				fmt.Fprintf(os.Stderr, "demux: duplicate session %q in %s (overrides previous)\n", dn, name)
@@ -57,6 +59,21 @@ func LoadConfigSessions(configDir string) (SessionsConfig, error) {
 
 	cfg.WindowTemplates = resolveWindowTemplates(rawTemplates)
 	return cfg, nil
+}
+
+// expandTilde replaces a leading "~/" with the user's home directory.
+func expandTilde(path string) string {
+	if !strings.HasPrefix(path, "~/") && path != "~" {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, path[2:])
 }
 
 // resolveWindowTemplates builds an id-keyed map of WindowTemplate with

--- a/internal/session/load_test.go
+++ b/internal/session/load_test.go
@@ -153,6 +153,26 @@ windows = ["editor", "generic"]
 	}
 }
 
+func TestLoadConfigSessions_TildeExpanded(t *testing.T) {
+	dir := t.TempDir()
+	writeTOML(t, dir, "sessions.toml", `
+[[session]]
+name = "home"
+path = "~/"
+`)
+	cfg, err := LoadConfigSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(cfg.Entries))
+	}
+	home, _ := os.UserHomeDir()
+	if cfg.Entries[0].Path != home {
+		t.Errorf("tilde not expanded: got %q, want %q", cfg.Entries[0].Path, home)
+	}
+}
+
 func TestLoadConfigSessions_WindowTemplateOverride(t *testing.T) {
 	dir := t.TempDir()
 	writeTOML(t, dir, "sessions.toml", `


### PR DESCRIPTION
## Summary
- Session config paths starting with `~/` are now expanded to home directory
- Expansion happens at parse time so all consumers receive absolute paths
- Fixes error: `session path "~/": stat ~/: no such file or directory`

## Test Plan
- [x] All 528 existing tests pass
- [x] New test verifies tilde expansion works correctly