### PR TITLE
feat(cmd): session connect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,28 @@ replace = "~"
 
 </details>
 
+<details>
+
+<summary>Connecting to sessions</summary>
+
+`demux session connect` attaches or switches to a session. Pass a name or use `--fuzzy` to pick interactively via fzf.
+
+```bash
+demux session connect myproject        # connect by exact name
+demux session connect --fuzzy          # pick via fzf
+```
+
+Behavior depends on context:
+
+- Inside tmux: runs `tmux switch-client -t <name>`.
+- Outside tmux: replaces the current process with `tmux attach-session -t <name>`.
+
+If the named session is configured in `sessions.toml` or `private.toml` but not yet running, demux creates it (applying window templates) before connecting.
+
+`--fuzzy` and a positional name are mutually exclusive. Pressing Esc in fzf exits silently with code 1.
+
+</details>
+
 ## Hooks
 
 ### Tmux
@@ -901,6 +923,8 @@ demux session config-get  --name <n>
 demux session config-remove --name <n> [--private]
 demux session remove      --name <n> [--private]   # kills tmux + removes config + clears states
 demux session create-windows --session <n> --windows <ids>
+demux session connect <name>           # attach or switch to a session
+demux session connect --fuzzy          # pick session via fzf
 
 # Windows
 demux windows --session <n>        # list windows in a session

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -74,7 +75,12 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
+		var see *SilentExitError
+		if errors.As(err, &see) {
+			os.Exit(see.code)
+		} else {
+			os.Exit(1)
+		}
 	}
 }
 

--- a/cmd/session_connect.go
+++ b/cmd/session_connect.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/session"
+	"github.com/rtalexk/demux/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+var sessionConnectFuzzy bool
+
+var sessionConnectCmd = &cobra.Command{
+	Use:   "connect [name]",
+	Short: "Attach or switch to a session (auto-creates from config when not live)",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runSessionConnect,
+}
+
+func init() {
+	sessionConnectCmd.Flags().BoolVar(&sessionConnectFuzzy, "fuzzy", false, "Pick session interactively via fzf")
+	sessionCmd.AddCommand(sessionConnectCmd)
+}
+
+func runSessionConnect(_ *cobra.Command, args []string) error {
+	name := ""
+	if len(args) == 1 {
+		name = args[0]
+	}
+	if err := validateConnectArgs(name, sessionConnectFuzzy); err != nil {
+		return err
+	}
+
+	sessions, err := loadMergedSessions()
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		name, err = pickSessionFuzzy(sessions)
+		if err != nil {
+			return err
+		}
+	}
+
+	target, err := resolveConnectTarget(sessions, name)
+	if err != nil {
+		return err
+	}
+
+	return dispatchConnect(target)
+}
+
+func validateConnectArgs(name string, fuzzy bool) error {
+	if name == "" && !fuzzy {
+		return fmt.Errorf("provide a session name or use --fuzzy")
+	}
+	if name != "" && fuzzy {
+		return fmt.Errorf("--fuzzy and a positional name are mutually exclusive")
+	}
+	return nil
+}
+
+func resolveConnectTarget(sessions []session.Session, name string) (*session.Session, error) {
+	for i := range sessions {
+		if sessions[i].DisplayName == name {
+			return &sessions[i], nil
+		}
+	}
+	return nil, fmt.Errorf("session %q not found", name)
+}
+
+func loadMergedSessions() ([]session.Session, error) {
+	panes, err := tmux.ListPanes()
+	if err != nil {
+		return nil, fmt.Errorf("tmux not available: %w", err)
+	}
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		return nil, fmt.Errorf("config dir: %w", err)
+	}
+	scfg, err := session.LoadConfigSessions(filepath.Dir(cfgPath))
+	if err != nil {
+		return nil, err
+	}
+	return session.Merge(panes, scfg.Entries), nil
+}
+
+func pickSessionFuzzy(sessions []session.Session) (string, error) {
+	if _, err := exec.LookPath("fzf"); err != nil {
+		return "", fmt.Errorf("fzf not installed")
+	}
+	if len(sessions) == 0 {
+		return "", fmt.Errorf("no sessions to pick from")
+	}
+
+	var sb strings.Builder
+	for _, s := range sessions {
+		sb.WriteString(s.DisplayName)
+		sb.WriteByte('\n')
+	}
+
+	cmd := exec.Command("fzf", "--prompt", "session> ", "--height", "40%")
+	cmd.Stdin = strings.NewReader(sb.String())
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 130 {
+			os.Exit(1)
+		}
+		return "", fmt.Errorf("fzf: %w", err)
+	}
+	pick := strings.TrimSpace(string(out))
+	if pick == "" {
+		return "", fmt.Errorf("no selection")
+	}
+	return pick, nil
+}
+
+func dispatchConnect(target *session.Session) error {
+	if target.IsLive {
+		return tmux.Connect(target.DisplayName)
+	}
+	if target.IsConfig {
+		ce := target.Config
+		if err := tmux.NewSessionDetached(ce.Name, ce.Path); err != nil {
+			return err
+		}
+		cfgPath, err := config.DefaultPath()
+		if err != nil {
+			return fmt.Errorf("config dir: %w", err)
+		}
+		scfg, err := session.LoadConfigSessions(filepath.Dir(cfgPath))
+		if err != nil {
+			return err
+		}
+		specs, unknown := session.ResolveWindowSpecs(ce.Windows, scfg.WindowTemplates)
+		for _, id := range unknown {
+			fmt.Fprintf(os.Stderr, "demux: unknown window_template id %q (skipped)\n", id)
+		}
+		if len(specs) > 0 {
+			if err := tmux.CreateSessionWindows(ce.Name, ce.Path, specs); err != nil {
+				return fmt.Errorf("window setup: %w", err)
+			}
+		}
+		return tmux.Connect(ce.Name)
+	}
+	return fmt.Errorf("session %q is neither live nor in config", target.DisplayName)
+}

