### PR TITLE
feat(sidebar): per-session process labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ match = "node*"
 label = "node"
 
 [[sidebar.processes]]
-match = "uv*"
+match = ["python*", "uvicorn", "uv"]
 label = "py"
 fg = "#fee685"
 bg = "#3b3000"
@@ -497,7 +497,7 @@ bg = "#3b3000"
 
 **Fields**
 
-- `match`: a glob pattern (Go [`filepath.Match`](https://pkg.go.dev/path/filepath#Match) syntax, case-insensitive). Matched against the process name and any whitespace-separated token of its full command line, including the basename of each token.
+- `match`: a glob pattern (Go [`filepath.Match`](https://pkg.go.dev/path/filepath#Match) syntax, case-insensitive), or an array of globs that share the same `label`/`fg`/`bg`. Matched against the process name and any whitespace-separated token of its full command line, including the basename of each token.
 - `label`: the text rendered in the sidebar when the pattern matches.
 - `fg`, `bg` (optional): per-entry hex colors. When unset, fall back to the theme defaults `color_proc_label_fg` and `color_proc_label_bg`.
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,50 @@ enabled = false                     # show PR info in the detail panel
 
 </details>
 
+### Sidebar process labels
+
+Render a small text label on each sidebar row to surface what kind of process is running in that session. Useful when you want to see at a glance which sessions hold a Claude agent, a dev server, a Python virtualenv, etc.
+
+Configure via the `[[sidebar.processes]]` array in `demux.toml`:
+
+```toml
+[[sidebar.processes]]
+match = "claude*"
+label = "🤖"
+
+[[sidebar.processes]]
+match = "node*"
+label = "node"
+
+[[sidebar.processes]]
+match = "uv*"
+label = "py"
+fg = "#fee685"
+bg = "#3b3000"
+```
+
+**Fields**
+
+- `match`: a glob pattern (Go [`filepath.Match`](https://pkg.go.dev/path/filepath#Match) syntax, case-insensitive). Matched against the process name and any whitespace-separated token of its full command line, including the basename of each token.
+- `label`: the text rendered in the sidebar when the pattern matches.
+- `fg`, `bg` (optional): per-entry hex colors. When unset, fall back to the theme defaults `color_proc_label_fg` and `color_proc_label_bg`.
+
+**Match rules**
+
+- Each pane is inspected at level 0 (the pane root) first. If the root matches a pattern, the result wins for that pane and child processes are skipped.
+- If the root has no match, level 1 (direct children of the pane root) is inspected. The first child that matches a pattern wins.
+- Deeper descendants are never inspected.
+- Across a session's panes, the label with the highest occurrence count wins. On a count tie, the entry declared first in the array wins.
+- Sessions with zero matches show no proc label.
+
+**Render position**
+
+The proc label is the leftmost indicator on the sidebar row. Indicator order is `[proc] [git] [state] [todo] [last-seen] [watch]`.
+
+**Compact mode**
+
+The label renders in both full and compact mode. In compact mode the proc snapshot is fetched only when at least one `[[sidebar.processes]]` entry is configured; otherwise compact mode keeps its current zero-cost behavior.
+
 <details>
 
 <summary>Theme customization</summary>
@@ -503,6 +547,10 @@ color_proc_claude = "#cba6f7"
 color_proc_server = "#89dceb"
 color_proc_editor = "#b4befe"
 color_proc_child  = "#a6adc8"
+
+# Default fg/bg for sidebar process labels (per-entry [[sidebar.processes]] overrides win)
+color_proc_label_fg = "#cdd6f4"
+color_proc_label_bg = ""
 
 # Git status indicators
 color_git_dirty  = "#f9e2af"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -81,6 +81,26 @@ sort = ["priority", "last_seen", "alphabetical"]
 #   oldest   — navigate to oldest updated state window
 switch_focus = "default"
 
+# Sidebar process labels — render a single highest-count label per session.
+# Globs match either the process name or any whitespace-separated token of the
+# full cmdline (case-insensitive). Only the pane root and its direct children
+# are inspected; deeper procs are ignored. If a parent matches a pattern, its
+# children are skipped. On a count tie, the entry declared first wins.
+# Example:
+# [[sidebar.processes]]
+# match = "claude*"
+# label = "🤖"
+#
+# [[sidebar.processes]]
+# match = "node*"
+# label = "node"
+#
+# [[sidebar.processes]]
+# match = "uv*"
+# label = "py"
+# fg = "#fee685"
+# bg = "#3b3000"
+
 [process_list]
 # Right-align pane CWD paths in the process list, with a fill separator
 path_right_align = false
@@ -153,6 +173,10 @@ color_proc_claude = "#cba6f7"
 color_proc_server = "#89dceb"
 color_proc_editor = "#b4befe"
 color_proc_child  = "#a6adc8"
+
+# Default fg/bg for sidebar process labels (per-entry [[sidebar.processes]] overrides win)
+color_proc_label_fg = "#cdd6f4"
+color_proc_label_bg = ""
 
 # Git status indicators
 color_git_dirty  = "#f9e2af"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -86,6 +86,8 @@ switch_focus = "default"
 # full cmdline (case-insensitive). Only the pane root and its direct children
 # are inspected; deeper procs are ignored. If a parent matches a pattern, its
 # children are skipped. On a count tie, the entry declared first wins.
+# match accepts either a single glob string or an array of globs that share
+# the same label/fg/bg.
 # Example:
 # [[sidebar.processes]]
 # match = "claude*"
@@ -96,7 +98,7 @@ switch_focus = "default"
 # label = "node"
 #
 # [[sidebar.processes]]
-# match = "uv*"
+# match = ["python*", "uvicorn", "uv"]
 # label = "py"
 # fg = "#fee685"
 # bg = "#3b3000"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,14 +129,43 @@ type ProcessesConfig struct {
 	Shells  []string `toml:"shells"`
 }
 
-// ProcessLabel declares a sidebar process indicator: a glob-matched process
-// is rendered using Label, optionally styled with FG/BG. Empty colours fall
-// back to the theme defaults (ColorProcLabelFG / ColorProcLabelBG).
+// StringList accepts either a TOML scalar string or an array of strings and
+// stores both as a []string. Used to let users supply one glob or many for a
+// single sidebar.processes entry without duplicating label/fg/bg.
+type StringList []string
+
+func (s *StringList) UnmarshalTOML(data interface{}) error {
+	switch v := data.(type) {
+	case string:
+		*s = StringList{v}
+		return nil
+	case []interface{}:
+		out := make(StringList, 0, len(v))
+		for i, item := range v {
+			str, ok := item.(string)
+			if !ok {
+				return fmt.Errorf("element %d: expected string, got %T", i, item)
+			}
+			out = append(out, str)
+		}
+		*s = out
+		return nil
+	case nil:
+		*s = nil
+		return nil
+	}
+	return fmt.Errorf("expected string or []string, got %T", data)
+}
+
+// ProcessLabel declares a sidebar process indicator: any glob in Match (case-
+// insensitive) flags a process for Label rendering, optionally styled with
+// FG/BG. Empty colours fall back to the theme defaults (ColorProcLabelFG /
+// ColorProcLabelBG). Match accepts either a scalar string or an array.
 type ProcessLabel struct {
-	Match string `toml:"match"`
-	Label string `toml:"label"`
-	FG    string `toml:"fg"`
-	BG    string `toml:"bg"`
+	Match StringList `toml:"match"`
+	Label string     `toml:"label"`
+	FG    string     `toml:"fg"`
+	BG    string     `toml:"bg"`
 }
 
 type SidebarConfig struct {
@@ -327,14 +356,26 @@ func Load(path string) (Config, error) {
 
 	filteredProcs := cfg.Sidebar.Processes[:0]
 	for _, p := range cfg.Sidebar.Processes {
-		if p.Match == "" || p.Label == "" {
+		if len(p.Match) == 0 || p.Label == "" {
 			fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.processes entry with empty match/label: %+v\n", p)
 			continue
 		}
-		if _, err := filepath.Match(p.Match, ""); err != nil {
-			fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.processes entry with bad glob %q: %v\n", p.Match, err)
+		validGlobs := p.Match[:0]
+		for _, glob := range p.Match {
+			if glob == "" {
+				continue
+			}
+			if _, err := filepath.Match(glob, ""); err != nil {
+				fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.processes glob %q: %v\n", glob, err)
+				continue
+			}
+			validGlobs = append(validGlobs, glob)
+		}
+		if len(validGlobs) == 0 {
+			fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.processes entry with no valid globs: %+v\n", p)
 			continue
 		}
+		p.Match = validGlobs
 		filteredProcs = append(filteredProcs, p)
 	}
 	cfg.Sidebar.Processes = filteredProcs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/rtalexk/demux/internal/procmatch"
 )
 
 var defaultSessionSortOrder = []string{"priority", "last_seen", "alphabetical"}
@@ -166,6 +167,26 @@ type ProcessLabel struct {
 	Label string     `toml:"label"`
 	FG    string     `toml:"fg"`
 	BG    string     `toml:"bg"`
+}
+
+// Patterns fans out a single ProcessLabel's globs into one procmatch.Pattern
+// per glob, all sharing the same Label/FG/BG.
+func (p ProcessLabel) Patterns() []procmatch.Pattern {
+	out := make([]procmatch.Pattern, 0, len(p.Match))
+	for _, g := range p.Match {
+		out = append(out, procmatch.Pattern{Match: g, Label: p.Label, FG: p.FG, BG: p.BG})
+	}
+	return out
+}
+
+// ProcessPatterns flattens every configured sidebar process label into a
+// single Pattern slice, preserving declaration order.
+func (s SidebarConfig) ProcessPatterns() []procmatch.Pattern {
+	var out []procmatch.Pattern
+	for _, p := range s.Processes {
+		out = append(out, p.Patterns()...)
+	}
+	return out
 }
 
 type SidebarConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,9 @@ type ThemeConfig struct {
 	ColorProcEditor string `toml:"color_proc_editor"`
 	ColorProcChild  string `toml:"color_proc_child"`
 
+	ColorProcLabelFG string `toml:"color_proc_label_fg"`
+	ColorProcLabelBG string `toml:"color_proc_label_bg"`
+
 	ColorGitDirty  string `toml:"color_git_dirty"`
 	ColorGitBehind string `toml:"color_git_behind"`
 	ColorGitAhead  string `toml:"color_git_ahead"`
@@ -126,16 +129,27 @@ type ProcessesConfig struct {
 	Shells  []string `toml:"shells"`
 }
 
+// ProcessLabel declares a sidebar process indicator: a glob-matched process
+// is rendered using Label, optionally styled with FG/BG. Empty colours fall
+// back to the theme defaults (ColorProcLabelFG / ColorProcLabelBG).
+type ProcessLabel struct {
+	Match string `toml:"match"`
+	Label string `toml:"label"`
+	FG    string `toml:"fg"`
+	BG    string `toml:"bg"`
+}
+
 type SidebarConfig struct {
-	DefaultFilter     string   `toml:"default_filter"`
-	FocusOnOpen       string   `toml:"focus_on_open"`
-	FocusSearchOnOpen bool     `toml:"focus_search_on_open"`
-	SearchSort        string   `toml:"search_sort"`
-	ShowLastSeen      bool     `toml:"show_last_seen"`
-	ActiveSessionIcon string   `toml:"active_session_icon"`
-	Sort              []string `toml:"sort"`
-	SwitchFocus       string   `toml:"switch_focus"`
-	Width             int      `toml:"width"`
+	DefaultFilter     string         `toml:"default_filter"`
+	FocusOnOpen       string         `toml:"focus_on_open"`
+	FocusSearchOnOpen bool           `toml:"focus_search_on_open"`
+	SearchSort        string         `toml:"search_sort"`
+	ShowLastSeen      bool           `toml:"show_last_seen"`
+	ActiveSessionIcon string         `toml:"active_session_icon"`
+	Sort              []string       `toml:"sort"`
+	SwitchFocus       string         `toml:"switch_focus"`
+	Width             int            `toml:"width"`
+	Processes         []ProcessLabel `toml:"processes"`
 }
 
 type ProcessListConfig struct {
@@ -223,6 +237,9 @@ func Default() Config {
 			ColorProcServer: "#89dceb",
 			ColorProcEditor: "#b4befe",
 			ColorProcChild:  "#a6adc8",
+
+			ColorProcLabelFG: "#cdd6f4",
+			ColorProcLabelBG: "",
 
 			ColorGitDirty:  "#f9e2af",
 			ColorGitBehind: "#74c7ec",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -324,6 +324,21 @@ func Load(path string) (Config, error) {
 		return len(cfg.PathAliases[i].Prefix) > len(cfg.PathAliases[j].Prefix)
 	})
 	cfg.Sidebar.Sort = normalizeSortKeys(cfg.Sidebar.Sort)
+
+	filteredProcs := cfg.Sidebar.Processes[:0]
+	for _, p := range cfg.Sidebar.Processes {
+		if p.Match == "" || p.Label == "" {
+			fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.processes entry with empty match/label: %+v\n", p)
+			continue
+		}
+		if _, err := filepath.Match(p.Match, ""); err != nil {
+			fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.processes entry with bad glob %q: %v\n", p.Match, err)
+			continue
+		}
+		filteredProcs = append(filteredProcs, p)
+	}
+	cfg.Sidebar.Processes = filteredProcs
+
 	return cfg, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -506,7 +506,7 @@ active_session_icon = "@"
 	}
 }
 
-func TestLoad_SidebarProcesses(t *testing.T) {
+func TestLoad_SidebarProcesses_ScalarMatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "demux.toml")
 	body := `
@@ -530,11 +530,100 @@ bg = "#101010"
 	if len(cfg.Sidebar.Processes) != 2 {
 		t.Fatalf("expected 2 entries, got %d", len(cfg.Sidebar.Processes))
 	}
-	if cfg.Sidebar.Processes[0].Match != "claude*" || cfg.Sidebar.Processes[0].Label != "🤖" {
+	if len(cfg.Sidebar.Processes[0].Match) != 1 || cfg.Sidebar.Processes[0].Match[0] != "claude*" || cfg.Sidebar.Processes[0].Label != "🤖" {
 		t.Fatalf("entry 0 mismatch: %+v", cfg.Sidebar.Processes[0])
 	}
 	if cfg.Sidebar.Processes[1].FG != "#abcdef" || cfg.Sidebar.Processes[1].BG != "#101010" {
 		t.Fatalf("entry 1 colours mismatch: %+v", cfg.Sidebar.Processes[1])
+	}
+}
+
+func TestLoad_SidebarProcesses_ArrayMatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := `
+[[sidebar.processes]]
+match = ["python*", "uvicorn", "uv"]
+label = "py"
+fg = "#1e1e2e"
+bg = "#a6e3a1"
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Sidebar.Processes) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(cfg.Sidebar.Processes))
+	}
+	got := cfg.Sidebar.Processes[0]
+	want := []string{"python*", "uvicorn", "uv"}
+	if len(got.Match) != len(want) {
+		t.Fatalf("expected %d globs, got %d: %+v", len(want), len(got.Match), got.Match)
+	}
+	for i, w := range want {
+		if got.Match[i] != w {
+			t.Fatalf("glob[%d] = %q, want %q", i, got.Match[i], w)
+		}
+	}
+	if got.Label != "py" || got.FG != "#1e1e2e" || got.BG != "#a6e3a1" {
+		t.Fatalf("entry mismatch: %+v", got)
+	}
+}
+
+func TestLoad_SidebarProcesses_ArrayMatch_DropsInvalidGlobs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := `
+[[sidebar.processes]]
+match = ["python*", "[", "uvicorn"]
+label = "py"
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Sidebar.Processes) != 1 {
+		t.Fatalf("expected entry kept, got %d", len(cfg.Sidebar.Processes))
+	}
+	got := cfg.Sidebar.Processes[0].Match
+	want := []string{"python*", "uvicorn"}
+	if len(got) != len(want) {
+		t.Fatalf("expected bad glob filtered out, got %+v", got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Fatalf("glob[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestLoad_SidebarProcesses_ArrayMatch_AllInvalidDropsEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := `
+[[sidebar.processes]]
+match = ["[", "[bad"]
+label = "py"
+
+[[sidebar.processes]]
+match = ["python*"]
+label = "py"
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Sidebar.Processes) != 1 {
+		t.Fatalf("expected only valid entry, got %d", len(cfg.Sidebar.Processes))
 	}
 }
 
@@ -568,7 +657,7 @@ label = "🤖"
 	if len(cfg.Sidebar.Processes) != 1 {
 		t.Fatalf("expected only the valid entry, got %d: %+v", len(cfg.Sidebar.Processes), cfg.Sidebar.Processes)
 	}
-	if cfg.Sidebar.Processes[0].Match != "claude*" {
+	if len(cfg.Sidebar.Processes[0].Match) != 1 || cfg.Sidebar.Processes[0].Match[0] != "claude*" {
 		t.Fatalf("expected claude entry, got %+v", cfg.Sidebar.Processes[0])
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -538,6 +538,41 @@ bg = "#101010"
 	}
 }
 
+func TestLoad_FiltersInvalidProcesses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := `
+[[sidebar.processes]]
+match = ""
+label = "noop"
+
+[[sidebar.processes]]
+match = "node*"
+label = ""
+
+[[sidebar.processes]]
+match = "["
+label = "broken"
+
+[[sidebar.processes]]
+match = "claude*"
+label = "🤖"
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Sidebar.Processes) != 1 {
+		t.Fatalf("expected only the valid entry, got %d: %+v", len(cfg.Sidebar.Processes), cfg.Sidebar.Processes)
+	}
+	if cfg.Sidebar.Processes[0].Match != "claude*" {
+		t.Fatalf("expected claude entry, got %+v", cfg.Sidebar.Processes[0])
+	}
+}
+
 func TestLoad_ProcLabelThemeKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "demux.toml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -505,3 +505,58 @@ active_session_icon = "@"
 		t.Errorf("expected @, got %q", cfg.Sidebar.ActiveSessionIcon)
 	}
 }
+
+func TestLoad_SidebarProcesses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := `
+[[sidebar.processes]]
+match = "claude*"
+label = "🤖"
+
+[[sidebar.processes]]
+match = "node*"
+label = "node"
+fg = "#abcdef"
+bg = "#101010"
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Sidebar.Processes) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(cfg.Sidebar.Processes))
+	}
+	if cfg.Sidebar.Processes[0].Match != "claude*" || cfg.Sidebar.Processes[0].Label != "🤖" {
+		t.Fatalf("entry 0 mismatch: %+v", cfg.Sidebar.Processes[0])
+	}
+	if cfg.Sidebar.Processes[1].FG != "#abcdef" || cfg.Sidebar.Processes[1].BG != "#101010" {
+		t.Fatalf("entry 1 colours mismatch: %+v", cfg.Sidebar.Processes[1])
+	}
+}
+
+func TestLoad_ProcLabelThemeKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := `
+[theme]
+color_proc_label_fg = "#111111"
+color_proc_label_bg = "#222222"
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Theme.ColorProcLabelFG != "#111111" {
+		t.Fatalf("fg mismatch: %q", cfg.Theme.ColorProcLabelFG)
+	}
+	if cfg.Theme.ColorProcLabelBG != "#222222" {
+		t.Fatalf("bg mismatch: %q", cfg.Theme.ColorProcLabelBG)
+	}
+}

--- a/internal/procmatch/procmatch.go
+++ b/internal/procmatch/procmatch.go
@@ -3,6 +3,13 @@
 // only data transformation.
 package procmatch
 
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/rtalexk/demux/internal/proc"
+)
+
 type Pattern struct {
 	Match string
 	Label string
@@ -14,4 +21,37 @@ type Label struct {
 	Text string
 	FG   string
 	BG   string
+}
+
+// MatchProcess returns the Label of the first pattern whose lowered glob
+// matches either the lowered FriendlyName, any whitespace-separated token of
+// the lowered Cmdline, or the basename of such a token. Returns (Label{},
+// false) if no pattern matches. Patterns whose Match is not a valid glob are
+// skipped silently.
+func MatchProcess(p proc.Process, patterns []Pattern) (Label, bool) {
+	name := strings.ToLower(p.FriendlyName())
+	fields := strings.Fields(strings.ToLower(p.Cmdline))
+	for _, pat := range patterns {
+		if pat.Match == "" || pat.Label == "" {
+			continue
+		}
+		glob := strings.ToLower(pat.Match)
+		if _, err := filepath.Match(glob, ""); err != nil {
+			continue
+		}
+		if hit, _ := filepath.Match(glob, name); hit {
+			return Label{Text: pat.Label, FG: pat.FG, BG: pat.BG}, true
+		}
+		for _, tok := range fields {
+			if hit, _ := filepath.Match(glob, tok); hit {
+				return Label{Text: pat.Label, FG: pat.FG, BG: pat.BG}, true
+			}
+			if base := filepath.Base(tok); base != tok {
+				if hit, _ := filepath.Match(glob, base); hit {
+					return Label{Text: pat.Label, FG: pat.FG, BG: pat.BG}, true
+				}
+			}
+		}
+	}
+	return Label{}, false
 }

--- a/internal/procmatch/procmatch.go
+++ b/internal/procmatch/procmatch.go
@@ -58,17 +58,21 @@ func MatchProcess(p proc.Process, patterns []Pattern) (Label, bool) {
 }
 
 // Match returns at most one Label per session. For each pane:
-//   - Level 0 (pane root) is matched first; the first hit (in declaration
+//   - The effective level 0 is the pane root proc, descending past any proc
+//     whose FriendlyName is in ignored (case-insensitive). This mirrors the
+//     shell-promotion done by the proc list display, so a pane whose raw root
+//     is zsh -> make is treated as if make were the root.
+//   - Effective level 0 is matched first; the first hit (in declaration
 //     order) wins and children are not inspected.
-//   - Level 1 is inspected only when level 0 had no hit. The first child
-//     proc whose name or cmdline matches a pattern wins.
+//   - Effective level 1 is inspected only when level 0 had no hit. Children
+//     of an ignored proc are flattened up to the same effective depth.
 //
 // Across all matched panes for a session, the label with the highest
 // occurrence count is selected. Ties are broken by earliest declaration
 // order in patterns.
 //
 // Sessions with zero matched panes do not appear in the returned map.
-func Match(panes []tmux.Pane, procs []proc.Process, patterns []Pattern) map[string]Label {
+func Match(panes []tmux.Pane, procs []proc.Process, patterns []Pattern, ignored []string) map[string]Label {
 	if len(panes) == 0 || len(procs) == 0 || len(patterns) == 0 {
 		return map[string]Label{}
 	}
@@ -78,6 +82,45 @@ func Match(panes []tmux.Pane, procs []proc.Process, patterns []Pattern) map[stri
 	for _, p := range procs {
 		byPID[p.PID] = p
 		childrenOf[p.PPID] = append(childrenOf[p.PPID], p)
+	}
+
+	ignoredSet := make(map[string]struct{}, len(ignored))
+	for _, n := range ignored {
+		ignoredSet[strings.ToLower(n)] = struct{}{}
+	}
+	isIgnored := func(p proc.Process) bool {
+		_, ok := ignoredSet[strings.ToLower(p.FriendlyName())]
+		return ok
+	}
+
+	// effectiveChildren flattens any direct child whose FriendlyName is in
+	// ignored, replacing it with its own direct children (recursively). The
+	// returned slice never contains an ignored proc.
+	var effectiveChildren func(pid int32) []proc.Process
+	effectiveChildren = func(pid int32) []proc.Process {
+		var out []proc.Process
+		for _, c := range childrenOf[pid] {
+			if isIgnored(c) {
+				out = append(out, effectiveChildren(c.PID)...)
+				continue
+			}
+			out = append(out, c)
+		}
+		return out
+	}
+
+	// effectiveRoots returns the pane's effective level-0 procs: either the
+	// raw root (if not ignored), or its flattened descendants past every
+	// ignored ancestor.
+	effectiveRoots := func(panePID int32) []proc.Process {
+		root, ok := byPID[panePID]
+		if !ok {
+			return nil
+		}
+		if !isIgnored(root) {
+			return []proc.Process{root}
+		}
+		return effectiveChildren(root.PID)
 	}
 
 	patternRank := make(map[string]int, len(patterns))
@@ -108,17 +151,32 @@ func Match(panes []tmux.Pane, procs []proc.Process, patterns []Pattern) map[stri
 	}
 
 	for _, pane := range panes {
-		root, ok := byPID[pane.PanePID]
-		if !ok {
+		roots := effectiveRoots(pane.PanePID)
+		if len(roots) == 0 {
 			continue
 		}
-		if lbl, hit := MatchProcess(root, patterns); hit {
-			addHit(pane.Session, lbl)
-			continue
-		}
-		for _, child := range childrenOf[pane.PanePID] {
-			if lbl, hit := MatchProcess(child, patterns); hit {
+		matched := false
+		for _, r := range roots {
+			if lbl, hit := MatchProcess(r, patterns); hit {
 				addHit(pane.Session, lbl)
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+		for _, r := range roots {
+			children := effectiveChildren(r.PID)
+			found := false
+			for _, child := range children {
+				if lbl, hit := MatchProcess(child, patterns); hit {
+					addHit(pane.Session, lbl)
+					found = true
+					break
+				}
+			}
+			if found {
 				break
 			}
 		}

--- a/internal/procmatch/procmatch.go
+++ b/internal/procmatch/procmatch.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 type Pattern struct {
@@ -54,4 +55,91 @@ func MatchProcess(p proc.Process, patterns []Pattern) (Label, bool) {
 		}
 	}
 	return Label{}, false
+}
+
+// Match returns at most one Label per session. For each pane:
+//   - Level 0 (pane root) is matched first; the first hit (in declaration
+//     order) wins and children are not inspected.
+//   - Level 1 is inspected only when level 0 had no hit. The first child
+//     proc whose name or cmdline matches a pattern wins.
+//
+// Across all matched panes for a session, the label with the highest
+// occurrence count is selected. Ties are broken by earliest declaration
+// order in patterns.
+//
+// Sessions with zero matched panes do not appear in the returned map.
+func Match(panes []tmux.Pane, procs []proc.Process, patterns []Pattern) map[string]Label {
+	if len(panes) == 0 || len(procs) == 0 || len(patterns) == 0 {
+		return map[string]Label{}
+	}
+
+	byPID := make(map[int32]proc.Process, len(procs))
+	childrenOf := make(map[int32][]proc.Process, len(procs))
+	for _, p := range procs {
+		byPID[p.PID] = p
+		childrenOf[p.PPID] = append(childrenOf[p.PPID], p)
+	}
+
+	patternRank := make(map[string]int, len(patterns))
+	for i, pat := range patterns {
+		if _, seen := patternRank[pat.Label]; !seen {
+			patternRank[pat.Label] = i
+		}
+	}
+
+	type tally struct {
+		label Label
+		count int
+	}
+	tallies := make(map[string]map[string]*tally)
+
+	addHit := func(session string, lbl Label) {
+		bySession, ok := tallies[session]
+		if !ok {
+			bySession = make(map[string]*tally)
+			tallies[session] = bySession
+		}
+		t, ok := bySession[lbl.Text]
+		if !ok {
+			t = &tally{label: lbl}
+			bySession[lbl.Text] = t
+		}
+		t.count++
+	}
+
+	for _, pane := range panes {
+		root, ok := byPID[pane.PanePID]
+		if !ok {
+			continue
+		}
+		if lbl, hit := MatchProcess(root, patterns); hit {
+			addHit(pane.Session, lbl)
+			continue
+		}
+		for _, child := range childrenOf[pane.PanePID] {
+			if lbl, hit := MatchProcess(child, patterns); hit {
+				addHit(pane.Session, lbl)
+				break
+			}
+		}
+	}
+
+	out := make(map[string]Label, len(tallies))
+	for sess, bySession := range tallies {
+		var best *tally
+		for _, t := range bySession {
+			switch {
+			case best == nil:
+				best = t
+			case t.count > best.count:
+				best = t
+			case t.count == best.count && patternRank[t.label.Text] < patternRank[best.label.Text]:
+				best = t
+			}
+		}
+		if best != nil {
+			out[sess] = best.label
+		}
+	}
+	return out
 }

--- a/internal/procmatch/procmatch.go
+++ b/internal/procmatch/procmatch.go
@@ -1,0 +1,17 @@
+// Package procmatch matches processes inside tmux pane trees against
+// user-configured glob patterns. It is pure: no TUI or tmux side effects,
+// only data transformation.
+package procmatch
+
+type Pattern struct {
+	Match string
+	Label string
+	FG    string
+	BG    string
+}
+
+type Label struct {
+	Text string
+	FG   string
+	BG   string
+}

--- a/internal/procmatch/procmatch.go
+++ b/internal/procmatch/procmatch.go
@@ -24,14 +24,15 @@ type Label struct {
 	BG   string
 }
 
-// MatchProcess returns the Label of the first pattern whose lowered glob
-// matches either the lowered FriendlyName, any whitespace-separated token of
-// the lowered Cmdline, or the basename of such a token. Returns (Label{},
-// false) if no pattern matches. Patterns whose Match is not a valid glob are
-// skipped silently.
-func MatchProcess(p proc.Process, patterns []Pattern) (Label, bool) {
-	name := strings.ToLower(p.FriendlyName())
-	fields := strings.Fields(strings.ToLower(p.Cmdline))
+// normalizedPattern is a Pattern with the glob lower-cased once and
+// validated; invalid/empty entries are dropped during normalization.
+type normalizedPattern struct {
+	glob  string
+	label Label
+}
+
+func normalize(patterns []Pattern) []normalizedPattern {
+	out := make([]normalizedPattern, 0, len(patterns))
 	for _, pat := range patterns {
 		if pat.Match == "" || pat.Label == "" {
 			continue
@@ -40,21 +41,49 @@ func MatchProcess(p proc.Process, patterns []Pattern) (Label, bool) {
 		if _, err := filepath.Match(glob, ""); err != nil {
 			continue
 		}
-		if hit, _ := filepath.Match(glob, name); hit {
-			return Label{Text: pat.Label, FG: pat.FG, BG: pat.BG}, true
+		out = append(out, normalizedPattern{
+			glob:  glob,
+			label: Label{Text: pat.Label, FG: pat.FG, BG: pat.BG},
+		})
+	}
+	return out
+}
+
+func matchGlob(glob, candidate string) bool {
+	hit, _ := filepath.Match(glob, candidate)
+	return hit
+}
+
+// matchNormalized scans pre-normalized patterns against an already-lowered
+// name and lowered cmdline tokens. Returns the first pattern's label.
+func matchNormalized(name string, fields []string, patterns []normalizedPattern) (Label, bool) {
+	for _, pat := range patterns {
+		if matchGlob(pat.glob, name) {
+			return pat.label, true
 		}
 		for _, tok := range fields {
-			if hit, _ := filepath.Match(glob, tok); hit {
-				return Label{Text: pat.Label, FG: pat.FG, BG: pat.BG}, true
+			if matchGlob(pat.glob, tok) {
+				return pat.label, true
 			}
-			if base := filepath.Base(tok); base != tok {
-				if hit, _ := filepath.Match(glob, base); hit {
-					return Label{Text: pat.Label, FG: pat.FG, BG: pat.BG}, true
-				}
+			if base := filepath.Base(tok); base != tok && matchGlob(pat.glob, base) {
+				return pat.label, true
 			}
 		}
 	}
 	return Label{}, false
+}
+
+// MatchProcess returns the Label of the first pattern whose lowered glob
+// matches either the lowered FriendlyName, any whitespace-separated token of
+// the lowered Cmdline, or the basename of such a token. Returns (Label{},
+// false) if no pattern matches. Patterns whose Match is not a valid glob are
+// skipped silently.
+func MatchProcess(p proc.Process, patterns []Pattern) (Label, bool) {
+	return matchNormalized(
+		strings.ToLower(p.FriendlyName()),
+		strings.Fields(strings.ToLower(p.Cmdline)),
+		normalize(patterns),
+	)
 }
 
 // Match returns at most one Label per session. For each pane:
@@ -74,6 +103,11 @@ func MatchProcess(p proc.Process, patterns []Pattern) (Label, bool) {
 // Sessions with zero matched panes do not appear in the returned map.
 func Match(panes []tmux.Pane, procs []proc.Process, patterns []Pattern, ignored []string) map[string]Label {
 	if len(panes) == 0 || len(procs) == 0 || len(patterns) == 0 {
+		return map[string]Label{}
+	}
+
+	normalized := normalize(patterns)
+	if len(normalized) == 0 {
 		return map[string]Label{}
 	}
 
@@ -123,6 +157,22 @@ func Match(panes []tmux.Pane, procs []proc.Process, patterns []Pattern, ignored 
 		return effectiveChildren(root.PID)
 	}
 
+	matchProc := func(p proc.Process) (Label, bool) {
+		return matchNormalized(
+			strings.ToLower(p.FriendlyName()),
+			strings.Fields(strings.ToLower(p.Cmdline)),
+			normalized,
+		)
+	}
+	firstHit := func(procs []proc.Process) (Label, bool) {
+		for _, p := range procs {
+			if lbl, ok := matchProc(p); ok {
+				return lbl, true
+			}
+		}
+		return Label{}, false
+	}
+
 	patternRank := make(map[string]int, len(patterns))
 	for i, pat := range patterns {
 		if _, seen := patternRank[pat.Label]; !seen {
@@ -155,28 +205,13 @@ func Match(panes []tmux.Pane, procs []proc.Process, patterns []Pattern, ignored 
 		if len(roots) == 0 {
 			continue
 		}
-		matched := false
-		for _, r := range roots {
-			if lbl, hit := MatchProcess(r, patterns); hit {
-				addHit(pane.Session, lbl)
-				matched = true
-				break
-			}
-		}
-		if matched {
+		if lbl, ok := firstHit(roots); ok {
+			addHit(pane.Session, lbl)
 			continue
 		}
 		for _, r := range roots {
-			children := effectiveChildren(r.PID)
-			found := false
-			for _, child := range children {
-				if lbl, hit := MatchProcess(child, patterns); hit {
-					addHit(pane.Session, lbl)
-					found = true
-					break
-				}
-			}
-			if found {
+			if lbl, ok := firstHit(effectiveChildren(r.PID)); ok {
+				addHit(pane.Session, lbl)
 				break
 			}
 		}

--- a/internal/procmatch/procmatch_test.go
+++ b/internal/procmatch/procmatch_test.go
@@ -100,7 +100,7 @@ func TestMatch_LevelZeroPaneRoot(t *testing.T) {
 		makeProc(100, 1, "claude", ""),
 	}
 	patterns := []procmatch.Pattern{{Match: "claude*", Label: "🤖"}}
-	got := procmatch.Match(panes, procs, patterns)
+	got := procmatch.Match(panes, procs, patterns, nil)
 	if got["s1"].Text != "🤖" {
 		t.Fatalf("expected 🤖, got %+v", got)
 	}
@@ -113,7 +113,7 @@ func TestMatch_LevelOneChildWhenRootUnmatched(t *testing.T) {
 		makeProc(101, 100, "node", ""),
 	}
 	patterns := []procmatch.Pattern{{Match: "node*", Label: "n"}}
-	got := procmatch.Match(panes, procs, patterns)
+	got := procmatch.Match(panes, procs, patterns, nil)
 	if got["s1"].Text != "n" {
 		t.Fatalf("expected child match, got %+v", got)
 	}
@@ -129,7 +129,7 @@ func TestMatch_ParentPrecedenceSkipsChildren(t *testing.T) {
 		{Match: "nvim*", Label: "nvim"},
 		{Match: "node*", Label: "node"},
 	}
-	got := procmatch.Match(panes, procs, patterns)
+	got := procmatch.Match(panes, procs, patterns, nil)
 	if got["s1"].Text != "nvim" {
 		t.Fatalf("expected parent to win, got %+v", got)
 	}
@@ -150,7 +150,7 @@ func TestMatch_TopCountWinsAcrossPanes(t *testing.T) {
 		{Match: "node*", Label: "node"},
 		{Match: "uv*", Label: "py"},
 	}
-	got := procmatch.Match(panes, procs, patterns)
+	got := procmatch.Match(panes, procs, patterns, nil)
 	if got["s1"].Text != "node" {
 		t.Fatalf("expected highest-count node, got %+v", got)
 	}
@@ -169,7 +169,7 @@ func TestMatch_TieBreakByDeclarationOrder(t *testing.T) {
 		{Match: "uv*", Label: "py"},
 		{Match: "node*", Label: "node"},
 	}
-	got := procmatch.Match(panes, procs, patterns)
+	got := procmatch.Match(panes, procs, patterns, nil)
 	if got["s1"].Text != "py" {
 		t.Fatalf("expected declaration-order tiebreak, got %+v", got)
 	}
@@ -187,7 +187,7 @@ func TestMatch_NoDescentBeyondLevelOne(t *testing.T) {
 		{Match: "uv*", Label: "py"},
 		{Match: "node*", Label: "node"},
 	}
-	got := procmatch.Match(panes, procs, patterns)
+	got := procmatch.Match(panes, procs, patterns, nil)
 	if got["s1"].Text != "node" {
 		t.Fatalf("expected level-1 node, got %+v", got)
 	}
@@ -202,7 +202,7 @@ func TestMatch_PaneWithNoRootProcSkipped(t *testing.T) {
 		makeProc(100, 1, "node", ""),
 	}
 	patterns := []procmatch.Pattern{{Match: "node*", Label: "n"}}
-	got := procmatch.Match(panes, procs, patterns)
+	got := procmatch.Match(panes, procs, patterns, nil)
 	if got["s1"].Text != "n" {
 		t.Fatalf("expected node from valid pane, got %+v", got)
 	}
@@ -212,14 +212,84 @@ func TestMatch_NoMatchProducesNoEntry(t *testing.T) {
 	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
 	procs := []proc.Process{makeProc(100, 1, "zsh", "")}
 	patterns := []procmatch.Pattern{{Match: "node*", Label: "n"}}
-	got := procmatch.Match(panes, procs, patterns)
+	got := procmatch.Match(panes, procs, patterns, nil)
 	if _, ok := got["s1"]; ok {
 		t.Fatalf("expected no entry for s1, got %+v", got)
 	}
 }
 
 func TestMatch_EmptyInputs(t *testing.T) {
-	if got := procmatch.Match(nil, nil, nil); len(got) != 0 {
+	if got := procmatch.Match(nil, nil, nil, nil); len(got) != 0 {
 		t.Fatalf("expected empty map, got %+v", got)
+	}
+}
+
+func TestMatch_IgnoredShellPromotesChildren(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "zsh", "-zsh"),
+		makeProc(101, 100, "make", "make dev"),
+		makeProc(102, 101, "node", "node server.js"),
+	}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "node"}}
+	got := procmatch.Match(panes, procs, patterns, []string{"zsh"})
+	if got["s1"].Text != "node" {
+		t.Fatalf("expected node label after shell promoted, got %+v", got)
+	}
+}
+
+func TestMatch_IgnoredShellPreservesDepthCap(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "zsh", ""),
+		makeProc(101, 100, "make", ""),
+		makeProc(102, 101, "node", ""),
+		makeProc(103, 102, "uv", ""),
+	}
+	patterns := []procmatch.Pattern{{Match: "uv*", Label: "py"}}
+	got := procmatch.Match(panes, procs, patterns, []string{"zsh"})
+	if _, ok := got["s1"]; ok {
+		t.Fatalf("expected uv at effective depth 2 to be skipped, got %+v", got)
+	}
+}
+
+func TestMatch_IgnoredChainPromotedTransparently(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "zsh", ""),
+		makeProc(101, 100, "bash", ""),
+		makeProc(102, 101, "make", ""),
+		makeProc(103, 102, "node", ""),
+	}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "node"}}
+	got := procmatch.Match(panes, procs, patterns, []string{"zsh", "bash"})
+	if got["s1"].Text != "node" {
+		t.Fatalf("expected chained shell promotion, got %+v", got)
+	}
+}
+
+func TestMatch_IgnoredCaseInsensitive(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "Zsh", ""),
+		makeProc(101, 100, "node", ""),
+	}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "node"}}
+	got := procmatch.Match(panes, procs, patterns, []string{"ZSH"})
+	if got["s1"].Text != "node" {
+		t.Fatalf("expected case-insensitive ignored match, got %+v", got)
+	}
+}
+
+func TestMatch_NilIgnoredBehavesLikeBefore(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "zsh", ""),
+		makeProc(101, 100, "node", ""),
+	}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "node"}}
+	got := procmatch.Match(panes, procs, patterns, nil)
+	if got["s1"].Text != "node" {
+		t.Fatalf("expected level-1 node hit with nil ignored, got %+v", got)
 	}
 }

--- a/internal/procmatch/procmatch_test.go
+++ b/internal/procmatch/procmatch_test.go
@@ -1,0 +1,21 @@
+package procmatch_test
+
+import (
+	"testing"
+
+	"github.com/rtalexk/demux/internal/procmatch"
+)
+
+func TestPatternZeroValue(t *testing.T) {
+	var p procmatch.Pattern
+	if p.Match != "" || p.Label != "" || p.FG != "" || p.BG != "" {
+		t.Fatalf("expected zero-valued Pattern, got %+v", p)
+	}
+}
+
+func TestLabelZeroValue(t *testing.T) {
+	var l procmatch.Label
+	if l.Text != "" || l.FG != "" || l.BG != "" {
+		t.Fatalf("expected zero-valued Label, got %+v", l)
+	}
+}

--- a/internal/procmatch/procmatch_test.go
+++ b/internal/procmatch/procmatch_test.go
@@ -3,6 +3,7 @@ package procmatch_test
 import (
 	"testing"
 
+	"github.com/rtalexk/demux/internal/proc"
 	"github.com/rtalexk/demux/internal/procmatch"
 )
 
@@ -17,5 +18,73 @@ func TestLabelZeroValue(t *testing.T) {
 	var l procmatch.Label
 	if l.Text != "" || l.FG != "" || l.BG != "" {
 		t.Fatalf("expected zero-valued Label, got %+v", l)
+	}
+}
+
+func TestMatchProcess_ByName(t *testing.T) {
+	p := proc.Process{Name: "node", Cmdline: "node"}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "node"}}
+	got, ok := procmatch.MatchProcess(p, patterns)
+	if !ok || got.Text != "node" {
+		t.Fatalf("expected node hit, got=%+v ok=%v", got, ok)
+	}
+}
+
+func TestMatchProcess_ByCmdline(t *testing.T) {
+	p := proc.Process{Name: "node", Cmdline: "/usr/bin/node /app/server.js --port 3000"}
+	patterns := []procmatch.Pattern{{Match: "*server.js*", Label: "srv"}}
+	got, ok := procmatch.MatchProcess(p, patterns)
+	if !ok || got.Text != "srv" {
+		t.Fatalf("expected srv hit, got=%+v ok=%v", got, ok)
+	}
+}
+
+func TestMatchProcess_CaseInsensitive(t *testing.T) {
+	p := proc.Process{Name: "Node", Cmdline: ""}
+	patterns := []procmatch.Pattern{{Match: "NODE*", Label: "n"}}
+	got, ok := procmatch.MatchProcess(p, patterns)
+	if !ok || got.Text != "n" {
+		t.Fatalf("expected case-insensitive hit, got=%+v ok=%v", got, ok)
+	}
+}
+
+func TestMatchProcess_DeclarationOrderWins(t *testing.T) {
+	p := proc.Process{Name: "claude", Cmdline: ""}
+	patterns := []procmatch.Pattern{
+		{Match: "claude*", Label: "first"},
+		{Match: "claude", Label: "second"},
+	}
+	got, ok := procmatch.MatchProcess(p, patterns)
+	if !ok || got.Text != "first" {
+		t.Fatalf("expected first declaration to win, got=%+v ok=%v", got, ok)
+	}
+}
+
+func TestMatchProcess_NoMatch(t *testing.T) {
+	p := proc.Process{Name: "zsh", Cmdline: "/bin/zsh"}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "node"}}
+	if _, ok := procmatch.MatchProcess(p, patterns); ok {
+		t.Fatalf("expected no match")
+	}
+}
+
+func TestMatchProcess_BadGlobSkipped(t *testing.T) {
+	p := proc.Process{Name: "node", Cmdline: ""}
+	patterns := []procmatch.Pattern{
+		{Match: "[", Label: "broken"},
+		{Match: "node*", Label: "node"},
+	}
+	got, ok := procmatch.MatchProcess(p, patterns)
+	if !ok || got.Text != "node" {
+		t.Fatalf("expected fallthrough past bad glob, got=%+v ok=%v", got, ok)
+	}
+}
+
+func TestMatchProcess_LabelCarriesColors(t *testing.T) {
+	p := proc.Process{Name: "uv", Cmdline: ""}
+	patterns := []procmatch.Pattern{{Match: "uv*", Label: "py", FG: "#fff", BG: "#000"}}
+	got, ok := procmatch.MatchProcess(p, patterns)
+	if !ok || got.Text != "py" || got.FG != "#fff" || got.BG != "#000" {
+		t.Fatalf("expected colors propagated, got=%+v ok=%v", got, ok)
 	}
 }

--- a/internal/procmatch/procmatch_test.go
+++ b/internal/procmatch/procmatch_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rtalexk/demux/internal/proc"
 	"github.com/rtalexk/demux/internal/procmatch"
+	"github.com/rtalexk/demux/internal/tmux"
 )
 
 func TestPatternZeroValue(t *testing.T) {
@@ -86,5 +87,139 @@ func TestMatchProcess_LabelCarriesColors(t *testing.T) {
 	got, ok := procmatch.MatchProcess(p, patterns)
 	if !ok || got.Text != "py" || got.FG != "#fff" || got.BG != "#000" {
 		t.Fatalf("expected colors propagated, got=%+v ok=%v", got, ok)
+	}
+}
+
+func makeProc(pid, ppid int32, name, cmd string) proc.Process {
+	return proc.Process{PID: pid, PPID: ppid, Name: name, Cmdline: cmd}
+}
+
+func TestMatch_LevelZeroPaneRoot(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "claude", ""),
+	}
+	patterns := []procmatch.Pattern{{Match: "claude*", Label: "🤖"}}
+	got := procmatch.Match(panes, procs, patterns)
+	if got["s1"].Text != "🤖" {
+		t.Fatalf("expected 🤖, got %+v", got)
+	}
+}
+
+func TestMatch_LevelOneChildWhenRootUnmatched(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "make", ""),
+		makeProc(101, 100, "node", ""),
+	}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "n"}}
+	got := procmatch.Match(panes, procs, patterns)
+	if got["s1"].Text != "n" {
+		t.Fatalf("expected child match, got %+v", got)
+	}
+}
+
+func TestMatch_ParentPrecedenceSkipsChildren(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "nvim", ""),
+		makeProc(101, 100, "node", ""),
+	}
+	patterns := []procmatch.Pattern{
+		{Match: "nvim*", Label: "nvim"},
+		{Match: "node*", Label: "node"},
+	}
+	got := procmatch.Match(panes, procs, patterns)
+	if got["s1"].Text != "nvim" {
+		t.Fatalf("expected parent to win, got %+v", got)
+	}
+}
+
+func TestMatch_TopCountWinsAcrossPanes(t *testing.T) {
+	panes := []tmux.Pane{
+		{Session: "s1", PanePID: 100},
+		{Session: "s1", PanePID: 200},
+		{Session: "s1", PanePID: 300},
+	}
+	procs := []proc.Process{
+		makeProc(100, 1, "node", ""),
+		makeProc(200, 1, "node", ""),
+		makeProc(300, 1, "uv", ""),
+	}
+	patterns := []procmatch.Pattern{
+		{Match: "node*", Label: "node"},
+		{Match: "uv*", Label: "py"},
+	}
+	got := procmatch.Match(panes, procs, patterns)
+	if got["s1"].Text != "node" {
+		t.Fatalf("expected highest-count node, got %+v", got)
+	}
+}
+
+func TestMatch_TieBreakByDeclarationOrder(t *testing.T) {
+	panes := []tmux.Pane{
+		{Session: "s1", PanePID: 100},
+		{Session: "s1", PanePID: 200},
+	}
+	procs := []proc.Process{
+		makeProc(100, 1, "node", ""),
+		makeProc(200, 1, "uv", ""),
+	}
+	patterns := []procmatch.Pattern{
+		{Match: "uv*", Label: "py"},
+		{Match: "node*", Label: "node"},
+	}
+	got := procmatch.Match(panes, procs, patterns)
+	if got["s1"].Text != "py" {
+		t.Fatalf("expected declaration-order tiebreak, got %+v", got)
+	}
+}
+
+func TestMatch_NoDescentBeyondLevelOne(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{
+		makeProc(100, 1, "make", ""),
+		makeProc(101, 100, "node", ""),
+		makeProc(102, 101, "uv", ""),
+		makeProc(103, 102, "python", ""),
+	}
+	patterns := []procmatch.Pattern{
+		{Match: "uv*", Label: "py"},
+		{Match: "node*", Label: "node"},
+	}
+	got := procmatch.Match(panes, procs, patterns)
+	if got["s1"].Text != "node" {
+		t.Fatalf("expected level-1 node, got %+v", got)
+	}
+}
+
+func TestMatch_PaneWithNoRootProcSkipped(t *testing.T) {
+	panes := []tmux.Pane{
+		{Session: "s1", PanePID: 999},
+		{Session: "s1", PanePID: 100},
+	}
+	procs := []proc.Process{
+		makeProc(100, 1, "node", ""),
+	}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "n"}}
+	got := procmatch.Match(panes, procs, patterns)
+	if got["s1"].Text != "n" {
+		t.Fatalf("expected node from valid pane, got %+v", got)
+	}
+}
+
+func TestMatch_NoMatchProducesNoEntry(t *testing.T) {
+	panes := []tmux.Pane{{Session: "s1", PanePID: 100}}
+	procs := []proc.Process{makeProc(100, 1, "zsh", "")}
+	patterns := []procmatch.Pattern{{Match: "node*", Label: "n"}}
+	got := procmatch.Match(panes, procs, patterns)
+	if _, ok := got["s1"]; ok {
+		t.Fatalf("expected no entry for s1, got %+v", got)
+	}
+}
+
+func TestMatch_EmptyInputs(t *testing.T) {
+	if got := procmatch.Match(nil, nil, nil); len(got) != 0 {
+		t.Fatalf("expected empty map, got %+v", got)
 	}
 }

--- a/internal/tui/model_proc_labels_test.go
+++ b/internal/tui/model_proc_labels_test.go
@@ -8,6 +8,20 @@ import (
 	"github.com/rtalexk/demux/internal/tmux"
 )
 
+func TestModel_CompactSchedulesProcFetchWhenPatternsConfigured(t *testing.T) {
+	cfg := config.Default()
+	cfg.Mode = "compact"
+	cfg.Sidebar.Processes = []config.ProcessLabel{{Match: "node*", Label: "n"}}
+	m := New(cfg, nil)
+	msg := panesMsg{
+		panes: []tmux.Pane{{Session: "s1", PanePID: 100, PaneIndex: 0}},
+	}
+	_, cmd := m.handlePanesMsg(msg)
+	if cmd == nil {
+		t.Fatalf("expected commands batch including a proc fetch")
+	}
+}
+
 func TestModel_HandleProcDataMsg_PopulatesProcLabels(t *testing.T) {
 	cfg := config.Default()
 	cfg.Sidebar.Processes = []config.ProcessLabel{

--- a/internal/tui/model_proc_labels_test.go
+++ b/internal/tui/model_proc_labels_test.go
@@ -1,0 +1,28 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+)
+
+func TestModel_HandleProcDataMsg_PopulatesProcLabels(t *testing.T) {
+	cfg := config.Default()
+	cfg.Sidebar.Processes = []config.ProcessLabel{
+		{Match: "claude*", Label: "🤖"},
+	}
+	m := New(cfg, nil)
+	m.panes = []tmux.Pane{{Session: "s1", PanePID: 100}}
+	m.procGen = 1
+	msg := procDataMsg{
+		gen:    1,
+		procs:  []proc.Process{{PID: 100, PPID: 1, Name: "claude"}},
+		cwdMap: map[int32]string{},
+	}
+	updated, _ := m.handleProcDataMsg(msg)
+	if got := updated.sidebar.procLabels["s1"].Text; got != "🤖" {
+		t.Fatalf("expected 🤖, got %q", got)
+	}
+}

--- a/internal/tui/model_proc_labels_test.go
+++ b/internal/tui/model_proc_labels_test.go
@@ -11,7 +11,7 @@ import (
 func TestModel_CompactSchedulesProcFetchWhenPatternsConfigured(t *testing.T) {
 	cfg := config.Default()
 	cfg.Mode = "compact"
-	cfg.Sidebar.Processes = []config.ProcessLabel{{Match: "node*", Label: "n"}}
+	cfg.Sidebar.Processes = []config.ProcessLabel{{Match: config.StringList{"node*"}, Label: "n"}}
 	m := New(cfg, nil)
 	msg := panesMsg{
 		panes: []tmux.Pane{{Session: "s1", PanePID: 100, PaneIndex: 0}},
@@ -25,7 +25,7 @@ func TestModel_CompactSchedulesProcFetchWhenPatternsConfigured(t *testing.T) {
 func TestModel_HandleProcDataMsg_PopulatesProcLabels(t *testing.T) {
 	cfg := config.Default()
 	cfg.Sidebar.Processes = []config.ProcessLabel{
-		{Match: "claude*", Label: "🤖"},
+		{Match: config.StringList{"claude*"}, Label: "🤖"},
 	}
 	m := New(cfg, nil)
 	m.panes = []tmux.Pane{{Session: "s1", PanePID: 100}}

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -211,6 +211,20 @@ func (m Model) handleQueryResultMsg(msg queryResultMsg) (Model, tea.Cmd) {
 	return m, nil
 }
 
+// shouldKickInitialProcFetch reports whether the first proc snapshot must be
+// requested right after panes arrive. Two cases need it:
+//   - startup focus landed on a window node (proc list will render), OR
+//   - compact mode hides the proc list but sidebar.processes is configured,
+//     so the per-session labels still need a snapshot.
+func (m Model) shouldKickInitialProcFetch() bool {
+	if m.sidebar.Selected() != nil {
+		return true
+	}
+	return m.cfg.Mode == "compact" &&
+		len(m.cfg.Sidebar.Processes) > 0 &&
+		len(m.sidebar.nodes) > 0
+}
+
 func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 	m.panes = msg.panes
 	// Build display maps from fresh pane data.
@@ -247,13 +261,7 @@ func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 			}
 		}
 		cmds = append(cmds, tick(time.Duration(m.cfg.RefreshIntervalMs)*time.Millisecond), m.fetchStates(), m.fetchWatches(), m.fetchItemSessions())
-		// Kick off an initial proc fetch when:
-		//   - startup focus landed on a window node, OR
-		//   - compact mode is configured with sidebar.processes — the proc list
-		//     is hidden but the labels still need a snapshot.
-		hasNode := m.sidebar.Selected() != nil
-		needsProcsForLabels := m.cfg.Mode == "compact" && len(m.cfg.Sidebar.Processes) > 0 && len(m.sidebar.nodes) > 0
-		if hasNode || needsProcsForLabels {
+		if m.shouldKickInitialProcFetch() {
 			m.procGen++
 			cmds = append(cmds, m.scheduleProcFetch())
 		}
@@ -279,15 +287,7 @@ func (m Model) handleProcDataMsg(msg procDataMsg) (Model, tea.Cmd) {
 	}
 	m.procs = msg.procs
 	m.cwdMap = msg.cwdMap
-	if len(m.cfg.Sidebar.Processes) > 0 {
-		patterns := make([]procmatch.Pattern, 0, len(m.cfg.Sidebar.Processes))
-		for _, p := range m.cfg.Sidebar.Processes {
-			for _, glob := range p.Match {
-				patterns = append(patterns, procmatch.Pattern{
-					Match: glob, Label: p.Label, FG: p.FG, BG: p.BG,
-				})
-			}
-		}
+	if patterns := m.cfg.Sidebar.ProcessPatterns(); len(patterns) > 0 {
 		m.sidebar.SetProcLabels(procmatch.Match(m.panes, m.procs, patterns, m.cfg.IgnoredProcesses))
 	}
 	if node := m.sidebar.Selected(); node != nil {

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -247,8 +247,13 @@ func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 			}
 		}
 		cmds = append(cmds, tick(time.Duration(m.cfg.RefreshIntervalMs)*time.Millisecond), m.fetchStates(), m.fetchWatches(), m.fetchItemSessions())
-		// If startup focus landed on a window node, kick off an initial proc fetch.
-		if node := m.sidebar.Selected(); node != nil {
+		// Kick off an initial proc fetch when:
+		//   - startup focus landed on a window node, OR
+		//   - compact mode is configured with sidebar.processes — the proc list
+		//     is hidden but the labels still need a snapshot.
+		hasNode := m.sidebar.Selected() != nil
+		needsProcsForLabels := m.cfg.Mode == "compact" && len(m.cfg.Sidebar.Processes) > 0 && len(m.sidebar.nodes) > 0
+		if hasNode || needsProcsForLabels {
 			m.procGen++
 			cmds = append(cmds, m.scheduleProcFetch())
 		}

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -282,9 +282,11 @@ func (m Model) handleProcDataMsg(msg procDataMsg) (Model, tea.Cmd) {
 	if len(m.cfg.Sidebar.Processes) > 0 {
 		patterns := make([]procmatch.Pattern, 0, len(m.cfg.Sidebar.Processes))
 		for _, p := range m.cfg.Sidebar.Processes {
-			patterns = append(patterns, procmatch.Pattern{
-				Match: p.Match, Label: p.Label, FG: p.FG, BG: p.BG,
-			})
+			for _, glob := range p.Match {
+				patterns = append(patterns, procmatch.Pattern{
+					Match: glob, Label: p.Label, FG: p.FG, BG: p.BG,
+				})
+			}
 		}
 		m.sidebar.SetProcLabels(procmatch.Match(m.panes, m.procs, patterns, m.cfg.IgnoredProcesses))
 	}

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -286,7 +286,7 @@ func (m Model) handleProcDataMsg(msg procDataMsg) (Model, tea.Cmd) {
 				Match: p.Match, Label: p.Label, FG: p.FG, BG: p.BG,
 			})
 		}
-		m.sidebar.SetProcLabels(procmatch.Match(m.panes, m.procs, patterns))
+		m.sidebar.SetProcLabels(procmatch.Match(m.panes, m.procs, patterns, m.cfg.IgnoredProcesses))
 	}
 	if node := m.sidebar.Selected(); node != nil {
 		m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.cfg)

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rtalexk/demux/internal/git"
 	demuxlog "github.com/rtalexk/demux/internal/log"
 	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/procmatch"
 	"github.com/rtalexk/demux/internal/query"
 	"github.com/rtalexk/demux/internal/session"
 	"github.com/rtalexk/demux/internal/tmux"
@@ -273,6 +274,15 @@ func (m Model) handleProcDataMsg(msg procDataMsg) (Model, tea.Cmd) {
 	}
 	m.procs = msg.procs
 	m.cwdMap = msg.cwdMap
+	if len(m.cfg.Sidebar.Processes) > 0 {
+		patterns := make([]procmatch.Pattern, 0, len(m.cfg.Sidebar.Processes))
+		for _, p := range m.cfg.Sidebar.Processes {
+			patterns = append(patterns, procmatch.Pattern{
+				Match: p.Match, Label: p.Label, FG: p.FG, BG: p.BG,
+			})
+		}
+		m.sidebar.SetProcLabels(procmatch.Match(m.panes, m.procs, patterns))
+	}
 	if node := m.sidebar.Selected(); node != nil {
 		m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.cfg)
 	}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -637,6 +637,35 @@ func sessionIcon(sess session.Session) string {
 	return sessionIconStyle.Render(icon)
 }
 
+// procLabelIndicator renders the configured sidebar process label for a
+// session row. Returns "" when the session has no match. When the row is
+// selected and focused, the selection background overrides the per-entry bg.
+func (s SidebarModel) procLabelIndicator(node SidebarNode, selected, focused bool) string {
+	lbl, ok := s.procLabels[node.Session]
+	if !ok {
+		return ""
+	}
+	style := lipgloss.NewStyle()
+	fg := lipgloss.Color(lbl.FG)
+	if fg == "" {
+		fg = activeTheme.ColorProcLabelFG
+	}
+	if fg != "" {
+		style = style.Foreground(fg)
+	}
+	bg := lipgloss.Color(lbl.BG)
+	if bg == "" {
+		bg = activeTheme.ColorProcLabelBG
+	}
+	if selected && focused {
+		bg = activeTheme.ColorSelected
+	}
+	if bg != "" {
+		style = style.Background(bg)
+	}
+	return style.Render(lbl.Text)
+}
+
 // gitIndicator returns the rendered git status indicator for a sidebar row, or "".
 func (s SidebarModel) gitIndicator(node SidebarNode, selected, focused bool) string {
 	info, ok := s.gitInfo[node.Session]

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rtalexk/demux/internal/config"
 	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/procmatch"
 	"github.com/rtalexk/demux/internal/query"
 	"github.com/rtalexk/demux/internal/session"
 )
@@ -71,6 +72,7 @@ type SidebarModel struct {
 	watches           map[string]struct{}
 	itemSessions      map[string]struct{} // sessions with open (unchecked) TODOs
 	noteSessions      map[string]struct{} // sessions with at least one note
+	procLabels        map[string]procmatch.Label
 	marquee           Marquee
 	lastMarqueeCursor int
 }
@@ -117,6 +119,11 @@ func (s *SidebarModel) SetNoteSessions(sessions []string) {
 	for _, name := range sessions {
 		s.noteSessions[name] = struct{}{}
 	}
+}
+
+// SetProcLabels updates the per-session sidebar process labels. Pass nil to clear.
+func (s *SidebarModel) SetProcLabels(labels map[string]procmatch.Label) {
+	s.procLabels = labels
 }
 
 // SetFilter changes the active sidebar filter. Pressing the current filter's

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -665,6 +665,9 @@ func (s SidebarModel) procLabelIndicator(node SidebarNode, selected, focused boo
 	}
 	fg, bg := resolveProcLabelColors(lbl, selected, focused)
 	style := lipgloss.NewStyle()
+	// Empty fg/bg means "leave the attribute unset" so the terminal's default
+	// (or the row's underlying background) shows through. Don't apply zero
+	// values — lipgloss would force them to black.
 	if fg != "" {
 		style = style.Foreground(fg)
 	}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -637,28 +637,36 @@ func sessionIcon(sess session.Session) string {
 	return sessionIconStyle.Render(icon)
 }
 
+// resolveProcLabelColors picks the effective fg/bg for a sidebar proc label.
+// When selected and focused, both fg and bg are overridden to match the
+// selection row so the label stays readable against the selection bg.
+func resolveProcLabelColors(lbl procmatch.Label, selected, focused bool) (fg, bg lipgloss.Color) {
+	fg = lipgloss.Color(lbl.FG)
+	if fg == "" {
+		fg = activeTheme.ColorProcLabelFG
+	}
+	bg = lipgloss.Color(lbl.BG)
+	if bg == "" {
+		bg = activeTheme.ColorProcLabelBG
+	}
+	if selected && focused {
+		fg = activeTheme.ColorFgPrimary
+		bg = activeTheme.ColorSelected
+	}
+	return fg, bg
+}
+
 // procLabelIndicator renders the configured sidebar process label for a
-// session row. Returns "" when the session has no match. When the row is
-// selected and focused, the selection background overrides the per-entry bg.
+// session row. Returns "" when the session has no match.
 func (s SidebarModel) procLabelIndicator(node SidebarNode, selected, focused bool) string {
 	lbl, ok := s.procLabels[node.Session]
 	if !ok {
 		return ""
 	}
+	fg, bg := resolveProcLabelColors(lbl, selected, focused)
 	style := lipgloss.NewStyle()
-	fg := lipgloss.Color(lbl.FG)
-	if fg == "" {
-		fg = activeTheme.ColorProcLabelFG
-	}
 	if fg != "" {
 		style = style.Foreground(fg)
-	}
-	bg := lipgloss.Color(lbl.BG)
-	if bg == "" {
-		bg = activeTheme.ColorProcLabelBG
-	}
-	if selected && focused {
-		bg = activeTheme.ColorSelected
 	}
 	if bg != "" {
 		style = style.Background(bg)

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -760,9 +760,12 @@ func (s SidebarModel) itemIndicator(node SidebarNode, selected, focused bool) st
 }
 
 // sessionIndicators assembles the right-side indicator string for a sidebar row.
-// Order: [git] [state] [todo] [last-seen] [watch]
+// Order: [proc] [git] [state] [todo] [last-seen] [watch]
 func (s SidebarModel) sessionIndicators(node SidebarNode, selected, focused bool) string {
 	var indParts []string
+	if ind := s.procLabelIndicator(node, selected, focused); ind != "" {
+		indParts = append(indParts, ind)
+	}
 	if ind := s.gitIndicator(node, selected, focused); ind != "" {
 		indParts = append(indParts, ind)
 	}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1320,3 +1320,17 @@ func TestSidebar_SetProcLabels(t *testing.T) {
 		t.Fatalf("expected node, got %q", got)
 	}
 }
+
+func TestSidebar_ProcLabelIndicator(t *testing.T) {
+	var s SidebarModel
+	s.procLabels = map[string]procmatch.Label{
+		"sess-a": {Text: "node"},
+	}
+	got := s.procLabelIndicator(SidebarNode{Session: "sess-a"}, false, false)
+	if !strings.Contains(stripANSI(got), "node") {
+		t.Fatalf("expected rendered indicator to include 'node', got %q", got)
+	}
+	if blank := s.procLabelIndicator(SidebarNode{Session: "no-match"}, false, false); blank != "" {
+		t.Fatalf("expected empty for unmatched session, got %q", blank)
+	}
+}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1321,6 +1321,22 @@ func TestSidebar_SetProcLabels(t *testing.T) {
 	}
 }
 
+func TestSidebar_ProcLabelLeftmost(t *testing.T) {
+	var s SidebarModel
+	s.procLabels = map[string]procmatch.Label{
+		"sess-a": {Text: "node"},
+	}
+	s.gitInfo = map[string]git.Info{
+		"sess-a": {Ahead: 1},
+	}
+	got := stripANSI(s.sessionIndicators(SidebarNode{Session: "sess-a"}, false, false))
+	li := strings.Index(got, "node")
+	gi := strings.Index(got, gitAheadGlyph)
+	if li < 0 || gi < 0 || li > gi {
+		t.Fatalf("expected proc label before git indicator, got %q", got)
+	}
+}
+
 func TestSidebar_ProcLabelIndicator(t *testing.T) {
 	var s SidebarModel
 	s.procLabels = map[string]procmatch.Label{

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1350,3 +1350,37 @@ func TestSidebar_ProcLabelIndicator(t *testing.T) {
 		t.Fatalf("expected empty for unmatched session, got %q", blank)
 	}
 }
+
+func TestSidebar_ResolveProcLabelColors_FocusedOverridesPerEntry(t *testing.T) {
+	initStyles(Theme{
+		ColorFgPrimary: lipgloss.Color("#cdd6f4"),
+		ColorSelected:  lipgloss.Color("#2a2a4a"),
+	}, config.ProcessesConfig{}, nil)
+	lbl := procmatch.Label{Text: "node", FG: "#1e1e2e", BG: "#89dceb"}
+
+	fg, bg := resolveProcLabelColors(lbl, false, false)
+	if fg != lipgloss.Color("#1e1e2e") || bg != lipgloss.Color("#89dceb") {
+		t.Fatalf("unfocused should use entry colors, got fg=%v bg=%v", fg, bg)
+	}
+	fg, bg = resolveProcLabelColors(lbl, true, false)
+	if fg != lipgloss.Color("#1e1e2e") || bg != lipgloss.Color("#89dceb") {
+		t.Fatalf("selected-only should keep entry colors, got fg=%v bg=%v", fg, bg)
+	}
+	fg, bg = resolveProcLabelColors(lbl, true, true)
+	if fg != lipgloss.Color("#cdd6f4") || bg != lipgloss.Color("#2a2a4a") {
+		t.Fatalf("selected+focused should override to theme colors, got fg=%v bg=%v", fg, bg)
+	}
+}
+
+func TestSidebar_ResolveProcLabelColors_FallsBackToThemeDefaults(t *testing.T) {
+	initStyles(Theme{
+		ColorProcLabelFG: lipgloss.Color("#aaa"),
+		ColorProcLabelBG: lipgloss.Color("#222"),
+	}, config.ProcessesConfig{}, nil)
+	lbl := procmatch.Label{Text: "x"}
+
+	fg, bg := resolveProcLabelColors(lbl, false, false)
+	if fg != lipgloss.Color("#aaa") || bg != lipgloss.Color("#222") {
+		t.Fatalf("expected theme fallback, got fg=%v bg=%v", fg, bg)
+	}
+}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rtalexk/demux/internal/config"
 	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/git"
+	"github.com/rtalexk/demux/internal/procmatch"
 	"github.com/rtalexk/demux/internal/query"
 	"github.com/rtalexk/demux/internal/session"
 )
@@ -1307,5 +1308,15 @@ func TestRenderSession_ActiveSessionSelectedFocused(t *testing.T) {
 	plain := stripANSI(row)
 	if !strings.Contains(plain, "►") {
 		t.Errorf("expected ► indicator for selected+focused active session, got: %q", plain)
+	}
+}
+
+func TestSidebar_SetProcLabels(t *testing.T) {
+	var s SidebarModel
+	s.SetProcLabels(map[string]procmatch.Label{
+		"sess-a": {Text: "node", FG: "#abc", BG: ""},
+	})
+	if got := s.procLabels["sess-a"].Text; got != "node" {
+		t.Fatalf("expected node, got %q", got)
 	}
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -28,6 +28,9 @@ type Theme struct {
 	ColorProcEditor lipgloss.Color
 	ColorProcChild  lipgloss.Color
 
+	ColorProcLabelFG lipgloss.Color
+	ColorProcLabelBG lipgloss.Color
+
 	// Git status
 	ColorGitDirty  lipgloss.Color
 	ColorGitBehind lipgloss.Color
@@ -96,6 +99,9 @@ func ThemeFromConfig(tc config.ThemeConfig) Theme {
 		ColorProcServer: lipgloss.Color(tc.ColorProcServer),
 		ColorProcEditor: lipgloss.Color(tc.ColorProcEditor),
 		ColorProcChild:  lipgloss.Color(tc.ColorProcChild),
+
+		ColorProcLabelFG: lipgloss.Color(tc.ColorProcLabelFG),
+		ColorProcLabelBG: lipgloss.Color(tc.ColorProcLabelBG),
 
 		ColorGitDirty:  lipgloss.Color(tc.ColorGitDirty),
 		ColorGitBehind: lipgloss.Color(tc.ColorGitBehind),


### PR DESCRIPTION
## Context

A sidebar row currently exposes only the session name plus state/git/todo/last-seen/watch indicators. There is no way to see at a glance which kind of long-running process a session actually has open — e.g. which sessions hold a Claude agent, a dev server, or a Python virtualenv. The user has to switch into each session and look at the process list to find out.

This PR adds a configurable per-session process label so that information is visible directly on the sidebar row.

Scope is **sidebar render + configuration**. The underlying proc-fetch pipeline is unchanged; the new feature only consumes existing proc data, plus one targeted opt-in fetch in compact mode.

## What does this PR do

Adds a new `[[sidebar.processes]]` config array that maps glob patterns to a small text label rendered as the leftmost indicator on each sidebar session row.

- New `procmatch` package: pure pattern matcher. `Match()` takes pane trees + `[]Pattern` + ignored-process list and returns `map[session]Label`. Glob (Go `filepath.Match`, case-insensitive) matches the process **name** OR any whitespace-separated cmdline token (including the token basename).
- Match traversal: inspect pane root first; if it matches, child procs are skipped. Otherwise inspect direct children only. Deeper descendants are never inspected. Ignored shells (e.g. `zsh`, `bash`) are transparently flattened — `zsh → make → node` matches `node` at effective level 1.
- Per-session aggregation: across a session's panes, the label with the highest occurrence count wins; on tie, the entry declared first in config wins.
- Config: `match` accepts a scalar (`match = "claude*"`) or array (`match = ["python*", "uvicorn"]`) so entries that share `label`/`fg`/`bg` don't have to be duplicated. Invalid globs are filtered per-entry on load; the entry is dropped only if all of its globs are invalid.
- Theme: new keys `color_proc_label_fg` (default `#cdd6f4`) and `color_proc_label_bg` (default empty = transparent). Per-entry `fg`/`bg` overrides win when set. When the sidebar row is focused-and-selected, both fg and bg are overridden to the selection-row theme colors so the label stays readable against the selection background.
- Indicator order on a sidebar row becomes `[proc] [git] [state] [todo] [last-seen] [watch]`.
- Compact-mode behavior: the proc snapshot is fetched only when at least one `[[sidebar.processes]]` entry is configured. Compact mode without `[[sidebar.processes]]` stays zero-cost (no behavior change for existing users).
- Docs: README section `Sidebar process labels` and a corresponding block in the `demux config init` template.