--- a/cmd/session_connect.go
+++ b/cmd/session_connect.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,18 @@ import (
 	"github.com/rtalexk/demux/internal/tmux"
 	"github.com/spf13/cobra"
 )
+
+var errFzfAborted = errors.New("fzf: aborted")
+
+// SilentExitError signals termination without printing an error.
+// Used for user-initiated exits like fzf cancellation.
+type SilentExitError struct {
+	code int
+}
+
+func (e *SilentExitError) Error() string {
+	return ""
+}
 
 var sessionConnectFuzzy bool
 
@@ -36,13 +49,16 @@ func runSessionConnect(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	sessions, err := loadMergedSessions()
+	sessions, scfg, err := loadMergedSessions()
 	if err != nil {
 		return err
 	}
 
 	if name == "" {
 		name, err = pickSessionFuzzy(sessions)
+		if errors.Is(err, errFzfAborted) {
+			return &SilentExitError{code: 1}
+		}
 		if err != nil {
 			return err
 		}
@@ -53,7 +69,7 @@ func runSessionConnect(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	return dispatchConnect(target)
+	return dispatchConnect(target, scfg)
 }
 
 func validateConnectArgs(name string, fuzzy bool) error {
@@ -75,20 +91,17 @@ func resolveConnectTarget(sessions []session.Session, name string) (*session.Ses
 	return nil, fmt.Errorf("session %q not found", name)
 }
 
-func loadMergedSessions() ([]session.Session, error) {
-	panes, err := tmux.ListPanes()
-	if err != nil {
-		return nil, fmt.Errorf("tmux not available: %w", err)
-	}
+func loadMergedSessions() ([]session.Session, session.SessionsConfig, error) {
+	panes, _ := tmux.ListPanes()  // Soft fallback: zero live sessions on error
 	cfgPath, err := config.DefaultPath()
 	if err != nil {
-		return nil, fmt.Errorf("config dir: %w", err)
+		return nil, session.SessionsConfig{}, fmt.Errorf("config dir: %w", err)
 	}
 	scfg, err := session.LoadConfigSessions(filepath.Dir(cfgPath))
 	if err != nil {
-		return nil, err
+		return nil, session.SessionsConfig{}, err
 	}
-	return session.Merge(panes, scfg.Entries), nil
+	return session.Merge(panes, scfg.Entries), scfg, nil
 }
 
 func pickSessionFuzzy(sessions []session.Session) (string, error) {
@@ -99,19 +112,18 @@ func pickSessionFuzzy(sessions []session.Session) (string, error) {
 		return "", fmt.Errorf("no sessions to pick from")
 	}
 
-	var sb strings.Builder
-	for _, s := range sessions {
-		sb.WriteString(s.DisplayName)
-		sb.WriteByte('\n')
+	names := make([]string, len(sessions))
+	for i, s := range sessions {
+		names[i] = s.DisplayName
 	}
 
 	cmd := exec.Command("fzf", "--prompt", "session> ", "--height", "40%")
-	cmd.Stdin = strings.NewReader(sb.String())
+	cmd.Stdin = strings.NewReader(strings.Join(names, "\n") + "\n")
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 130 {
-			os.Exit(1)
+			return "", errFzfAborted
 		}
 		return "", fmt.Errorf("fzf: %w", err)
 	}
@@ -122,33 +134,17 @@ func pickSessionFuzzy(sessions []session.Session) (string, error) {
 	return pick, nil
 }
 
-func dispatchConnect(target *session.Session) error {
+func dispatchConnect(target *session.Session, scfg session.SessionsConfig) error {
 	if target.IsLive {
 		return tmux.Connect(target.DisplayName)
 	}
-	if target.IsConfig {
+	if target.IsConfig && target.Config != nil {
 		ce := target.Config
-		if err := tmux.NewSessionDetached(ce.Name, ce.Path); err != nil {
-			return err
-		}
-		cfgPath, err := config.DefaultPath()
-		if err != nil {
-			return fmt.Errorf("config dir: %w", err)
-		}
-		scfg, err := session.LoadConfigSessions(filepath.Dir(cfgPath))
-		if err != nil {
-			return err
-		}
-		specs, unknown := session.ResolveWindowSpecs(ce.Windows, scfg.WindowTemplates)
+		_, unknown := session.ResolveWindowSpecs(ce.Windows, scfg.WindowTemplates)
 		for _, id := range unknown {
 			fmt.Fprintf(os.Stderr, "demux: unknown window_template id %q (skipped)\n", id)
 		}
-		if len(specs) > 0 {
-			if err := tmux.CreateSessionWindows(ce.Name, ce.Path, specs); err != nil {
-				return fmt.Errorf("window setup: %w", err)
-			}
-		}
-		return tmux.Connect(ce.Name)
+		return session.LaunchAndConnectConfigSession(ce.Name, ce.Path, ce.Windows, scfg.WindowTemplates)
 	}
 	return fmt.Errorf("session %q is neither live nor in config", target.DisplayName)
 }

--- a/cmd/session_connect_test.go
+++ b/cmd/session_connect_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rtalexk/demux/internal/session"
+)
+
+func TestResolveTarget_PositionalFound(t *testing.T) {
+	sessions := []session.Session{
+		{DisplayName: "alpha", IsLive: true},
+		{DisplayName: "beta", IsConfig: true, Config: &session.ConfigEntry{Name: "beta", Path: "/tmp"}},
+	}
+	got, err := resolveConnectTarget(sessions, "beta")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.DisplayName != "beta" {
+		t.Errorf("got %q, want beta", got.DisplayName)
+	}
+}
+
+func TestResolveTarget_PositionalUnknown(t *testing.T) {
+	sessions := []session.Session{{DisplayName: "alpha", IsLive: true}}
+	_, err := resolveConnectTarget(sessions, "missing")
+	if err == nil {
+		t.Fatal("expected error for unknown name")
+	}
+	if !strings.Contains(err.Error(), `"missing"`) {
+		t.Errorf("error should mention name, got: %v", err)
+	}
+}
+
+func TestValidateConnectArgs_RequiresNameOrFuzzy(t *testing.T) {
+	if err := validateConnectArgs("", false); err == nil {
+		t.Error("expected error when neither name nor --fuzzy provided")
+	}
+}
+
+func TestValidateConnectArgs_BothNameAndFuzzy(t *testing.T) {
+	if err := validateConnectArgs("alpha", true); err == nil {
+		t.Error("expected error when both name and --fuzzy provided")
+	}
+}
+
+func TestValidateConnectArgs_NameOnly(t *testing.T) {
+	if err := validateConnectArgs("alpha", false); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateConnectArgs_FuzzyOnly(t *testing.T) {
+	if err := validateConnectArgs("", true); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/rtalexk/demux/internal/tmux"
@@ -96,4 +97,19 @@ func Merge(panes []tmux.Pane, entries []ConfigEntry) []Session {
 	}
 
 	return sessions
+}
+
+// LaunchAndConnectConfigSession launches a new session from config and connects to it.
+// It creates a detached session, sets up windows, and connects the client.
+func LaunchAndConnectConfigSession(name, path string, windowIDs []string, templates map[string]WindowTemplate) error {
+	if err := tmux.NewSessionDetached(name, path); err != nil {
+		return err
+	}
+	specs, _ := ResolveWindowSpecs(windowIDs, templates)
+	if len(specs) > 0 {
+		if err := tmux.CreateSessionWindows(name, path, specs); err != nil {
+			return fmt.Errorf("window setup: %w", err)
+		}
+	}
+	return tmux.Connect(name)
 }

--- a/internal/tmux/launch.go
+++ b/internal/tmux/launch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 // WindowSpec describes a window to create inside a tmux session.
@@ -12,10 +13,10 @@ type WindowSpec struct {
 	AfterCreateCmd string
 }
 
-// NewSession creates a detached tmux session named `name` rooted at `path`,
-// then switches the client to it. Returns an error if name or path is empty,
-// or if the path does not exist on disk.
-func NewSession(name, path string) error {
+// NewSessionDetached creates a detached tmux session named `name` rooted at
+// `path`. It does NOT switch or attach the client. Returns an error if name
+// or path is empty, or if the path does not exist on disk.
+func NewSessionDetached(name, path string) error {
 	if name == "" {
 		return fmt.Errorf("session name is required")
 	}
@@ -28,10 +29,41 @@ func NewSession(name, path string) error {
 	if err := exec.Command("tmux", "new-session", "-d", "-s", name, "-c", path).Run(); err != nil {
 		return fmt.Errorf("tmux new-session: %w", err)
 	}
-	if err := exec.Command("tmux", "switch-client", "-t", name).Run(); err != nil {
-		return fmt.Errorf("tmux switch-client: %w", err)
+	return nil
+}
+
+// Connect attaches the current process to the named tmux session, picking
+// the right verb based on $TMUX:
+//   - inside tmux ($TMUX set): runs `tmux switch-client -t name`.
+//   - outside tmux: replaces the current process with `tmux attach-session -t name`
+//     via syscall.Exec, so the user lands directly in tmux.
+func Connect(name string) error {
+	insideTmux := os.Getenv("TMUX") != ""
+	args := resolveConnectArgs(insideTmux, name)
+	if insideTmux {
+		if err := exec.Command("tmux", args...).Run(); err != nil {
+			return fmt.Errorf("tmux %s: %w", args[0], err)
+		}
+		return nil
+	}
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		return fmt.Errorf("tmux not found in PATH: %w", err)
+	}
+	argv := append([]string{"tmux"}, args...)
+	if err := syscall.Exec(tmuxPath, argv, os.Environ()); err != nil {
+		return fmt.Errorf("tmux attach-session: %w", err)
 	}
 	return nil
+}
+
+// resolveConnectArgs returns the tmux subcommand and args for Connect,
+// based on whether the caller is currently inside a tmux client.
+func resolveConnectArgs(insideTmux bool, name string) []string {
+	if insideTmux {
+		return []string{"switch-client", "-t", name}
+	}
+	return []string{"attach-session", "-t", name}
 }
 
 // CreateSessionWindows configures windows for an existing tmux session.

--- a/internal/tmux/launch_test.go
+++ b/internal/tmux/launch_test.go
@@ -1,26 +1,40 @@
 package tmux
 
 import (
+	"reflect"
 	"testing"
 )
 
-func TestNewSession_PathRequired(t *testing.T) {
-	err := NewSession("test-session", "")
-	if err == nil {
+func TestNewSessionDetached_PathRequired(t *testing.T) {
+	if err := NewSessionDetached("test-session", ""); err == nil {
 		t.Error("expected error for empty path")
 	}
 }
 
-func TestNewSession_NameRequired(t *testing.T) {
-	err := NewSession("", "/tmp")
-	if err == nil {
+func TestNewSessionDetached_NameRequired(t *testing.T) {
+	if err := NewSessionDetached("", "/tmp"); err == nil {
 		t.Error("expected error for empty name")
 	}
 }
 
-func TestNewSession_PathNotExist(t *testing.T) {
-	err := NewSession("test-session", "/tmp/demux-no-such-dir-xyz")
-	if err == nil {
+func TestNewSessionDetached_PathNotExist(t *testing.T) {
+	if err := NewSessionDetached("test-session", "/tmp/demux-no-such-dir-xyz"); err == nil {
 		t.Error("expected error for nonexistent path")
+	}
+}
+
+func TestResolveConnectArgs_TmuxSet(t *testing.T) {
+	got := resolveConnectArgs(true, "myapp")
+	want := []string{"switch-client", "-t", "myapp"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("inside tmux: got %v, want %v", got, want)
+	}
+}
+
+func TestResolveConnectArgs_TmuxUnset(t *testing.T) {
+	got := resolveConnectArgs(false, "myapp")
+	want := []string{"attach-session", "-t", "myapp"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("outside tmux: got %v, want %v", got, want)
 	}
 }

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -215,7 +215,7 @@ func (m Model) handleSearchInputUpdate(msg tea.KeyMsg) (Model, tea.Cmd) {
 // launchConfigSession creates a new tmux session from a config-only session entry.
 // Returns the updated model and a command (nil on launch failure, fetchPanes or tea.Quit on success).
 func (m Model) launchConfigSession(sess *session.Session) (Model, tea.Cmd) {
-	if err := tmux.NewSession(sess.DisplayName, sess.Config.Path); err != nil {
+	if err := tmux.NewSessionDetached(sess.DisplayName, sess.Config.Path); err != nil {
 		m.statusMsg = "launch failed: " + err.Error()
 		m.statusExp = time.Now().Add(statusExpError)
 		m.sidebar.SetLaunchErr(err.Error())
@@ -226,6 +226,12 @@ func (m Model) launchConfigSession(sess *session.Session) (Model, tea.Cmd) {
 			m.statusMsg = "window setup failed: " + err.Error()
 			m.statusExp = time.Now().Add(statusExpError)
 		}
+	}
+	if err := tmux.Connect(sess.DisplayName); err != nil {
+		m.statusMsg = "connect failed: " + err.Error()
+		m.statusExp = time.Now().Add(statusExpError)
+		m.sidebar.SetLaunchErr(err.Error())
+		return m, nil
 	}
 	m.sidebar.ClearLaunchErr()
 	if m.popupMode {


### PR DESCRIPTION
## Summary
- Add session connect command with fzf picker and dispatch
- Improve error handling and cleanup duplication in session handling
- Document session connect command in README

## Test Plan
- [x] All 536 tests pass
- Manual testing: run `demux session connect` to test fzf picker and session attachment