<img width="1421" height="846" alt="image" src="https://github.com/user-attachments/assets/fe4e158e-a724-42e9-824d-90f3a08c6ac5" />

### Out of scope

- The label is single-text per pattern (no icon-plus-text composite, no dynamic content from cmdline captures). Worth a follow-up if users ask, but YAGNI for now.
- `[[sidebar.processes]]` is the only new opt-in fetch path. We did not revisit the full proc-fetch scheduling outside compact mode — `internal/tui/model_update.go` `handleProcDataMsg` reuses the existing tick path unchanged.

## Manual QA

> TUI feature. Verify by running `demux` against a tmux server with a few sessions and observing the sidebar render. Both `demux.toml` config and theme defaults need to be exercised.

### Prerequisites

<details>

<summary>1. demux config file exists at the expected path.</summary>

```bash
ls -l ~/.config/demux/demux.toml
```

If missing, generate the default template:

```bash
demux config init
```

</details>

<details>

<summary>2. A tmux server is running with at least two sessions whose pane roots run different processes.</summary>

```bash
tmux list-sessions
tmux list-panes -a -F '#{session_name} #{pane_pid} #{pane_current_command}'
```

Expect at least two rows. If empty, create test sessions:

```bash
tmux new-session -d -s py-test 'python3 -c "import time; time.sleep(9999)"'
tmux new-session -d -s node-test 'node -e "setInterval(()=>{}, 1e9)"'
```

</details>

<details>

<summary>3. Build is current.</summary>

```bash
go build ./... && go test ./...
```

Expect zero failures (572 tests passed locally).

</details>

### Setup

Capture baseline sidebar render *before* configuring proc labels:

```bash
demux
```

Open `demux`, note the sidebar rows — there should be no proc-label indicator anywhere (existing behavior). Quit with `q`.

Then add to `~/.config/demux/demux.toml` under `[sidebar]`:

```toml
[[sidebar.processes]]
match = "claude*"
label = "🤖"

[[sidebar.processes]]
match = "node*"
label = "node"

[[sidebar.processes]]
match = ["python*", "uvicorn", "uv"]
label = "py"
fg = "#fee685"
bg = "#3b3000"
```

<details>

<summary>Scenario 1 — Labels render as the leftmost indicator</summary>

1. Start `demux`.
2. Expect each session with a matching process to show its label as the **leftmost** indicator on the sidebar row, before any git / state / todo / last-seen / watch indicators.
3. Sessions with no matching process show **no** proc-label indicator (no blank gap).
4. The `py` label is styled with the configured yellow fg `#fee685` on dark bg `#3b3000`; the `node` and `🤖` labels use the theme default fg `#cdd6f4` with transparent bg.

</details>

<details>

<summary>Scenario 2 — Focused-selected row keeps the label readable</summary>

1. In `demux`, focus the sidebar (default focus on open) and move the cursor onto a row with a proc label.
2. Expected: when that row is both selected **and** focused, the proc label's fg/bg are overridden to the selection row theme colors (`color_fg_primary` on `color_selected`), so the label is not washed out against the selection background.
3. Move the cursor away. Expected: the label reverts to its configured (or theme-default) colors.

</details>

<details>

<summary>Scenario 3 — Scalar vs array `match` are equivalent</summary>

1. Replace the `python*` array entry with a scalar entry, e.g.:
   ```toml
   [[sidebar.processes]]
   match = "python*"
   label = "py"
   ```
2. Restart `demux`. Expected: sessions running `python*` still show the `py` label. Sessions running `uvicorn` no longer match (expected — we narrowed the rule).
3. Revert to the array form. Expected: `uvicorn` and `uv` sessions match again under the same `py` label.

</details>

<details>

<summary>Scenario 4 — Invalid globs are filtered, valid siblings survive</summary>

1. Add a deliberately invalid glob alongside a valid one:
   ```toml
   [[sidebar.processes]]
   match = ["python*", "[invalid"]
   label = "py"
   ```
2. Start `demux` from a terminal that shows stderr (not inside the TUI itself — run with `2>/tmp/demux.log` or check the parent terminal).
3. Expected stderr line:
   ```
   demux: ignoring sidebar.processes glob "[invalid": syntax error in pattern
   ```
4. Expected sidebar behavior: `python*` matches still produce the `py` label. The entry is not dropped.
5. Replace **all** globs in an entry with invalid ones:
   ```toml
   [[sidebar.processes]]
   match = ["[invalid"]
   label = "py"
   ```
   Expected stderr:
   ```
   demux: ignoring sidebar.processes entry with no valid globs: ...
   ```
   And no `py` label renders anywhere.

</details>

<details>

<summary>Scenario 5 — Shell wrappers are transparently skipped</summary>

1. Create a session whose pane root is a shell wrapping a target process, e.g.:
   ```bash
   tmux new-session -d -s wrapped 'zsh -c "node -e \"setInterval(()=>{}, 1e9)\""'
   ```
2. Start `demux`. Expected: the `wrapped` session shows the `node` proc label, even though the literal pane root is `zsh` (an ignored shell) and `node` is at effective level 1 after the shell flattening.
3. Kill the session: `tmux kill-session -t wrapped`.

</details>

<details>

<summary>Scenario 6 — Compact mode is zero-cost when no `[[sidebar.processes]]` is configured</summary>

1. Comment out **all** `[[sidebar.processes]]` blocks in `~/.config/demux/demux.toml`.
2. Start `demux` in compact mode (the layout where the proc snapshot is normally not fetched).
3. Expected: no proc label renders. No extra proc fetch is scheduled — behavior is identical to `main`.
4. Re-add a single `[[sidebar.processes]]` entry. Restart `demux` in compact mode. Expected: the proc fetch is now scheduled, and matching sessions render their label.

</details>