### PR TITLE
feat(tui): add two-row card view to sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ focus_search_on_open = false        # start with cursor in the search input
 default_filter = "t"                # t | a | c | w | !
 sort = ["priority", "last_seen", "alphabetical"]
 switch_focus = "default"            # default | newest | oldest
+session_view = "row"                # row | card  (card = two-row layout with separator between sessions)
 
 [process_list]
 path_right_align = false            # right-align pane CWD paths

--- a/README.md
+++ b/README.md
@@ -443,7 +443,10 @@ focus_search_on_open = false        # start with cursor in the search input
 default_filter = "t"                # t | a | c | w | !
 sort = ["priority", "last_seen", "alphabetical"]
 switch_focus = "default"            # default | newest | oldest
-session_view = "row"                # row | card  (card = two-row layout with separator between sessions)
+session_view = "row"                # row | card  (default for both modes; card = two-row layout)
+session_view_mode_compact = ""      # row | card  (override session_view in compact mode; "" = inherit)
+session_view_mode_full = ""         # row | card  (override session_view in full mode; "" = inherit)
+card_separator = true               # show a blank row between cards (card view only)
 
 [process_list]
 path_right_align = false            # right-align pane CWD paths

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ switch_focus = "default"            # default | newest | oldest
 session_view = "row"                # row | card  (default for both modes; card = two-row layout)
 session_view_mode_compact = ""      # row | card  (override session_view in compact mode; "" = inherit)
 session_view_mode_full = ""         # row | card  (override session_view in full mode; "" = inherit)
-card_separator = true               # show a blank row between cards (card view only)
+card_separator = "blank"            # none | blank | rule  (separator row between cards in card view)
 
 [process_list]
 path_right_align = false            # right-align pane CWD paths

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -88,9 +88,11 @@ session_view = "row"
 session_view_mode_compact = ""
 session_view_mode_full = ""
 
-# Show a blank row between cards (card view only). Set to false for a denser
-# layout with no separator.
-card_separator = true
+# Separator row between cards (card view only):
+#   none   — no row, denser layout
+#   blank  — empty row (default)
+#   rule   — horizontal rule ('─') in the border color
+card_separator = "blank"
 
 # Sidebar process labels — render a single highest-count label per session.
 # Globs match either the process name or any whitespace-separated token of the

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -81,6 +81,9 @@ sort = ["priority", "last_seen", "alphabetical"]
 #   oldest   — navigate to oldest updated state window
 switch_focus = "default"
 
+# Session view: row (single row, default) | card (two-row with separator)
+session_view = "row"
+
 # Sidebar process labels — render a single highest-count label per session.
 # Globs match either the process name or any whitespace-separated token of the
 # full cmdline (case-insensitive). Only the pane root and its direct children

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -81,8 +81,16 @@ sort = ["priority", "last_seen", "alphabetical"]
 #   oldest   — navigate to oldest updated state window
 switch_focus = "default"
 
-# Session view: row (single row, default) | card (two-row with separator)
+# Session view: row (single row, default) | card (two-row layout).
+# session_view is the fallback for both modes; the *_mode_* overrides win
+# when set. Use "" (or omit) to inherit from session_view.
 session_view = "row"
+session_view_mode_compact = ""
+session_view_mode_full = ""
+
+# Show a blank row between cards (card view only). Set to false for a denser
+# layout with no separator.
+card_separator = true
 
 # Sidebar process labels — render a single highest-count label per session.
 # Globs match either the process name or any whitespace-separated token of the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -189,18 +189,56 @@ func (s SidebarConfig) ProcessPatterns() []procmatch.Pattern {
 	return out
 }
 
+// ResolvedSessionView returns the effective session view for the given top-level
+// mode. Mode-specific overrides win, then SessionView, then the row default.
+// Caller is expected to pass Config.Mode (e.g. "full" or "compact").
+func (s SidebarConfig) ResolvedSessionView(mode string) string {
+	switch mode {
+	case "compact":
+		if s.SessionViewModeCompact != "" {
+			return s.SessionViewModeCompact
+		}
+	case "full":
+		if s.SessionViewModeFull != "" {
+			return s.SessionViewModeFull
+		}
+	}
+	if s.SessionView != "" {
+		return s.SessionView
+	}
+	return SidebarViewRow
+}
+
+// normalizeSessionView validates a session_view-style value. Empty input
+// returns emptyDefault unchanged; an invalid non-empty value warns to stderr
+// and returns emptyDefault.
+func normalizeSessionView(value, key, emptyDefault string) string {
+	switch value {
+	case "":
+		return emptyDefault
+	case SidebarViewRow, SidebarViewCard:
+		return value
+	default:
+		fmt.Fprintf(os.Stderr, "demux: ignoring %s %q: must be \"row\" or \"card\"\n", key, value)
+		return emptyDefault
+	}
+}
+
 type SidebarConfig struct {
-	DefaultFilter     string         `toml:"default_filter"`
-	FocusOnOpen       string         `toml:"focus_on_open"`
-	FocusSearchOnOpen bool           `toml:"focus_search_on_open"`
-	SearchSort        string         `toml:"search_sort"`
-	ShowLastSeen      bool           `toml:"show_last_seen"`
-	ActiveSessionIcon string         `toml:"active_session_icon"`
-	Sort              []string       `toml:"sort"`
-	SwitchFocus       string         `toml:"switch_focus"`
-	Width             int            `toml:"width"`
-	SessionView       string         `toml:"session_view"`
-	Processes         []ProcessLabel `toml:"processes"`
+	DefaultFilter          string         `toml:"default_filter"`
+	FocusOnOpen            string         `toml:"focus_on_open"`
+	FocusSearchOnOpen      bool           `toml:"focus_search_on_open"`
+	SearchSort             string         `toml:"search_sort"`
+	ShowLastSeen           bool           `toml:"show_last_seen"`
+	ActiveSessionIcon      string         `toml:"active_session_icon"`
+	Sort                   []string       `toml:"sort"`
+	SwitchFocus            string         `toml:"switch_focus"`
+	Width                  int            `toml:"width"`
+	SessionView            string         `toml:"session_view"`
+	SessionViewModeCompact string         `toml:"session_view_mode_compact"`
+	SessionViewModeFull    string         `toml:"session_view_mode_full"`
+	CardSeparator          bool           `toml:"card_separator"`
+	Processes              []ProcessLabel `toml:"processes"`
 }
 
 type ProcessListConfig struct {
@@ -254,6 +292,7 @@ func Default() Config {
 			ShowLastSeen:      true,
 			ActiveSessionIcon: DefaultActiveSessionIcon,
 			SessionView:       SidebarViewRow,
+			CardSeparator:     true,
 		},
 		StatusBar: StatusBarConfig{Show: true},
 		Log:       LogConfig{Level: "warn"},
@@ -377,15 +416,9 @@ func Load(path string) (Config, error) {
 	})
 	cfg.Sidebar.Sort = normalizeSortKeys(cfg.Sidebar.Sort)
 
-	switch cfg.Sidebar.SessionView {
-	case SidebarViewRow, SidebarViewCard:
-		// valid
-	default:
-		if cfg.Sidebar.SessionView != "" {
-			fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.session_view %q: must be \"row\" or \"card\"\n", cfg.Sidebar.SessionView)
-		}
-		cfg.Sidebar.SessionView = SidebarViewRow
-	}
+	cfg.Sidebar.SessionView = normalizeSessionView(cfg.Sidebar.SessionView, "sidebar.session_view", SidebarViewRow)
+	cfg.Sidebar.SessionViewModeCompact = normalizeSessionView(cfg.Sidebar.SessionViewModeCompact, "sidebar.session_view_mode_compact", "")
+	cfg.Sidebar.SessionViewModeFull = normalizeSessionView(cfg.Sidebar.SessionViewModeFull, "sidebar.session_view_mode_full", "")
 
 	filteredProcs := cfg.Sidebar.Processes[:0]
 	for _, p := range cfg.Sidebar.Processes {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,6 +209,21 @@ func (s SidebarConfig) ResolvedSessionView(mode string) string {
 	return SidebarViewRow
 }
 
+// normalizeCardSeparator validates sidebar.card_separator. Empty defaults to
+// "blank" (preserving the previous behavior). An invalid value warns and
+// also defaults to "blank".
+func normalizeCardSeparator(value string) string {
+	switch value {
+	case "":
+		return CardSeparatorBlank
+	case CardSeparatorNone, CardSeparatorBlank, CardSeparatorRule:
+		return value
+	default:
+		fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.card_separator %q: must be \"none\", \"blank\", or \"rule\"\n", value)
+		return CardSeparatorBlank
+	}
+}
+
 // normalizeSessionView validates a session_view-style value. Empty input
 // returns emptyDefault unchanged; an invalid non-empty value warns to stderr
 // and returns emptyDefault.
@@ -237,7 +252,7 @@ type SidebarConfig struct {
 	SessionView            string         `toml:"session_view"`
 	SessionViewModeCompact string         `toml:"session_view_mode_compact"`
 	SessionViewModeFull    string         `toml:"session_view_mode_full"`
-	CardSeparator          bool           `toml:"card_separator"`
+	CardSeparator          string         `toml:"card_separator"`
 	Processes              []ProcessLabel `toml:"processes"`
 }
 
@@ -292,7 +307,7 @@ func Default() Config {
 			ShowLastSeen:      true,
 			ActiveSessionIcon: DefaultActiveSessionIcon,
 			SessionView:       SidebarViewRow,
-			CardSeparator:     true,
+			CardSeparator:     CardSeparatorBlank,
 		},
 		StatusBar: StatusBarConfig{Show: true},
 		Log:       LogConfig{Level: "warn"},
@@ -419,6 +434,7 @@ func Load(path string) (Config, error) {
 	cfg.Sidebar.SessionView = normalizeSessionView(cfg.Sidebar.SessionView, "sidebar.session_view", SidebarViewRow)
 	cfg.Sidebar.SessionViewModeCompact = normalizeSessionView(cfg.Sidebar.SessionViewModeCompact, "sidebar.session_view_mode_compact", "")
 	cfg.Sidebar.SessionViewModeFull = normalizeSessionView(cfg.Sidebar.SessionViewModeFull, "sidebar.session_view_mode_full", "")
+	cfg.Sidebar.CardSeparator = normalizeCardSeparator(cfg.Sidebar.CardSeparator)
 
 	filteredProcs := cfg.Sidebar.Processes[:0]
 	for _, p := range cfg.Sidebar.Processes {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,7 +253,7 @@ func Default() Config {
 			Width:             DefaultSidebarWidth,
 			ShowLastSeen:      true,
 			ActiveSessionIcon: DefaultActiveSessionIcon,
-			SessionView:       "row",
+			SessionView:       SidebarViewRow,
 		},
 		StatusBar: StatusBarConfig{Show: true},
 		Log:       LogConfig{Level: "warn"},
@@ -378,13 +378,13 @@ func Load(path string) (Config, error) {
 	cfg.Sidebar.Sort = normalizeSortKeys(cfg.Sidebar.Sort)
 
 	switch cfg.Sidebar.SessionView {
-	case "row", "card":
+	case SidebarViewRow, SidebarViewCard:
 		// valid
 	default:
 		if cfg.Sidebar.SessionView != "" {
 			fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.session_view %q: must be \"row\" or \"card\"\n", cfg.Sidebar.SessionView)
 		}
-		cfg.Sidebar.SessionView = "row"
+		cfg.Sidebar.SessionView = SidebarViewRow
 	}
 
 	filteredProcs := cfg.Sidebar.Processes[:0]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,6 +199,7 @@ type SidebarConfig struct {
 	Sort              []string       `toml:"sort"`
 	SwitchFocus       string         `toml:"switch_focus"`
 	Width             int            `toml:"width"`
+	SessionView       string         `toml:"session_view"`
 	Processes         []ProcessLabel `toml:"processes"`
 }
 
@@ -252,6 +253,7 @@ func Default() Config {
 			Width:             DefaultSidebarWidth,
 			ShowLastSeen:      true,
 			ActiveSessionIcon: DefaultActiveSessionIcon,
+			SessionView:       "row",
 		},
 		StatusBar: StatusBarConfig{Show: true},
 		Log:       LogConfig{Level: "warn"},
@@ -374,6 +376,16 @@ func Load(path string) (Config, error) {
 		return len(cfg.PathAliases[i].Prefix) > len(cfg.PathAliases[j].Prefix)
 	})
 	cfg.Sidebar.Sort = normalizeSortKeys(cfg.Sidebar.Sort)
+
+	switch cfg.Sidebar.SessionView {
+	case "row", "card":
+		// valid
+	default:
+		if cfg.Sidebar.SessionView != "" {
+			fmt.Fprintf(os.Stderr, "demux: ignoring sidebar.session_view %q: must be \"row\" or \"card\"\n", cfg.Sidebar.SessionView)
+		}
+		cfg.Sidebar.SessionView = "row"
+	}
 
 	filteredProcs := cfg.Sidebar.Processes[:0]
 	for _, p := range cfg.Sidebar.Processes {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -684,3 +684,57 @@ color_proc_label_bg = "#222222"
 		t.Fatalf("bg mismatch: %q", cfg.Theme.ColorProcLabelBG)
 	}
 }
+
+func TestDefault_SidebarSessionView(t *testing.T) {
+	c := config.Default()
+	if c.Sidebar.SessionView != "row" {
+		t.Errorf("expected SessionView=\"row\", got %q", c.Sidebar.SessionView)
+	}
+}
+
+func TestLoadFromFile_SessionView_Card(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := "[sidebar]\nsession_view = \"card\"\n"
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Sidebar.SessionView != "card" {
+		t.Errorf("expected \"card\", got %q", c.Sidebar.SessionView)
+	}
+}
+
+func TestLoadFromFile_SessionView_InvalidFallsBackToRow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := "[sidebar]\nsession_view = \"banana\"\n"
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Sidebar.SessionView != "row" {
+		t.Errorf("expected fallback \"row\", got %q", c.Sidebar.SessionView)
+	}
+}
+
+func TestLoadFromFile_SessionView_MissingDefaultsRow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	if err := os.WriteFile(path, []byte("[sidebar]\nwidth = 40\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Sidebar.SessionView != "row" {
+		t.Errorf("expected default \"row\", got %q", c.Sidebar.SessionView)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -685,7 +686,7 @@ color_proc_label_bg = "#222222"
 	}
 }
 
-func TestDefault_SidebarSessionView(t *testing.T) {
+func TestDefaults_SidebarSessionView(t *testing.T) {
 	c := config.Default()
 	if c.Sidebar.SessionView != "row" {
 		t.Errorf("expected SessionView=\"row\", got %q", c.Sidebar.SessionView)
@@ -693,12 +694,7 @@ func TestDefault_SidebarSessionView(t *testing.T) {
 }
 
 func TestLoadFromFile_SessionView_Card(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "demux.toml")
-	body := "[sidebar]\nsession_view = \"card\"\n"
-	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
-		t.Fatal(err)
-	}
+	path := writeTempConfig(t, "[sidebar]\nsession_view = \"card\"\n")
 	c, err := config.Load(path)
 	if err != nil {
 		t.Fatal(err)
@@ -709,12 +705,7 @@ func TestLoadFromFile_SessionView_Card(t *testing.T) {
 }
 
 func TestLoadFromFile_SessionView_InvalidFallsBackToRow(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "demux.toml")
-	body := "[sidebar]\nsession_view = \"banana\"\n"
-	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
-		t.Fatal(err)
-	}
+	path := writeTempConfig(t, "[sidebar]\nsession_view = \"banana\"\n")
 	c, err := config.Load(path)
 	if err != nil {
 		t.Fatal(err)
@@ -725,16 +716,35 @@ func TestLoadFromFile_SessionView_InvalidFallsBackToRow(t *testing.T) {
 }
 
 func TestLoadFromFile_SessionView_MissingDefaultsRow(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "demux.toml")
-	if err := os.WriteFile(path, []byte("[sidebar]\nwidth = 40\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	path := writeTempConfig(t, "[sidebar]\nwidth = 40\n")
 	c, err := config.Load(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if c.Sidebar.SessionView != "row" {
 		t.Errorf("expected default \"row\", got %q", c.Sidebar.SessionView)
+	}
+}
+
+func TestLoadFromFile_SessionView_InvalidWarnsOnStderr(t *testing.T) {
+	path := writeTempConfig(t, "[sidebar]\nsession_view = \"banana\"\n")
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	if _, err := config.Load(path); err != nil {
+		os.Stderr = origStderr
+		t.Fatal(err)
+	}
+	w.Close()
+	os.Stderr = origStderr
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(buf), `ignoring sidebar.session_view "banana"`) {
+		t.Errorf("expected stderr warning, got %q", string(buf))
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -751,19 +751,51 @@ func TestLoadFromFile_SessionView_InvalidWarnsOnStderr(t *testing.T) {
 
 func TestDefaults_CardSeparator(t *testing.T) {
 	c := config.Default()
-	if !c.Sidebar.CardSeparator {
-		t.Errorf("expected CardSeparator default true, got false")
+	if c.Sidebar.CardSeparator != config.CardSeparatorBlank {
+		t.Errorf("expected CardSeparator default %q, got %q", config.CardSeparatorBlank, c.Sidebar.CardSeparator)
 	}
 }
 
-func TestLoadFromFile_CardSeparator_False(t *testing.T) {
-	path := writeTempConfig(t, "[sidebar]\ncard_separator = false\n")
+func TestLoadFromFile_CardSeparator_Values(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"none", config.CardSeparatorNone},
+		{"blank", config.CardSeparatorBlank},
+		{"rule", config.CardSeparatorRule},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			path := writeTempConfig(t, "[sidebar]\ncard_separator = \""+tc.input+"\"\n")
+			c, err := config.Load(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c.Sidebar.CardSeparator != tc.expected {
+				t.Errorf("got %q, want %q", c.Sidebar.CardSeparator, tc.expected)
+			}
+		})
+	}
+}
+
+func TestLoadFromFile_CardSeparator_InvalidWarnsAndDefaults(t *testing.T) {
+	path := writeTempConfig(t, "[sidebar]\ncard_separator = \"banana\"\n")
+	origStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
 	c, err := config.Load(path)
+	w.Close()
+	os.Stderr = origStderr
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.Sidebar.CardSeparator {
-		t.Errorf("expected CardSeparator=false, got true")
+	buf, _ := io.ReadAll(r)
+	if !strings.Contains(string(buf), `ignoring sidebar.card_separator "banana"`) {
+		t.Errorf("expected stderr warning, got %q", string(buf))
+	}
+	if c.Sidebar.CardSeparator != config.CardSeparatorBlank {
+		t.Errorf("invalid value should fall back to %q, got %q", config.CardSeparatorBlank, c.Sidebar.CardSeparator)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -748,3 +748,91 @@ func TestLoadFromFile_SessionView_InvalidWarnsOnStderr(t *testing.T) {
 		t.Errorf("expected stderr warning, got %q", string(buf))
 	}
 }
+
+func TestDefaults_CardSeparator(t *testing.T) {
+	c := config.Default()
+	if !c.Sidebar.CardSeparator {
+		t.Errorf("expected CardSeparator default true, got false")
+	}
+}
+
+func TestLoadFromFile_CardSeparator_False(t *testing.T) {
+	path := writeTempConfig(t, "[sidebar]\ncard_separator = false\n")
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Sidebar.CardSeparator {
+		t.Errorf("expected CardSeparator=false, got true")
+	}
+}
+
+func TestLoadFromFile_SessionViewModeOverrides(t *testing.T) {
+	path := writeTempConfig(t, `[sidebar]
+session_view = "row"
+session_view_mode_compact = "card"
+session_view_mode_full = "row"
+`)
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Sidebar.SessionViewModeCompact != "card" {
+		t.Errorf("compact override: got %q, want \"card\"", c.Sidebar.SessionViewModeCompact)
+	}
+	if c.Sidebar.SessionViewModeFull != "row" {
+		t.Errorf("full override: got %q, want \"row\"", c.Sidebar.SessionViewModeFull)
+	}
+}
+
+func TestLoadFromFile_SessionViewModeInvalidWarnsAndClears(t *testing.T) {
+	path := writeTempConfig(t, "[sidebar]\nsession_view_mode_compact = \"banana\"\n")
+	origStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	c, err := config.Load(path)
+	w.Close()
+	os.Stderr = origStderr
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf, _ := io.ReadAll(r)
+	if !strings.Contains(string(buf), `ignoring sidebar.session_view_mode_compact "banana"`) {
+		t.Errorf("expected stderr warning, got %q", string(buf))
+	}
+	if c.Sidebar.SessionViewModeCompact != "" {
+		t.Errorf("invalid override should clear to \"\", got %q", c.Sidebar.SessionViewModeCompact)
+	}
+}
+
+func TestResolvedSessionView(t *testing.T) {
+	cases := []struct {
+		name     string
+		base     string
+		compact  string
+		full     string
+		mode     string
+		expected string
+	}{
+		{"default empty all", "", "", "", "full", "row"},
+		{"base only", "card", "", "", "full", "card"},
+		{"compact override beats base", "row", "card", "", "compact", "card"},
+		{"full override beats base", "card", "", "row", "full", "row"},
+		{"compact override ignored in full mode", "row", "card", "", "full", "row"},
+		{"full override ignored in compact mode", "card", "", "row", "compact", "card"},
+		{"unknown mode falls through to base", "card", "", "", "weird", "card"},
+		{"unknown mode falls through to default", "", "", "", "weird", "row"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := config.SidebarConfig{
+				SessionView:            tc.base,
+				SessionViewModeCompact: tc.compact,
+				SessionViewModeFull:    tc.full,
+			}
+			if got := sc.ResolvedSessionView(tc.mode); got != tc.expected {
+				t.Errorf("ResolvedSessionView(mode=%q): got %q, want %q", tc.mode, got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -4,16 +4,22 @@ import "time"
 
 // Exported defaults for use by other packages (e.g. TUI tick interval).
 const (
-	DefaultRefreshIntervalMs  = 3000
-	DefaultGitTimeoutMs       = 500
-	DefaultSidebarWidth       = 35
-	DefaultActiveSessionIcon  = "►"
+	DefaultRefreshIntervalMs = 3000
+	DefaultGitTimeoutMs      = 500
+	DefaultSidebarWidth      = 35
+	DefaultActiveSessionIcon = "►"
 
 	// SidebarViewRow and SidebarViewCard are the accepted values for
 	// SidebarConfig.SessionView.  TUI consumers should reference these
 	// constants rather than inline string literals.
 	SidebarViewRow  = "row"
 	SidebarViewCard = "card"
+
+	// CardSeparatorNone, CardSeparatorBlank, and CardSeparatorRule are the
+	// accepted values for SidebarConfig.CardSeparator.
+	CardSeparatorNone  = "none"
+	CardSeparatorBlank = "blank"
+	CardSeparatorRule  = "rule"
 
 	// MinRefreshIntervalMs is the minimum accepted value for RefreshIntervalMs.
 	MinRefreshIntervalMs = 100

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -9,6 +9,12 @@ const (
 	DefaultSidebarWidth       = 35
 	DefaultActiveSessionIcon  = "►"
 
+	// SidebarViewRow and SidebarViewCard are the accepted values for
+	// SidebarConfig.SessionView.  TUI consumers should reference these
+	// constants rather than inline string literals.
+	SidebarViewRow  = "row"
+	SidebarViewCard = "card"
+
 	// MinRefreshIntervalMs is the minimum accepted value for RefreshIntervalMs.
 	MinRefreshIntervalMs = 100
 	// MinSidebarWidth is the minimum accepted value for Sidebar.Width.

--- a/internal/tui/proclist_render.go
+++ b/internal/tui/proclist_render.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/format"
 	"github.com/rtalexk/demux/internal/proc"
@@ -583,6 +584,13 @@ func formatProcDuration(d time.Duration) string {
 	default:
 		return fmt.Sprintf("%ds", s)
 	}
+}
+
+// visualWidth returns the display-column width of s, ignoring ANSI escape
+// sequences. Use for layout math where the rendered width matters more than
+// the raw byte/rune count.
+func visualWidth(s string) int {
+	return runewidth.StringWidth(stripANSI(s))
 }
 
 func stripANSI(s string) string {

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -1111,10 +1111,7 @@ func (s SidebarModel) renderCardRow2(node SidebarNode, focused bool, innerW int)
 	}
 	rightW := runewidth.StringWidth(stripANSI(right))
 	used := 1 /*focus*/ + 1 /*sep*/ + leftIconW + 1 /*sep*/ + leftLabelW
-	trailW := 0
-	if focused {
-		trailW = 1
-	}
+	trailW := 1
 	gap := innerW - used - rightW - trailW
 	if gap < 1 {
 		gap = 1
@@ -1135,7 +1132,7 @@ func (s SidebarModel) renderCardRow2(node SidebarNode, focused bool, innerW int)
 	}
 
 	focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(focusGlyph)
-	return focusGl + " " + leftIcon + " " + leftLabel + strings.Repeat(" ", gap) + right
+	return focusGl + " " + leftIcon + " " + leftLabel + strings.Repeat(" ", gap) + right + " "
 }
 
 // formatAge returns a fixed-width 3-char age string for a session's last-seen

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -594,6 +594,19 @@ func (s SidebarModel) renderNode(node SidebarNode, selected, focused bool, width
 	return s.renderSession(node, selected, focused, width)
 }
 
+// nodeHeight returns the viewport rows consumed by a session in the current
+// view. Card mode reserves 2 content rows; a trailing separator row adds 1
+// for every card except the last visible one.
+func (s SidebarModel) nodeHeight(_ SidebarNode, isLast bool) int {
+	if s.cfg.Sidebar.SessionView == config.SidebarViewCard {
+		if isLast {
+			return 2
+		}
+		return 3
+	}
+	return 1
+}
+
 // alignedRow builds a single sidebar line with the name on the left and
 // indicators right-aligned to availWidth. Both name and indicators are
 // measured by display-column width (runewidth) after stripping ANSI codes,

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -901,6 +901,172 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 	return " " + gap + " " + iconPrefix + sessionStyle.Render(text)
 }
 
+// renderSessionCard renders a session as a two-row card.
+//
+//	Row 1: <focus(1)><active(1)> <session_icon> <session_name> <watch> <trail>
+//	Row 2: <focus(1)> <state_icon> <state_label> <gap> <proc> <git> <todo> <last_seen>
+//
+// Rows are joined with "\n". The blank separator row between cards is the
+// caller's responsibility (emitted by buildSidebarLines), so this renderer
+// stays usable in single-card contexts like the future sticky sidebar.
+//
+// focused == true means: the cursor is on this session AND the sidebar pane
+// has focus. The highlight background is applied to both content rows when
+// focused.
+func (s SidebarModel) renderSessionCard(node SidebarNode, focused bool, width int) string {
+	innerW := width - 2 // account for border overhead (matches single-row path)
+	if innerW < minRowWidth+4 {
+		innerW = minRowWidth + 4
+	}
+	row1 := s.renderCardRow1(node, focused, innerW)
+	row2 := s.renderCardRow2(node, focused, innerW)
+	return row1 + "\n" + row2
+}
+
+// renderCardRow1 builds row 1: focus + active + session icon + name + watch,
+// with the highlight background extended to the full innerW when focused.
+func (s SidebarModel) renderCardRow1(node SidebarNode, focused bool, innerW int) string {
+	// Active indicator slot (always 1 col so column alignment is stable).
+	activeIcon := s.cfg.Sidebar.ActiveSessionIcon
+	if activeIcon == "" {
+		activeIcon = config.DefaultActiveSessionIcon
+	}
+	active := " "
+	if node.Session == s.activeSession {
+		if focused {
+			active = lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(activeIcon)
+		} else {
+			active = lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(activeIcon)
+		}
+	} else if focused {
+		active = selectedBG.Render(active)
+	}
+
+	// Session icon.
+	iconPrefix := ""
+	if sess := s.FindSession(node.Session); sess != nil {
+		iconPrefix = sessionIcon(*sess) + " "
+	}
+	iconW := runewidth.StringWidth(stripANSI(iconPrefix))
+
+	// Watch slot (fixed width even when unwatched).
+	watch := s.watchIndicator(node, focused, focused)
+	watchW := runewidth.StringWidth(stripANSI(watch))
+
+	// Budget for name: total - focus(1) - active(1) - sep(1 between active & icon) - icon - sep(1) - watch - trail(1).
+	overhead := 1 /*focus*/ + 1 /*active*/ + 1 /*sep*/ + iconW + 1 /*sep*/ + watchW + 1 /*trail*/
+	maxName := innerW - overhead
+	if maxName < minRowWidth {
+		maxName = minRowWidth
+	}
+
+	var nameStr string
+	if focused && runewidth.StringWidth(node.Session) > maxName {
+		nameStr = s.marquee.View(node.Session, maxName)
+	} else {
+		nameStr = truncateSessionName(node.Session, maxName)
+	}
+
+	// Compute pad so highlight stretches to innerW on focus.
+	used := overhead + runewidth.StringWidth(stripANSI(nameStr))
+	pad := innerW - used
+	if pad < 0 {
+		pad = 0
+	}
+
+	if focused {
+		focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(focusGlyph)
+		iconStyled := selectedBG.Render(iconPrefix)
+		nameStyled := selectedBG.Bold(true).Render(nameStr)
+		sep := selectedBG.Render(" ")
+		trail := selectedBG.Render(strings.Repeat(" ", pad+1)) // +1 for the trailing slot in overhead
+		return focusGl + active + sep + iconStyled + nameStyled + sep + watch + trail
+	}
+
+	focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(focusGlyph)
+	nameStyled := sessionStyle.Render(nameStr)
+	return focusGl + active + " " + iconPrefix + nameStyled + " " + watch
+}
+
+// renderCardRow2 builds row 2: focus + state-icon + state-label (left) and
+// proc/git/todo/last-seen (right), with justify-between spacing. When the
+// session is idle or has no state, the left state group is blank.
+func (s SidebarModel) renderCardRow2(node SidebarNode, focused bool, innerW int) string {
+	// Left group: state icon + label.
+	var leftIcon, leftLabel string
+	st := s.stateForSession(node.Session)
+	if st != nil {
+		value := ageDrivenValue(*st, s.cfg.Tui.DoneIdleAfterSecs)
+		if value.IsDisplayable() {
+			if focused {
+				leftIcon = stateIconOnBG(value, activeTheme.ColorSelected)
+			} else {
+				leftIcon = stateIcon(value)
+			}
+			labelStyle := lipgloss.NewStyle().Foreground(activeTheme.ColorFgSubtext)
+			if focused {
+				labelStyle = labelStyle.Background(activeTheme.ColorSelected)
+			}
+			leftLabel = labelStyle.Render(value.String())
+		}
+	}
+
+	// Right group: proc, git, todo, last-seen. Reuse existing helpers, joined
+	// by single space (styled when focused so the gap inherits the highlight).
+	var rightParts []string
+	if ind := s.procLabelIndicator(node, focused, focused); ind != "" {
+		rightParts = append(rightParts, ind)
+	}
+	if ind := s.gitIndicator(node, focused, focused); ind != "" {
+		rightParts = append(rightParts, ind)
+	}
+	if ind := s.itemIndicator(node, focused, focused); ind != "" {
+		rightParts = append(rightParts, ind)
+	}
+	if ind := s.lastSeenIndicator(node, focused, focused); ind != "" {
+		rightParts = append(rightParts, ind)
+	}
+	var right string
+	if focused {
+		sep := lipgloss.NewStyle().Background(activeTheme.ColorSelected).Render(" ")
+		right = strings.Join(rightParts, sep)
+	} else {
+		right = strings.Join(rightParts, " ")
+	}
+
+	// If state is blank, the icon column is still reserved as a space so right group alignment
+	// stays consistent regardless of state presence.
+	leftIconW := runewidth.StringWidth(stripANSI(leftIcon))
+	leftLabelW := runewidth.StringWidth(stripANSI(leftLabel))
+	if leftIconW == 0 {
+		leftIcon = " "
+		leftIconW = 1
+	}
+	rightW := runewidth.StringWidth(stripANSI(right))
+	used := 1 /*focus*/ + 1 /*sep*/ + leftIconW + 1 /*sep*/ + leftLabelW
+	gap := innerW - used - rightW - 1 /*trail*/
+	if gap < 1 {
+		gap = 1
+	}
+
+	if focused {
+		focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(focusGlyph)
+		sep := selectedBG.Render(" ")
+		var leftIconStyled string
+		if leftLabel == "" {
+			leftIconStyled = selectedBG.Render(leftIcon)
+		} else {
+			leftIconStyled = leftIcon // stateIconOnBG already applied selected bg
+		}
+		gapStr := selectedBG.Render(strings.Repeat(" ", gap))
+		trail := selectedBG.Render(" ")
+		return focusGl + sep + leftIconStyled + sep + leftLabel + gapStr + right + trail
+	}
+
+	focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(focusGlyph)
+	return focusGl + " " + leftIcon + " " + leftLabel + strings.Repeat(" ", gap) + right
+}
+
 // formatAge returns a fixed-width 3-char age string for a session's last-seen
 // timestamp. Special cases: <15s → "now", <1m → "<1m". For longer durations:
 // ' Xm' / 'XXm' for minutes, ' Xh' / 'XXh' for hours, ' Xd' / 'XXd' for days.

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -981,7 +981,7 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 // has focus. The highlight background is applied to both content rows when
 // focused.
 func (s SidebarModel) renderSessionCard(node SidebarNode, focused bool, width int) string {
-	innerW := width - 2 // account for border overhead (matches single-row path)
+	innerW := width - borderOverhead
 	if innerW < minRowWidth+4 {
 		innerW = minRowWidth + 4
 	}
@@ -1226,7 +1226,7 @@ func (s *SidebarModel) clampViewport(visibleRows int) {
 	// viewport fills without a trailing blank line. With offset > 0 we have
 	// visibleRows-1 rows of content (▲ present). Pull offset back as far as
 	// possible without dropping the cursor. The first loop above ensures
-	// s.offset <= s.cursor, so newOffset starts below s.cursor — no extra
+	// s.offset <= s.cursor, so newOffset starts at or below s.cursor; no extra
 	// cursor-bound guard is needed here.
 	if s.offset > 0 {
 		contentRows := visibleRows - 1

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -846,6 +846,9 @@ func renderSelectedRow(iconPrefix, nameStr, indicators, gap string, availW, indW
 }
 
 func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, width int) string {
+	if s.cfg.Sidebar.SessionView == config.SidebarViewCard {
+		return s.renderSessionCard(node, selected && focused, width)
+	}
 	indicators := s.sessionIndicators(node, selected, focused)
 
 	// Icon prefix: look up the session and render its icon.

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -487,6 +487,27 @@ func (s *SidebarModel) rebuildNodes() {
 	}
 }
 
+// countFit walks nodes starting at offset, summing heights, and returns the
+// index just past the last fitting node plus whether the cursor index falls
+// within that range. Iteration continues until budget is exhausted or the
+// list ends, so consumed reflects the actual fitting range.
+func countFit(offset, nodeCount, cursor, budget int, height func(i int, isLast bool) int) (consumed int, cursorFits bool) {
+	rows := 0
+	consumed = offset
+	for i := offset; i < nodeCount; i++ {
+		h := height(i, i == nodeCount-1)
+		if rows+h > budget {
+			return consumed, cursorFits
+		}
+		rows += h
+		consumed = i + 1
+		if i == cursor {
+			cursorFits = true
+		}
+	}
+	return consumed, cursorFits
+}
+
 // sidebarViewport computes adjusted offset, content row budget, and scroll hints.
 // Pure function, safe to call from the read-only View/Render method.
 //
@@ -506,41 +527,17 @@ func sidebarViewport(cursor, offset, visibleRows, nodeCount int, height func(i i
 		if hasAbove {
 			contentRows--
 		}
-		rows := 0
-		cursorFits := false
-		consumed := 0
-		for i := offset; i < nodeCount; i++ {
-			h := height(i, i == nodeCount-1)
-			if rows+h > contentRows {
-				break
-			}
-			rows += h
-			consumed = i + 1
-			if i == cursor {
-				cursorFits = true
-			}
-		}
+		consumed, cursorFits := countFit(offset, nodeCount, cursor, contentRows, height)
 		hasBelow = consumed < nodeCount
 		if hasBelow {
+			// Reserve a row for the ▼ hint and re-measure: the first pass above
+			// did not know hasBelow yet, so the budget was one too generous.
 			if contentRows-1 < 1 {
 				contentRows = 1
 			} else {
 				contentRows--
 			}
-			rows = 0
-			cursorFits = false
-			consumed = 0
-			for i := offset; i < nodeCount; i++ {
-				h := height(i, i == nodeCount-1)
-				if rows+h > contentRows {
-					break
-				}
-				rows += h
-				consumed = i + 1
-				if i == cursor {
-					cursorFits = true
-				}
-			}
+			consumed, cursorFits = countFit(offset, nodeCount, cursor, contentRows, height)
 			hasBelow = consumed < nodeCount
 		}
 		if cursorFits || offset >= cursor {
@@ -584,16 +581,25 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 	blank := strings.Repeat(" ", innerW)
 	rowsLeft := contentRows
 	for i := offset; i < end; i++ {
-		isLastVisible := (i == len(s.nodes)-1)
-		h := s.nodeHeight(s.nodes[i], isLastVisible)
+		isLastInList := (i == len(s.nodes)-1)
+		h := s.nodeHeight(s.nodes[i], isLastInList)
 		if h > rowsLeft {
 			break
 		}
 		rendered := s.renderNode(s.nodes[i], i == s.cursor, focused, width)
 		lines = append(lines, strings.Split(rendered, "\n")...)
 		rowsLeft -= h
-		if s.cfg.Sidebar.SessionView == config.SidebarViewCard && !isLastVisible {
-			lines = append(lines, blank)
+		if s.cfg.Sidebar.SessionView == config.SidebarViewCard && !isLastInList {
+			// Only emit the separator if the next card will actually be rendered.
+			// Without this guard, scrolled-mid-list views produce a spurious blank
+			// between the last visible card and the ▼ scroll hint. nodeHeight
+			// includes the separator for non-last cards, so rowsLeft was already
+			// charged for it; skipping the append here over-subtracts rowsLeft by
+			// 1, but the loop is about to exit so no further damage.
+			nextH := s.nodeHeight(s.nodes[i+1], (i+1) == len(s.nodes)-1)
+			if nextH <= rowsLeft {
+				lines = append(lines, blank)
+			}
 		}
 	}
 	if hasBelow {
@@ -1210,19 +1216,7 @@ func (s *SidebarModel) clampViewport(visibleRows int) {
 		s.offset = s.cursor
 	}
 	for s.offset < s.cursor {
-		rows := 0
-		fits := false
-		for i := s.offset; i < len(s.nodes); i++ {
-			h := heightFn(i, i == len(s.nodes)-1)
-			if rows+h > effective {
-				break
-			}
-			rows += h
-			if i == s.cursor {
-				fits = true
-				break
-			}
-		}
+		_, fits := countFit(s.offset, len(s.nodes), s.cursor, effective, heightFn)
 		if fits {
 			break
 		}
@@ -1231,26 +1225,18 @@ func (s *SidebarModel) clampViewport(visibleRows int) {
 	// At the bottom of the list ▼ is absent; reclaim the freed row so the
 	// viewport fills without a trailing blank line. With offset > 0 we have
 	// visibleRows-1 rows of content (▲ present). Pull offset back as far as
-	// possible without dropping the cursor.
+	// possible without dropping the cursor. The first loop above ensures
+	// s.offset <= s.cursor, so newOffset starts below s.cursor — no extra
+	// cursor-bound guard is needed here.
 	if s.offset > 0 {
 		contentRows := visibleRows - 1
 		if contentRows < 1 {
 			contentRows = 1
 		}
-		// Find smallest newOffset such that nodes [newOffset, len-1] fit in contentRows
-		// and newOffset <= cursor.
+		// Find smallest newOffset such that nodes [newOffset, len-1] fit in contentRows.
 		for newOffset := s.offset - 1; newOffset >= 0; newOffset-- {
-			rows := 0
-			fits := true
-			for i := newOffset; i < len(s.nodes); i++ {
-				h := heightFn(i, i == len(s.nodes)-1)
-				if rows+h > contentRows {
-					fits = false
-					break
-				}
-				rows += h
-			}
-			if !fits || newOffset > s.cursor {
+			consumed, _ := countFit(newOffset, len(s.nodes), s.cursor, contentRows, heightFn)
+			if consumed < len(s.nodes) {
 				break
 			}
 			s.offset = newOffset

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -582,7 +582,7 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 	rowsLeft := contentRows
 	for i := offset; i < end; i++ {
 		isLastInList := (i == len(s.nodes)-1)
-		h := s.nodeHeight(s.nodes[i], isLastInList)
+		h := s.nodeHeight(isLastInList)
 		if h > rowsLeft {
 			break
 		}
@@ -596,7 +596,7 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 			// includes the separator for non-last cards, so rowsLeft was already
 			// charged for it; skipping the append here over-subtracts rowsLeft by
 			// 1, but the loop is about to exit so no further damage.
-			nextH := s.nodeHeight(s.nodes[i+1], (i+1) == len(s.nodes)-1)
+			nextH := s.nodeHeight((i + 1) == len(s.nodes)-1)
 			if nextH <= rowsLeft {
 				lines = append(lines, sep)
 			}
@@ -614,9 +614,7 @@ func (s SidebarModel) Render(width, height int, focused bool, title, rightTitle 
 		visibleRows = 1
 	}
 
-	heightFn := func(i int, isLast bool) int {
-		return s.nodeHeight(s.nodes[i], isLast)
-	}
+	heightFn := func(_ int, isLast bool) int { return s.nodeHeight(isLast) }
 	offset, contentRows, hasAbove, hasBelow := sidebarViewport(s.cursor, s.offset, visibleRows, len(s.nodes), heightFn)
 
 	innerW := width - borderOverhead
@@ -681,7 +679,7 @@ func (s SidebarModel) cardSeparatorRow(innerW int) string {
 // nodeHeight returns the viewport rows consumed by a session in the current
 // view. Card mode reserves 2 content rows; a trailing separator row adds 1
 // for every card except the last visible one when card_separator is enabled.
-func (s SidebarModel) nodeHeight(_ SidebarNode, isLast bool) int {
+func (s SidebarModel) nodeHeight(isLast bool) int {
 	if s.cardView() {
 		if isLast || s.cfg.Sidebar.CardSeparator == config.CardSeparatorNone {
 			return 2
@@ -696,8 +694,8 @@ func (s SidebarModel) nodeHeight(_ SidebarNode, isLast bool) int {
 // measured by display-column width (runewidth) after stripping ANSI codes,
 // so multi-column glyphs (e.g. emoji) are accounted for correctly.
 func alignedRow(name, indicators string, availWidth int) string {
-	nameW := runewidth.StringWidth(stripANSI(name))
-	indW := runewidth.StringWidth(stripANSI(indicators))
+	nameW := visualWidth(name)
+	indW := visualWidth(indicators)
 	pad := availWidth - nameW - indW
 	if pad < 1 {
 		pad = 1
@@ -917,7 +915,7 @@ func renderSelectedRow(iconPrefix, nameStr, indicators, gap string, availW, indW
 		pad = 0
 	}
 	if focused {
-		indicatorGlyph := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(focusGlyph)
+		indicatorGlyph := selectedSession.Render(focusGlyph)
 		trail := lipgloss.NewStyle().Background(activeTheme.ColorSelected).Render(selectedTrail)
 		name := selectedBG.Bold(true).Render(nameStr + strings.Repeat(" ", pad))
 		spacer := selectedBG.Render(" ")
@@ -940,13 +938,7 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 	if sess := s.FindSession(node.Session); sess != nil {
 		iconPrefix = sessionIcon(*sess) + " "
 	}
-	iconW := runewidth.StringWidth(stripANSI(iconPrefix))
-
-	// Resolve active icon early so its width can be accounted for in availW.
-	activeIcon := s.cfg.Sidebar.ActiveSessionIcon
-	if activeIcon == "" {
-		activeIcon = config.DefaultActiveSessionIcon
-	}
+	iconW := visualWidth(iconPrefix)
 
 	// Row format: [focus(1)] [gap(1)] [active-slot(1)] [icon(iconW)] [name+indicators(availW)]
 	// The active-slot is always reserved (indicator or space) so the session icon
@@ -955,7 +947,7 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 	if availW < minRowWidth {
 		availW = minRowWidth
 	}
-	indW := runewidth.StringWidth(stripANSI(indicators))
+	indW := visualWidth(indicators)
 	maxName := availW - indW
 	if indW > 0 {
 		maxName-- // alignedRow enforces pad>=1 separator; reserve it so truncation doesn't overflow
@@ -970,17 +962,7 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 		nameStr = truncateSessionName(node.Session, maxName)
 	}
 
-	// Compute gap: active session gets the directional indicator; others get a space.
-	gap := " "
-	if node.Session == s.activeSession {
-		if selected && focused {
-			gap = lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(activeIcon)
-		} else {
-			gap = lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(activeIcon)
-		}
-	} else if selected && focused {
-		gap = selectedBG.Render(gap)
-	}
+	gap := s.activeIndicator(node, selected && focused)
 	if selected {
 		return renderSelectedRow(iconPrefix, nameStr, indicators, gap, availW, indW, focused)
 	}
@@ -990,8 +972,8 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 
 // renderSessionCard renders a session as a two-row card.
 //
-//	Row 1: <focus(1)><active(1)> <session_icon> <session_name> <watch> <trail>
-//	Row 2: <focus(1)> <state_icon> <state_label> <gap> <proc> <git> <todo> <last_seen>
+//	header: <focus(1)><active(1)> <session_icon> <session_name> <watch> <trail>
+//	status: <focus(1)> <state_icon> <state_label> <gap> <proc> <git> <todo> <last_seen>
 //
 // Rows are joined with "\n". The blank separator row between cards is the
 // caller's responsibility (emitted by buildSidebarLines), so this renderer
@@ -1005,9 +987,9 @@ func (s SidebarModel) renderSessionCard(node SidebarNode, selected, focused bool
 	if innerW < minRowWidth+4 {
 		innerW = minRowWidth + 4
 	}
-	row1 := s.renderCardRow1(node, selected, focused, innerW)
-	row2 := s.renderCardRow2(node, selected, focused, innerW)
-	return row1 + "\n" + row2
+	header := s.renderCardHeader(node, selected, focused, innerW)
+	status := s.renderCardStatus(node, selected, focused, innerW)
+	return header + "\n" + status
 }
 
 // cardLeadingGlyph returns the column-0 glyph for a card row. Selected cards
@@ -1016,7 +998,7 @@ func (s SidebarModel) renderSessionCard(node SidebarNode, selected, focused bool
 func cardLeadingGlyph(selected, focused bool) string {
 	switch {
 	case focused:
-		return lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(focusGlyph)
+		return selectedSession.Render(focusGlyph)
 	case selected:
 		return lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(focusGlyph)
 	default:
@@ -1024,35 +1006,50 @@ func cardLeadingGlyph(selected, focused bool) string {
 	}
 }
 
-// renderCardRow1 builds row 1: focus + active + session icon + name + watch,
-// with the highlight background extended to the full innerW when focused.
-func (s SidebarModel) renderCardRow1(node SidebarNode, selected, focused bool, innerW int) string {
-	// Active indicator slot (always 1 col so column alignment is stable).
-	activeIcon := s.cfg.Sidebar.ActiveSessionIcon
-	if activeIcon == "" {
-		activeIcon = config.DefaultActiveSessionIcon
+// activeIconChar returns the configured active-session indicator, falling
+// back to the package default when unset.
+func (s SidebarModel) activeIconChar() string {
+	if icon := s.cfg.Sidebar.ActiveSessionIcon; icon != "" {
+		return icon
 	}
-	active := " "
+	return config.DefaultActiveSessionIcon
+}
+
+// activeIndicator returns the 1-col cell that goes in the "active session"
+// slot of a sidebar row. When the row represents the attached tmux session,
+// the configured icon is styled with the session color (with the selected
+// background when highlighted). Otherwise a plain space is returned, also
+// styled with the highlight background when highlighted so the slot blends
+// into the selection bar.
+func (s SidebarModel) activeIndicator(node SidebarNode, highlighted bool) string {
 	if node.Session == s.activeSession {
-		if focused {
-			active = lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(activeIcon)
-		} else {
-			active = lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(activeIcon)
+		if highlighted {
+			return selectedSession.Render(s.activeIconChar())
 		}
-	} else if focused {
-		active = selectedBG.Render(active)
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(s.activeIconChar())
 	}
+	if highlighted {
+		return selectedBG.Render(" ")
+	}
+	return " "
+}
+
+// renderCardHeader builds the top row of a session card: focus + active +
+// session icon + name + watch, with the highlight background extended to the
+// full innerW when focused.
+func (s SidebarModel) renderCardHeader(node SidebarNode, selected, focused bool, innerW int) string {
+	active := s.activeIndicator(node, focused)
 
 	// Session icon.
 	iconPrefix := ""
 	if sess := s.FindSession(node.Session); sess != nil {
 		iconPrefix = sessionIcon(*sess) + " "
 	}
-	iconW := runewidth.StringWidth(stripANSI(iconPrefix))
+	iconW := visualWidth(iconPrefix)
 
 	// Watch slot (fixed width even when unwatched).
 	watch := s.watchIndicator(node, focused, focused)
-	watchW := runewidth.StringWidth(stripANSI(watch))
+	watchW := visualWidth(watch)
 
 	// Budget for name: total - focus(1) - active(1) - sep(1 between active & icon) - icon - sep(1) - watch - trail(1).
 	overhead := 1 /*focus*/ + 1 /*active*/ + 1 /*sep*/ + iconW + 1 /*sep*/ + watchW + 1 /*trail*/
@@ -1069,7 +1066,7 @@ func (s SidebarModel) renderCardRow1(node SidebarNode, selected, focused bool, i
 	}
 
 	// Compute pad so highlight stretches to innerW on focus.
-	used := overhead + runewidth.StringWidth(stripANSI(nameStr))
+	used := overhead + visualWidth(nameStr)
 	pad := innerW - used
 	if pad < 0 {
 		pad = 0
@@ -1088,10 +1085,11 @@ func (s SidebarModel) renderCardRow1(node SidebarNode, selected, focused bool, i
 	return focusGl + active + " " + iconPrefix + nameStyled + " " + watch
 }
 
-// renderCardRow2 builds row 2: focus + state-icon + state-label (left) and
-// proc/git/todo/last-seen (right), with justify-between spacing. When the
-// session is idle or has no state, the left state group is blank.
-func (s SidebarModel) renderCardRow2(node SidebarNode, selected, focused bool, innerW int) string {
+// renderCardStatus builds the bottom row of a session card: focus +
+// state-icon + state-label (left) and proc/git/todo/last-seen (right), with
+// justify-between spacing. When the session is idle or has no state, the
+// left state group is blank.
+func (s SidebarModel) renderCardStatus(node SidebarNode, selected, focused bool, innerW int) string {
 	// Left group: state icon + label.
 	var leftIcon, leftLabel string
 	st := s.stateForSession(node.Session)
@@ -1111,38 +1109,32 @@ func (s SidebarModel) renderCardRow2(node SidebarNode, selected, focused bool, i
 		}
 	}
 
-	// Right group: proc, git, todo, last-seen. Reuse existing helpers, joined
-	// by single space (styled when focused so the gap inherits the highlight).
+	// Right group: proc, git, todo, last-seen. Joined by a single space, styled
+	// when focused so the gap inherits the highlight.
+	indicatorFns := []func(SidebarNode, bool, bool) string{
+		s.procLabelIndicator, s.gitIndicator, s.itemIndicator, s.lastSeenIndicator,
+	}
 	var rightParts []string
-	if ind := s.procLabelIndicator(node, focused, focused); ind != "" {
-		rightParts = append(rightParts, ind)
+	for _, fn := range indicatorFns {
+		if ind := fn(node, focused, focused); ind != "" {
+			rightParts = append(rightParts, ind)
+		}
 	}
-	if ind := s.gitIndicator(node, focused, focused); ind != "" {
-		rightParts = append(rightParts, ind)
-	}
-	if ind := s.itemIndicator(node, focused, focused); ind != "" {
-		rightParts = append(rightParts, ind)
-	}
-	if ind := s.lastSeenIndicator(node, focused, focused); ind != "" {
-		rightParts = append(rightParts, ind)
-	}
-	var right string
+	sep := " "
 	if focused {
-		sep := lipgloss.NewStyle().Background(activeTheme.ColorSelected).Render(" ")
-		right = strings.Join(rightParts, sep)
-	} else {
-		right = strings.Join(rightParts, " ")
+		sep = selectedBG.Render(" ")
 	}
+	right := strings.Join(rightParts, sep)
 
 	// If state is blank, the icon column is still reserved as a space so right group alignment
 	// stays consistent regardless of state presence.
-	leftIconW := runewidth.StringWidth(stripANSI(leftIcon))
-	leftLabelW := runewidth.StringWidth(stripANSI(leftLabel))
+	leftIconW := visualWidth(leftIcon)
+	leftLabelW := visualWidth(leftLabel)
 	if leftIconW == 0 {
 		leftIcon = " "
 		leftIconW = 1
 	}
-	rightW := runewidth.StringWidth(stripANSI(right))
+	rightW := visualWidth(right)
 	used := 1 /*focus*/ + 1 /*sep*/ + leftIconW + 1 /*sep*/ + leftLabelW
 	trailW := 1
 	gap := innerW - used - rightW - trailW
@@ -1240,7 +1232,7 @@ func (s *SidebarModel) clampViewport(visibleRows int) {
 	if effective < 1 {
 		effective = 1
 	}
-	heightFn := func(i int, isLast bool) int { return s.nodeHeight(s.nodes[i], isLast) }
+	heightFn := func(_ int, isLast bool) int { return s.nodeHeight(isLast) }
 	if s.cursor < s.offset {
 		s.offset = s.cursor
 	}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -589,7 +589,7 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 		rendered := s.renderNode(s.nodes[i], i == s.cursor, focused, width)
 		lines = append(lines, strings.Split(rendered, "\n")...)
 		rowsLeft -= h
-		if s.cfg.Sidebar.SessionView == config.SidebarViewCard && !isLastInList {
+		if s.cardView() && s.cfg.Sidebar.CardSeparator && !isLastInList {
 			// Only emit the separator if the next card will actually be rendered.
 			// Without this guard, scrolled-mid-list views produce a spurious blank
 			// between the last visible card and the ▼ scroll hint. nodeHeight
@@ -658,12 +658,18 @@ func (s SidebarModel) renderNode(node SidebarNode, selected, focused bool, width
 	return s.renderSession(node, selected, focused, width)
 }
 
+// cardView reports whether the resolved session view (taking into account the
+// per-mode overrides) is the card layout.
+func (s SidebarModel) cardView() bool {
+	return s.cfg.Sidebar.ResolvedSessionView(s.cfg.Mode) == config.SidebarViewCard
+}
+
 // nodeHeight returns the viewport rows consumed by a session in the current
-// view. Card mode reserves 2 content rows; a trailing separator row adds 1
-// for every card except the last visible one.
+// view. Card mode reserves 2 content rows; when sidebar.card_separator is on,
+// a trailing separator row adds 1 for every card except the last visible one.
 func (s SidebarModel) nodeHeight(_ SidebarNode, isLast bool) int {
-	if s.cfg.Sidebar.SessionView == config.SidebarViewCard {
-		if isLast {
+	if s.cardView() {
+		if isLast || !s.cfg.Sidebar.CardSeparator {
 			return 2
 		}
 		return 3
@@ -910,7 +916,7 @@ func renderSelectedRow(iconPrefix, nameStr, indicators, gap string, availW, indW
 }
 
 func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, width int) string {
-	if s.cfg.Sidebar.SessionView == config.SidebarViewCard {
+	if s.cardView() {
 		return s.renderSessionCard(node, selected && focused, width)
 	}
 	indicators := s.sessionIndicators(node, selected, focused)

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -931,7 +931,7 @@ func renderSelectedRow(iconPrefix, nameStr, indicators, gap string, availW, indW
 
 func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, width int) string {
 	if s.cardView() {
-		return s.renderSessionCard(node, selected && focused, width)
+		return s.renderSessionCard(node, selected, selected && focused, width)
 	}
 	indicators := s.sessionIndicators(node, selected, focused)
 
@@ -1000,19 +1000,33 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 // focused == true means: the cursor is on this session AND the sidebar pane
 // has focus. The highlight background is applied to both content rows when
 // focused.
-func (s SidebarModel) renderSessionCard(node SidebarNode, focused bool, width int) string {
+func (s SidebarModel) renderSessionCard(node SidebarNode, selected, focused bool, width int) string {
 	innerW := width - borderOverhead
 	if innerW < minRowWidth+4 {
 		innerW = minRowWidth + 4
 	}
-	row1 := s.renderCardRow1(node, focused, innerW)
-	row2 := s.renderCardRow2(node, focused, innerW)
+	row1 := s.renderCardRow1(node, selected, focused, innerW)
+	row2 := s.renderCardRow2(node, selected, focused, innerW)
 	return row1 + "\n" + row2
+}
+
+// cardLeadingGlyph returns the column-0 glyph for a card row. Selected cards
+// (regardless of pane focus) get the blue focus glyph; everything else gets a
+// plain space so unselected cards never look highlighted.
+func cardLeadingGlyph(selected, focused bool) string {
+	switch {
+	case focused:
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(focusGlyph)
+	case selected:
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(focusGlyph)
+	default:
+		return " "
+	}
 }
 
 // renderCardRow1 builds row 1: focus + active + session icon + name + watch,
 // with the highlight background extended to the full innerW when focused.
-func (s SidebarModel) renderCardRow1(node SidebarNode, focused bool, innerW int) string {
+func (s SidebarModel) renderCardRow1(node SidebarNode, selected, focused bool, innerW int) string {
 	// Active indicator slot (always 1 col so column alignment is stable).
 	activeIcon := s.cfg.Sidebar.ActiveSessionIcon
 	if activeIcon == "" {
@@ -1061,8 +1075,8 @@ func (s SidebarModel) renderCardRow1(node SidebarNode, focused bool, innerW int)
 		pad = 0
 	}
 
+	focusGl := cardLeadingGlyph(selected, focused)
 	if focused {
-		focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(focusGlyph)
 		iconStyled := selectedBG.Render(iconPrefix)
 		nameStyled := selectedBG.Bold(true).Render(nameStr)
 		sep := selectedBG.Render(" ")
@@ -1070,7 +1084,6 @@ func (s SidebarModel) renderCardRow1(node SidebarNode, focused bool, innerW int)
 		return focusGl + active + sep + iconStyled + nameStyled + sep + watch + trail
 	}
 
-	focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(focusGlyph)
 	nameStyled := sessionStyle.Render(nameStr)
 	return focusGl + active + " " + iconPrefix + nameStyled + " " + watch
 }
@@ -1078,7 +1091,7 @@ func (s SidebarModel) renderCardRow1(node SidebarNode, focused bool, innerW int)
 // renderCardRow2 builds row 2: focus + state-icon + state-label (left) and
 // proc/git/todo/last-seen (right), with justify-between spacing. When the
 // session is idle or has no state, the left state group is blank.
-func (s SidebarModel) renderCardRow2(node SidebarNode, focused bool, innerW int) string {
+func (s SidebarModel) renderCardRow2(node SidebarNode, selected, focused bool, innerW int) string {
 	// Left group: state icon + label.
 	var leftIcon, leftLabel string
 	st := s.stateForSession(node.Session)
@@ -1137,8 +1150,8 @@ func (s SidebarModel) renderCardRow2(node SidebarNode, focused bool, innerW int)
 		gap = 1
 	}
 
+	focusGl := cardLeadingGlyph(selected, focused)
 	if focused {
-		focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Background(activeTheme.ColorSelected).Render(focusGlyph)
 		sep := selectedBG.Render(" ")
 		var leftIconStyled string
 		if leftLabel == "" {
@@ -1151,7 +1164,6 @@ func (s SidebarModel) renderCardRow2(node SidebarNode, focused bool, innerW int)
 		return focusGl + sep + leftIconStyled + sep + leftLabel + gapStr + right + trail
 	}
 
-	focusGl := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(focusGlyph)
 	return focusGl + " " + leftIcon + " " + leftLabel + strings.Repeat(" ", gap) + right + " "
 }
 

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -488,25 +488,65 @@ func (s *SidebarModel) rebuildNodes() {
 }
 
 // sidebarViewport computes adjusted offset, content row budget, and scroll hints.
-// Pure function — safe to call from the read-only View/Render method.
-func sidebarViewport(cursor, offset, visibleRows, nodeCount int) (adjOffset, contentRows int, hasAbove, hasBelow bool) {
+// Pure function, safe to call from the read-only View/Render method.
+//
+// height(i, isLast) returns the row cost of node i. Cursor and offset are
+// still node indices; the function adjusts them so the cursor's node fits
+// within the row budget.
+func sidebarViewport(cursor, offset, visibleRows, nodeCount int, height func(i int, isLast bool) int) (adjOffset, contentRows int, hasAbove, hasBelow bool) {
 	if cursor < offset {
 		offset = cursor
-	}
-	if cursor >= offset+visibleRows {
-		offset = cursor - visibleRows + 1
 	}
 	if offset < 0 {
 		offset = 0
 	}
-	hasAbove = offset > 0
-	contentRows = visibleRows
-	if hasAbove {
-		contentRows--
-	}
-	hasBelow = offset+contentRows < nodeCount
-	if hasBelow {
-		contentRows--
+	for {
+		hasAbove = offset > 0
+		contentRows = visibleRows
+		if hasAbove {
+			contentRows--
+		}
+		rows := 0
+		cursorFits := false
+		consumed := 0
+		for i := offset; i < nodeCount; i++ {
+			h := height(i, i == nodeCount-1)
+			if rows+h > contentRows {
+				break
+			}
+			rows += h
+			consumed = i + 1
+			if i == cursor {
+				cursorFits = true
+			}
+		}
+		hasBelow = consumed < nodeCount
+		if hasBelow {
+			if contentRows-1 < 1 {
+				contentRows = 1
+			} else {
+				contentRows--
+			}
+			rows = 0
+			cursorFits = false
+			consumed = 0
+			for i := offset; i < nodeCount; i++ {
+				h := height(i, i == nodeCount-1)
+				if rows+h > contentRows {
+					break
+				}
+				rows += h
+				consumed = i + 1
+				if i == cursor {
+					cursorFits = true
+				}
+			}
+			hasBelow = consumed < nodeCount
+		}
+		if cursorFits || offset >= cursor {
+			break
+		}
+		offset++
 	}
 	if contentRows < 1 {
 		contentRows = 1
@@ -528,7 +568,9 @@ func (s SidebarModel) emptyHintText() string {
 	}
 }
 
-// buildSidebarLines builds the list of rendered node lines for the sidebar content area.
+// buildSidebarLines builds the list of rendered node lines for the sidebar
+// content area. Honors per-node height (card mode emits a blank separator
+// after each session except the last visible one).
 func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBelow, focused bool, width int, centeredHint func(string) string) []string {
 	var lines []string
 	if hasAbove {
@@ -538,8 +580,21 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 	if end > len(s.nodes) {
 		end = len(s.nodes)
 	}
+	innerW := width - borderOverhead
+	blank := strings.Repeat(" ", innerW)
+	rowsLeft := contentRows
 	for i := offset; i < end; i++ {
-		lines = append(lines, s.renderNode(s.nodes[i], i == s.cursor, focused, width))
+		isLastVisible := (i == len(s.nodes)-1)
+		h := s.nodeHeight(s.nodes[i], isLastVisible)
+		if h > rowsLeft {
+			break
+		}
+		rendered := s.renderNode(s.nodes[i], i == s.cursor, focused, width)
+		lines = append(lines, strings.Split(rendered, "\n")...)
+		rowsLeft -= h
+		if s.cfg.Sidebar.SessionView == config.SidebarViewCard && !isLastVisible {
+			lines = append(lines, blank)
+		}
 	}
 	if hasBelow {
 		lines = append(lines, centeredHint(scrollHintBelow))
@@ -553,7 +608,10 @@ func (s SidebarModel) Render(width, height int, focused bool, title, rightTitle 
 		visibleRows = 1
 	}
 
-	offset, contentRows, hasAbove, hasBelow := sidebarViewport(s.cursor, s.offset, visibleRows, len(s.nodes))
+	heightFn := func(i int, isLast bool) int {
+		return s.nodeHeight(s.nodes[i], isLast)
+	}
+	offset, contentRows, hasAbove, hasBelow := sidebarViewport(s.cursor, s.offset, visibleRows, len(s.nodes), heightFn)
 
 	innerW := width - borderOverhead
 	centeredHint := func(text string) string {
@@ -1147,24 +1205,55 @@ func (s *SidebarModel) clampViewport(visibleRows int) {
 	if effective < 1 {
 		effective = 1
 	}
+	heightFn := func(i int, isLast bool) int { return s.nodeHeight(s.nodes[i], isLast) }
 	if s.cursor < s.offset {
 		s.offset = s.cursor
 	}
-	if s.cursor >= s.offset+effective {
-		s.offset = s.cursor - effective + 1
+	for s.offset < s.cursor {
+		rows := 0
+		fits := false
+		for i := s.offset; i < len(s.nodes); i++ {
+			h := heightFn(i, i == len(s.nodes)-1)
+			if rows+h > effective {
+				break
+			}
+			rows += h
+			if i == s.cursor {
+				fits = true
+				break
+			}
+		}
+		if fits {
+			break
+		}
+		s.offset++
 	}
 	// At the bottom of the list ▼ is absent; reclaim the freed row so the
-	// viewport fills without a trailing blank line.
+	// viewport fills without a trailing blank line. With offset > 0 we have
+	// visibleRows-1 rows of content (▲ present). Pull offset back as far as
+	// possible without dropping the cursor.
 	if s.offset > 0 {
-		contentRows := visibleRows - 1 // ▲ is present whenever offset > 0
-		if s.offset+contentRows >= len(s.nodes) {
-			newOffset := len(s.nodes) - contentRows
-			if newOffset < 0 {
-				newOffset = 0
+		contentRows := visibleRows - 1
+		if contentRows < 1 {
+			contentRows = 1
+		}
+		// Find smallest newOffset such that nodes [newOffset, len-1] fit in contentRows
+		// and newOffset <= cursor.
+		for newOffset := s.offset - 1; newOffset >= 0; newOffset-- {
+			rows := 0
+			fits := true
+			for i := newOffset; i < len(s.nodes); i++ {
+				h := heightFn(i, i == len(s.nodes)-1)
+				if rows+h > contentRows {
+					fits = false
+					break
+				}
+				rows += h
 			}
-			if s.cursor >= newOffset {
-				s.offset = newOffset
+			if !fits || newOffset > s.cursor {
+				break
 			}
+			s.offset = newOffset
 		}
 	}
 	if s.offset < 0 {

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -1044,7 +1044,11 @@ func (s SidebarModel) renderCardRow2(node SidebarNode, focused bool, innerW int)
 	}
 	rightW := runewidth.StringWidth(stripANSI(right))
 	used := 1 /*focus*/ + 1 /*sep*/ + leftIconW + 1 /*sep*/ + leftLabelW
-	gap := innerW - used - rightW - 1 /*trail*/
+	trailW := 0
+	if focused {
+		trailW = 1
+	}
+	gap := innerW - used - rightW - trailW
 	if gap < 1 {
 		gap = 1
 	}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -578,7 +578,7 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 		end = len(s.nodes)
 	}
 	innerW := width - borderOverhead
-	blank := strings.Repeat(" ", innerW)
+	sep := s.cardSeparatorRow(innerW)
 	rowsLeft := contentRows
 	for i := offset; i < end; i++ {
 		isLastInList := (i == len(s.nodes)-1)
@@ -589,16 +589,16 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 		rendered := s.renderNode(s.nodes[i], i == s.cursor, focused, width)
 		lines = append(lines, strings.Split(rendered, "\n")...)
 		rowsLeft -= h
-		if s.cardView() && s.cfg.Sidebar.CardSeparator && !isLastInList {
+		if s.cardView() && sep != "" && !isLastInList {
 			// Only emit the separator if the next card will actually be rendered.
-			// Without this guard, scrolled-mid-list views produce a spurious blank
+			// Without this guard, scrolled-mid-list views produce a spurious row
 			// between the last visible card and the ▼ scroll hint. nodeHeight
 			// includes the separator for non-last cards, so rowsLeft was already
 			// charged for it; skipping the append here over-subtracts rowsLeft by
 			// 1, but the loop is about to exit so no further damage.
 			nextH := s.nodeHeight(s.nodes[i+1], (i+1) == len(s.nodes)-1)
 			if nextH <= rowsLeft {
-				lines = append(lines, blank)
+				lines = append(lines, sep)
 			}
 		}
 	}
@@ -664,12 +664,26 @@ func (s SidebarModel) cardView() bool {
 	return s.cfg.Sidebar.ResolvedSessionView(s.cfg.Mode) == config.SidebarViewCard
 }
 
+// cardSeparatorRow returns the row rendered between cards in card view. It
+// returns "" when separators are disabled, a row of spaces for "blank", and a
+// styled horizontal rule for "rule".
+func (s SidebarModel) cardSeparatorRow(innerW int) string {
+	switch s.cfg.Sidebar.CardSeparator {
+	case config.CardSeparatorNone:
+		return ""
+	case config.CardSeparatorRule:
+		return lipgloss.NewStyle().Foreground(activeTheme.ColorBorder).Render(strings.Repeat("─", innerW))
+	default:
+		return strings.Repeat(" ", innerW)
+	}
+}
+
 // nodeHeight returns the viewport rows consumed by a session in the current
-// view. Card mode reserves 2 content rows; when sidebar.card_separator is on,
-// a trailing separator row adds 1 for every card except the last visible one.
+// view. Card mode reserves 2 content rows; a trailing separator row adds 1
+// for every card except the last visible one when card_separator is enabled.
 func (s SidebarModel) nodeHeight(_ SidebarNode, isLast bool) int {
 	if s.cardView() {
-		if isLast || !s.cfg.Sidebar.CardSeparator {
+		if isLast || s.cfg.Sidebar.CardSeparator == config.CardSeparatorNone {
 			return 2
 		}
 		return 3

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1565,7 +1565,7 @@ func TestNodeHeight(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := SidebarModel{cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: tc.view, CardSeparator: tc.separator}}}
-			got := s.nodeHeight(SidebarNode{Session: "x"}, tc.isLast)
+			got := s.nodeHeight(tc.isLast)
 			if got != tc.expected {
 				t.Errorf("nodeHeight(view=%q, sep=%v, isLast=%v): got %d, want %d", tc.view, tc.separator, tc.isLast, got, tc.expected)
 			}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/muesli/termenv"
 	"github.com/rtalexk/demux/internal/config"
 	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/git"
@@ -1429,38 +1430,35 @@ func TestRenderSessionCard_Unfocused_Basic(t *testing.T) {
 }
 
 func TestRenderSessionCard_Focused_HighlightsBothRows(t *testing.T) {
-	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", ColorSelected: lipgloss.Color("#2a2a4a"), ColorFgPrimary: lipgloss.Color("#ffffff"), IconStateWorking: "⟳"}, config.ProcessesConfig{}, nil)
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+	initStyles(Theme{
+		IconTmuxSession: "⊞", IconCfgSession: "⚙︎",
+		ColorSelected: lipgloss.Color("#2a2a4a"), ColorFgPrimary: lipgloss.Color("#ffffff"),
+	}, config.ProcessesConfig{}, nil)
 	s := SidebarModel{
 		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40, ShowLastSeen: true}},
-		sessions: []session.Session{{DisplayName: "alpha", IsLive: true, Activity: time.Now().Add(-5 * time.Minute)}},
-		states:   []db.ToolState{{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateWorking}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
 	}
-	// Verify both focus states produce a 2-row card with the session name on row 1.
-	// Row 1 focused expands its trailing pad to fill innerW; unfocused does not —
-	// that width difference is intentional. Row 2 must have equal display width
-	// across both states (tested exhaustively in TestRenderSessionCard_FocusedAndUnfocusedRow2_RightGroupAligns).
 	focused := s.renderSessionCard(SidebarNode{Session: "alpha"}, true, 40)
 	unfocused := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
 	fLines := strings.Split(focused, "\n")
 	uLines := strings.Split(unfocused, "\n")
-	if len(fLines) != 2 {
-		t.Fatalf("expected 2 focused lines, got %d", len(fLines))
+	if len(fLines) != 2 || len(uLines) != 2 {
+		t.Fatalf("expected 2 lines each, got focused=%d unfocused=%d", len(fLines), len(uLines))
 	}
-	if len(uLines) != 2 {
-		t.Fatalf("expected 2 unfocused lines, got %d", len(uLines))
-	}
-	// Both rows must contain the session name.
-	for _, lines := range [][]string{fLines, uLines} {
-		if !strings.Contains(stripANSI(lines[0]), "alpha") {
-			t.Errorf("row 1 missing session name: %q", lines[0])
+	// Both focused rows must contain a SGR background code (\x1b[48...) for the
+	// selected background. Both unfocused rows must NOT.
+	const bgPrefix = "\x1b[48"
+	for i, l := range fLines {
+		if !strings.Contains(l, bgPrefix) {
+			t.Errorf("focused row %d missing background ANSI %q: %q", i+1, bgPrefix, l)
 		}
 	}
-	// Row 2 display widths must be equal across focus states.
-	wf := runewidth.StringWidth(stripANSI(fLines[1]))
-	wu := runewidth.StringWidth(stripANSI(uLines[1]))
-	if wf != wu {
-		t.Errorf("row 2: focused display width %d != unfocused %d (focused=%q unfocused=%q)",
-			wf, wu, fLines[1], uLines[1])
+	for i, l := range uLines {
+		if strings.Contains(l, bgPrefix) {
+			t.Errorf("unfocused row %d unexpectedly contains background ANSI %q: %q", i+1, bgPrefix, l)
+		}
 	}
 }
 

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	runewidth "github.com/mattn/go-runewidth"
 	"github.com/rtalexk/demux/internal/config"
 	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/git"
@@ -1428,14 +1429,16 @@ func TestRenderSessionCard_Unfocused_Basic(t *testing.T) {
 }
 
 func TestRenderSessionCard_Focused_HighlightsBothRows(t *testing.T) {
-	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", ColorSelected: lipgloss.Color("#2a2a4a"), ColorFgPrimary: lipgloss.Color("#ffffff")}, config.ProcessesConfig{}, nil)
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", ColorSelected: lipgloss.Color("#2a2a4a"), ColorFgPrimary: lipgloss.Color("#ffffff"), IconStateWorking: "⟳"}, config.ProcessesConfig{}, nil)
 	s := SidebarModel{
 		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40, ShowLastSeen: true}},
-		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true, Activity: time.Now().Add(-5 * time.Minute)}},
+		states:   []db.ToolState{{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateWorking}},
 	}
-	// Compare focused vs unfocused output: focused must differ (highlight
-	// styling extends the background to the row's full inner width on both
-	// rows, so the rendered strings can't be identical).
+	// Verify both focus states produce a 2-row card with the session name on row 1.
+	// Row 1 focused expands its trailing pad to fill innerW; unfocused does not —
+	// that width difference is intentional. Row 2 must have equal display width
+	// across both states (tested exhaustively in TestRenderSessionCard_FocusedAndUnfocusedRow2_RightGroupAligns).
 	focused := s.renderSessionCard(SidebarNode{Session: "alpha"}, true, 40)
 	unfocused := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
 	fLines := strings.Split(focused, "\n")
@@ -1446,10 +1449,18 @@ func TestRenderSessionCard_Focused_HighlightsBothRows(t *testing.T) {
 	if len(uLines) != 2 {
 		t.Fatalf("expected 2 unfocused lines, got %d", len(uLines))
 	}
-	for i := 0; i < 2; i++ {
-		if fLines[i] == uLines[i] {
-			t.Errorf("row %d: focused and unfocused output identical, expected highlight to differ: %q", i+1, fLines[i])
+	// Both rows must contain the session name.
+	for _, lines := range [][]string{fLines, uLines} {
+		if !strings.Contains(stripANSI(lines[0]), "alpha") {
+			t.Errorf("row 1 missing session name: %q", lines[0])
 		}
+	}
+	// Row 2 display widths must be equal across focus states.
+	wf := runewidth.StringWidth(stripANSI(fLines[1]))
+	wu := runewidth.StringWidth(stripANSI(uLines[1]))
+	if wf != wu {
+		t.Errorf("row 2: focused display width %d != unfocused %d (focused=%q unfocused=%q)",
+			wf, wu, fLines[1], uLines[1])
 	}
 }
 
@@ -1481,5 +1492,33 @@ func TestRenderSessionCard_WorkingStateShowsLabel(t *testing.T) {
 	row2 := strings.Split(out, "\n")[1]
 	if !strings.Contains(stripANSI(row2), "working") {
 		t.Errorf("row 2 expected \"working\" label: %q", row2)
+	}
+}
+
+func TestRenderSessionCard_FocusedAndUnfocusedRow2_RightGroupAligns(t *testing.T) {
+	initStyles(Theme{
+		IconTmuxSession:  "⊞",
+		IconCfgSession:   "⚙︎",
+		IconStateWorking: "⟳",
+		ColorSelected:    "#2a2a4a",
+		ColorFgPrimary:   "#ffffff",
+	}, config.ProcessesConfig{}, nil)
+	mk := func(focused bool) string {
+		s := SidebarModel{
+			cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40, ShowLastSeen: true}},
+			sessions: []session.Session{{DisplayName: "alpha", IsLive: true, Activity: time.Now().Add(-5 * time.Minute)}},
+			states:   []db.ToolState{{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateWorking}},
+		}
+		return s.renderSessionCard(SidebarNode{Session: "alpha"}, focused, 40)
+	}
+	row2Focused := strings.Split(mk(true), "\n")[1]
+	row2Unfocused := strings.Split(mk(false), "\n")[1]
+	// The display width (after stripping ANSI) of row 2 should be equal in both
+	// states, since both render to the same column budget.
+	wFocused := runewidth.StringWidth(stripANSI(row2Focused))
+	wUnfocused := runewidth.StringWidth(stripANSI(row2Unfocused))
+	if wFocused != wUnfocused {
+		t.Errorf("row 2 display widths differ: focused=%d unfocused=%d (focused=%q unfocused=%q)",
+			wFocused, wUnfocused, row2Focused, row2Unfocused)
 	}
 }

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1215,7 +1215,7 @@ func TestSidebarViewport_CardMode_KeepsCursorVisible(t *testing.T) {
 func TestBuildSidebarLines_CardMode_EmitsSeparatorsBetween(t *testing.T) {
 	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
 	s := SidebarModel{
-		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: true, Width: 40}},
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: config.CardSeparatorBlank, Width: 40}},
 		nodes: []SidebarNode{
 			{Session: "alpha"}, {Session: "beta"}, {Session: "gamma"},
 		},
@@ -1245,7 +1245,7 @@ func TestBuildSidebarLines_CardMode_EmitsSeparatorsBetween(t *testing.T) {
 func TestBuildSidebarLines_CardMode_NoSeparatorBeforeScrollHint(t *testing.T) {
 	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
 	s := SidebarModel{
-		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: true, Width: 40}},
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: config.CardSeparatorBlank, Width: 40}},
 		nodes: []SidebarNode{
 			{Session: "alpha"}, {Session: "beta"}, {Session: "gamma"}, {Session: "delta"},
 		},
@@ -1278,7 +1278,7 @@ func TestBuildSidebarLines_CardMode_NoSeparatorBeforeScrollHint(t *testing.T) {
 func TestBuildSidebarLines_CardMode_NoSeparatorWhenDisabled(t *testing.T) {
 	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
 	s := SidebarModel{
-		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: false, Width: 40}},
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: config.CardSeparatorNone, Width: 40}},
 		nodes: []SidebarNode{
 			{Session: "alpha"}, {Session: "beta"}, {Session: "gamma"},
 		},
@@ -1298,6 +1298,30 @@ func TestBuildSidebarLines_CardMode_NoSeparatorWhenDisabled(t *testing.T) {
 		if strings.TrimSpace(stripANSI(l)) == "" {
 			t.Errorf("line %d unexpectedly blank: %q", i, l)
 		}
+	}
+}
+
+func TestBuildSidebarLines_CardMode_RuleSeparator(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", ColorBorder: lipgloss.Color("#313244")}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: config.CardSeparatorRule, Width: 40}},
+		nodes: []SidebarNode{
+			{Session: "alpha"}, {Session: "beta"},
+		},
+		sessions: []session.Session{
+			{DisplayName: "alpha", IsLive: true},
+			{DisplayName: "beta", IsLive: true},
+		},
+	}
+	centered := func(t string) string { return t }
+	// 2 cards: 3 + 2 = 5 rows.
+	lines := s.buildSidebarLines(0, 5, false, false, false, 40, centered)
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 lines, got %d", len(lines))
+	}
+	// Separator is line index 2 (after alpha r1, r2). Must contain the rule glyph.
+	if !strings.Contains(stripANSI(lines[2]), "─") {
+		t.Errorf("line 2 should contain rule glyph, got %q", stripANSI(lines[2]))
 	}
 }
 
@@ -1522,17 +1546,18 @@ func TestNodeHeight(t *testing.T) {
 	cases := []struct {
 		name      string
 		view      string
-		separator bool
+		separator string
 		isLast    bool
 		expected  int
 	}{
-		{"row mode any", config.SidebarViewRow, true, false, 1},
-		{"row mode last", config.SidebarViewRow, true, true, 1},
-		{"card mode non-last with separator", config.SidebarViewCard, true, false, 3},
-		{"card mode last with separator", config.SidebarViewCard, true, true, 2},
-		{"card mode non-last no separator", config.SidebarViewCard, false, false, 2},
-		{"card mode last no separator", config.SidebarViewCard, false, true, 2},
-		{"empty defaults row", "", true, false, 1},
+		{"row mode any", config.SidebarViewRow, config.CardSeparatorBlank, false, 1},
+		{"row mode last", config.SidebarViewRow, config.CardSeparatorBlank, true, 1},
+		{"card mode non-last with blank separator", config.SidebarViewCard, config.CardSeparatorBlank, false, 3},
+		{"card mode non-last with rule separator", config.SidebarViewCard, config.CardSeparatorRule, false, 3},
+		{"card mode last with separator", config.SidebarViewCard, config.CardSeparatorBlank, true, 2},
+		{"card mode non-last no separator", config.SidebarViewCard, config.CardSeparatorNone, false, 2},
+		{"card mode last no separator", config.SidebarViewCard, config.CardSeparatorNone, true, 2},
+		{"empty defaults row", "", config.CardSeparatorBlank, false, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1231,14 +1231,17 @@ func TestBuildSidebarLines_CardMode_EmitsSeparatorsBetween(t *testing.T) {
 	if len(lines) != 8 {
 		t.Fatalf("expected 8 lines, got %d: %v", len(lines), lines)
 	}
+	for _, idx := range []int{0, 3, 6} {
+		want := []string{"alpha", "beta", "gamma"}[idx/3]
+		if !strings.Contains(stripANSI(lines[idx]), want) {
+			t.Errorf("line %d should contain %q (card row 1), got %q", idx, want, lines[idx])
+		}
+	}
 	if strings.TrimSpace(stripANSI(lines[2])) != "" {
 		t.Errorf("line 2 should be blank separator, got %q", lines[2])
 	}
 	if strings.TrimSpace(stripANSI(lines[5])) != "" {
 		t.Errorf("line 5 should be blank separator, got %q", lines[5])
-	}
-	if strings.TrimSpace(stripANSI(lines[7])) == "" {
-		t.Errorf("line 7 (last card row 2) should not be blank: %q", lines[7])
 	}
 }
 
@@ -1267,8 +1270,8 @@ func TestBuildSidebarLines_CardMode_NoSeparatorBeforeScrollHint(t *testing.T) {
 	if strings.TrimSpace(stripANSI(lines[2])) != "" {
 		t.Errorf("line 2 should be separator between cards, got %q", lines[2])
 	}
-	if strings.TrimSpace(stripANSI(lines[4])) == "" {
-		t.Errorf("line 4 (beta r2) should not be blank: %q", lines[4])
+	if !strings.Contains(stripANSI(lines[3]), "beta") {
+		t.Errorf("line 3 (beta r1) should contain \"beta\", got %q", lines[3])
 	}
 	if !strings.Contains(lines[5], "▼") {
 		t.Errorf("line 5 should be ▼ hint, got %q", lines[5])
@@ -1294,9 +1297,9 @@ func TestBuildSidebarLines_CardMode_NoSeparatorWhenDisabled(t *testing.T) {
 	if len(lines) != 6 {
 		t.Fatalf("expected 6 lines, got %d: %v", len(lines), lines)
 	}
-	for i, l := range lines {
-		if strings.TrimSpace(stripANSI(l)) == "" {
-			t.Errorf("line %d unexpectedly blank: %q", i, l)
+	for i, name := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(stripANSI(lines[i*2]), name) {
+			t.Errorf("line %d should contain %q (card row 1), got %q", i*2, name, lines[i*2])
 		}
 	}
 }
@@ -1578,7 +1581,7 @@ func TestRenderSessionCard_Unfocused_Basic(t *testing.T) {
 		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40, ShowLastSeen: true}},
 		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
 	}
-	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, false, 40)
 	lines := strings.Split(out, "\n")
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d: %q", len(lines), out)
@@ -1599,8 +1602,8 @@ func TestRenderSessionCard_Focused_HighlightsBothRows(t *testing.T) {
 		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40, ShowLastSeen: true}},
 		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
 	}
-	focused := s.renderSessionCard(SidebarNode{Session: "alpha"}, true, 40)
-	unfocused := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
+	focused := s.renderSessionCard(SidebarNode{Session: "alpha"}, true, true, 40)
+	unfocused := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, false, 40)
 	fLines := strings.Split(focused, "\n")
 	uLines := strings.Split(unfocused, "\n")
 	if len(fLines) != 2 || len(uLines) != 2 {
@@ -1628,7 +1631,7 @@ func TestRenderSessionCard_IdleStateBlanksLeftGroup(t *testing.T) {
 		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
 		states:   []db.ToolState{{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateIdle}},
 	}
-	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, false, 40)
 	row2 := strings.Split(out, "\n")[1]
 	if strings.Contains(stripANSI(row2), "idle") {
 		t.Errorf("row 2 should not show \"idle\" label: %q", row2)
@@ -1645,10 +1648,46 @@ func TestRenderSessionCard_WorkingStateShowsLabel(t *testing.T) {
 		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
 		states:   []db.ToolState{{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateWorking}},
 	}
-	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, false, 40)
 	row2 := strings.Split(out, "\n")[1]
 	if !strings.Contains(stripANSI(row2), "working") {
 		t.Errorf("row 2 expected \"working\" label: %q", row2)
+	}
+}
+
+func TestRenderSessionCard_UnselectedHasNoFocusGlyph(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+	}
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, false, 40)
+	for i, l := range strings.Split(out, "\n") {
+		if strings.Contains(stripANSI(l), focusGlyph) {
+			t.Errorf("unselected card row %d should not contain focus glyph %q: %q", i+1, focusGlyph, l)
+		}
+	}
+}
+
+func TestRenderSessionCard_SelectedUnfocusedShowsGlyphWithoutBg(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+	initStyles(Theme{
+		IconTmuxSession: "⊞", IconCfgSession: "⚙︎",
+		ColorSelected: lipgloss.Color("#2a2a4a"), ColorSession: lipgloss.Color("#89dceb"),
+	}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+	}
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, true, false, 40)
+	for i, l := range strings.Split(out, "\n") {
+		if !strings.Contains(stripANSI(l), focusGlyph) {
+			t.Errorf("selected card row %d should contain focus glyph %q: %q", i+1, focusGlyph, stripANSI(l))
+		}
+		if strings.Contains(l, "\x1b[48") {
+			t.Errorf("selected-but-pane-unfocused row %d should not have background: %q", i+1, l)
+		}
 	}
 }
 
@@ -1666,7 +1705,7 @@ func TestRenderSessionCard_FocusedAndUnfocusedRow2_RightGroupAligns(t *testing.T
 			sessions: []session.Session{{DisplayName: "alpha", IsLive: true, Activity: time.Now().Add(-5 * time.Minute)}},
 			states:   []db.ToolState{{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateWorking}},
 		}
-		return s.renderSessionCard(SidebarNode{Session: "alpha"}, focused, 40)
+		return s.renderSessionCard(SidebarNode{Session: "alpha"}, focused, focused, 40)
 	}
 	row2Focused := strings.Split(mk(true), "\n")[1]
 	row2Unfocused := strings.Split(mk(false), "\n")[1]

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1149,11 +1149,16 @@ func TestSidebarViewport(t *testing.T) {
 		{"all fit", 0, 0, 10, 5, 0, 10, false, false},
 		{"scroll below", 0, 0, 5, 10, 0, 4, false, true},
 		{"cursor before offset", 2, 5, 10, 10, 2, 9, true, false},
-		{"cursor past viewport", 8, 0, 5, 10, 4, 3, true, true},
+		// New variable-height algorithm advances offset until the cursor truly
+		// fits in the post-hint contentRows. Old algorithm snapped to 4 which
+		// put the cursor outside the visible range; new algorithm picks 6 so
+		// the four remaining nodes (6,7,8,9) fill the post-hint viewport.
+		{"cursor past viewport", 8, 0, 5, 10, 6, 4, true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOffset, gotContent, gotAbove, gotBelow := sidebarViewport(tt.cursor, tt.offset, tt.visRows, tt.nodeCount)
+			rowHeight := func(i int, isLast bool) int { return 1 }
+			gotOffset, gotContent, gotAbove, gotBelow := sidebarViewport(tt.cursor, tt.offset, tt.visRows, tt.nodeCount, rowHeight)
 			if gotOffset != tt.wantOffset {
 				t.Errorf("offset: got %d, want %d", gotOffset, tt.wantOffset)
 			}
@@ -1167,6 +1172,54 @@ func TestSidebarViewport(t *testing.T) {
 				t.Errorf("hasBelow: got %v, want %v", gotBelow, tt.wantBelow)
 			}
 		})
+	}
+}
+
+func TestSidebarViewport_CardMode_KeepsCursorVisible(t *testing.T) {
+	heightFn := func(i int, isLast bool) int {
+		if isLast {
+			return 2
+		}
+		return 3
+	}
+	offset, contentRows, hasAbove, hasBelow := sidebarViewport(3, 0, 8, 5, heightFn)
+	if offset == 0 {
+		t.Errorf("expected offset > 0 to bring cursor 3 into view, got %d", offset)
+	}
+	if contentRows < 1 {
+		t.Errorf("contentRows should be >= 1, got %d", contentRows)
+	}
+	_ = hasAbove
+	_ = hasBelow
+}
+
+func TestBuildSidebarLines_CardMode_EmitsSeparatorsBetween(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		nodes: []SidebarNode{
+			{Session: "alpha"}, {Session: "beta"}, {Session: "gamma"},
+		},
+		sessions: []session.Session{
+			{DisplayName: "alpha", IsLive: true},
+			{DisplayName: "beta", IsLive: true},
+			{DisplayName: "gamma", IsLive: true},
+		},
+	}
+	centered := func(t string) string { return t }
+	// Visible rows: 3 + 3 + 2 = 8 (alpha card, beta card, gamma card with no trailing separator).
+	lines := s.buildSidebarLines(0, 8, false, false, false, 40, centered)
+	if len(lines) != 8 {
+		t.Fatalf("expected 8 lines, got %d: %v", len(lines), lines)
+	}
+	if strings.TrimSpace(stripANSI(lines[2])) != "" {
+		t.Errorf("line 2 should be blank separator, got %q", lines[2])
+	}
+	if strings.TrimSpace(stripANSI(lines[5])) != "" {
+		t.Errorf("line 5 should be blank separator, got %q", lines[5])
+	}
+	if strings.TrimSpace(stripANSI(lines[7])) == "" {
+		t.Errorf("line 7 (last card row 2) should not be blank: %q", lines[7])
 	}
 }
 

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1384,3 +1384,27 @@ func TestSidebar_ResolveProcLabelColors_FallsBackToThemeDefaults(t *testing.T) {
 		t.Fatalf("expected theme fallback, got fg=%v bg=%v", fg, bg)
 	}
 }
+
+func TestNodeHeight(t *testing.T) {
+	cases := []struct {
+		name     string
+		view     string
+		isLast   bool
+		expected int
+	}{
+		{"row mode any", config.SidebarViewRow, false, 1},
+		{"row mode last", config.SidebarViewRow, true, 1},
+		{"card mode non-last", config.SidebarViewCard, false, 3},
+		{"card mode last", config.SidebarViewCard, true, 2},
+		{"empty defaults row", "", false, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := SidebarModel{cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: tc.view}}}
+			got := s.nodeHeight(SidebarNode{Session: "x"}, tc.isLast)
+			if got != tc.expected {
+				t.Errorf("nodeHeight(view=%q, isLast=%v): got %d, want %d", tc.view, tc.isLast, got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1408,3 +1408,78 @@ func TestNodeHeight(t *testing.T) {
 		})
 	}
 }
+
+// --- renderSessionCard ---
+
+func TestRenderSessionCard_Unfocused_Basic(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40, ShowLastSeen: true}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+	}
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), out)
+	}
+	if !strings.Contains(stripANSI(lines[0]), "alpha") {
+		t.Errorf("row 1 missing session name: %q", lines[0])
+	}
+}
+
+func TestRenderSessionCard_Focused_HighlightsBothRows(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", ColorSelected: lipgloss.Color("#2a2a4a"), ColorFgPrimary: lipgloss.Color("#ffffff")}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40, ShowLastSeen: true}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+	}
+	// Compare focused vs unfocused output: focused must differ (highlight
+	// styling extends the background to the row's full inner width on both
+	// rows, so the rendered strings can't be identical).
+	focused := s.renderSessionCard(SidebarNode{Session: "alpha"}, true, 40)
+	unfocused := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
+	fLines := strings.Split(focused, "\n")
+	uLines := strings.Split(unfocused, "\n")
+	if len(fLines) != 2 {
+		t.Fatalf("expected 2 focused lines, got %d", len(fLines))
+	}
+	if len(uLines) != 2 {
+		t.Fatalf("expected 2 unfocused lines, got %d", len(uLines))
+	}
+	for i := 0; i < 2; i++ {
+		if fLines[i] == uLines[i] {
+			t.Errorf("row %d: focused and unfocused output identical, expected highlight to differ: %q", i+1, fLines[i])
+		}
+	}
+}
+
+func TestRenderSessionCard_IdleStateBlanksLeftGroup(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", IconStateIdle: "○"}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+		states:   []db.ToolState{{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateIdle}},
+	}
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
+	row2 := strings.Split(out, "\n")[1]
+	if strings.Contains(stripANSI(row2), "idle") {
+		t.Errorf("row 2 should not show \"idle\" label: %q", row2)
+	}
+	if strings.Contains(stripANSI(row2), activeTheme.IconStateIdle) {
+		t.Errorf("row 2 should not show idle icon: %q", row2)
+	}
+}
+
+func TestRenderSessionCard_WorkingStateShowsLabel(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", IconStateWorking: "⟳"}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+		states:   []db.ToolState{{Target: db.Target{Type: db.TargetTypeSession, ID: "alpha"}, Value: db.StateWorking}},
+	}
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, 40)
+	row2 := strings.Split(out, "\n")[1]
+	if !strings.Contains(stripANSI(row2), "working") {
+		t.Errorf("row 2 expected \"working\" label: %q", row2)
+	}
+}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1215,7 +1215,7 @@ func TestSidebarViewport_CardMode_KeepsCursorVisible(t *testing.T) {
 func TestBuildSidebarLines_CardMode_EmitsSeparatorsBetween(t *testing.T) {
 	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
 	s := SidebarModel{
-		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: true, Width: 40}},
 		nodes: []SidebarNode{
 			{Session: "alpha"}, {Session: "beta"}, {Session: "gamma"},
 		},
@@ -1245,7 +1245,7 @@ func TestBuildSidebarLines_CardMode_EmitsSeparatorsBetween(t *testing.T) {
 func TestBuildSidebarLines_CardMode_NoSeparatorBeforeScrollHint(t *testing.T) {
 	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
 	s := SidebarModel{
-		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: true, Width: 40}},
 		nodes: []SidebarNode{
 			{Session: "alpha"}, {Session: "beta"}, {Session: "gamma"}, {Session: "delta"},
 		},
@@ -1272,6 +1272,32 @@ func TestBuildSidebarLines_CardMode_NoSeparatorBeforeScrollHint(t *testing.T) {
 	}
 	if !strings.Contains(lines[5], "▼") {
 		t.Errorf("line 5 should be ▼ hint, got %q", lines[5])
+	}
+}
+
+func TestBuildSidebarLines_CardMode_NoSeparatorWhenDisabled(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, CardSeparator: false, Width: 40}},
+		nodes: []SidebarNode{
+			{Session: "alpha"}, {Session: "beta"}, {Session: "gamma"},
+		},
+		sessions: []session.Session{
+			{DisplayName: "alpha", IsLive: true},
+			{DisplayName: "beta", IsLive: true},
+			{DisplayName: "gamma", IsLive: true},
+		},
+	}
+	centered := func(t string) string { return t }
+	// With separators off, each card consumes exactly 2 rows: 3 cards × 2 = 6.
+	lines := s.buildSidebarLines(0, 6, false, false, false, 40, centered)
+	if len(lines) != 6 {
+		t.Fatalf("expected 6 lines, got %d: %v", len(lines), lines)
+	}
+	for i, l := range lines {
+		if strings.TrimSpace(stripANSI(l)) == "" {
+			t.Errorf("line %d unexpectedly blank: %q", i, l)
+		}
 	}
 }
 
@@ -1494,23 +1520,26 @@ func TestSidebar_ResolveProcLabelColors_FallsBackToThemeDefaults(t *testing.T) {
 
 func TestNodeHeight(t *testing.T) {
 	cases := []struct {
-		name     string
-		view     string
-		isLast   bool
-		expected int
+		name      string
+		view      string
+		separator bool
+		isLast    bool
+		expected  int
 	}{
-		{"row mode any", config.SidebarViewRow, false, 1},
-		{"row mode last", config.SidebarViewRow, true, 1},
-		{"card mode non-last", config.SidebarViewCard, false, 3},
-		{"card mode last", config.SidebarViewCard, true, 2},
-		{"empty defaults row", "", false, 1},
+		{"row mode any", config.SidebarViewRow, true, false, 1},
+		{"row mode last", config.SidebarViewRow, true, true, 1},
+		{"card mode non-last with separator", config.SidebarViewCard, true, false, 3},
+		{"card mode last with separator", config.SidebarViewCard, true, true, 2},
+		{"card mode non-last no separator", config.SidebarViewCard, false, false, 2},
+		{"card mode last no separator", config.SidebarViewCard, false, true, 2},
+		{"empty defaults row", "", true, false, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s := SidebarModel{cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: tc.view}}}
+			s := SidebarModel{cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: tc.view, CardSeparator: tc.separator}}}
 			got := s.nodeHeight(SidebarNode{Session: "x"}, tc.isLast)
 			if got != tc.expected {
-				t.Errorf("nodeHeight(view=%q, isLast=%v): got %d, want %d", tc.view, tc.isLast, got, tc.expected)
+				t.Errorf("nodeHeight(view=%q, sep=%v, isLast=%v): got %d, want %d", tc.view, tc.separator, tc.isLast, got, tc.expected)
 			}
 		})
 	}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1182,15 +1182,34 @@ func TestSidebarViewport_CardMode_KeepsCursorVisible(t *testing.T) {
 		}
 		return 3
 	}
-	offset, contentRows, hasAbove, hasBelow := sidebarViewport(3, 0, 8, 5, heightFn)
-	if offset == 0 {
-		t.Errorf("expected offset > 0 to bring cursor 3 into view, got %d", offset)
+	// Setup: 5 nodes with heights [3, 3, 3, 3, 2], cursor=3, visibleRows=8.
+	// The viewport must advance offset until the cursor fits inside the
+	// budget (which shrinks by 1 for ▲ and another 1 for ▼). With offset=2
+	// and contentRows=6 (8 - 1 ▲ - 1 ▼), heights [3, 3] from offset 2 sum to
+	// 6 and include cursor 3 — first offset where this works.
+	const cursor = 3
+	const nodeCount = 5
+	offset, contentRows, hasAbove, hasBelow := sidebarViewport(cursor, 0, 8, nodeCount, heightFn)
+	if offset != 2 {
+		t.Errorf("offset: got %d, want 2", offset)
 	}
-	if contentRows < 1 {
-		t.Errorf("contentRows should be >= 1, got %d", contentRows)
+	if contentRows != 6 {
+		t.Errorf("contentRows: got %d, want 6", contentRows)
 	}
-	_ = hasAbove
-	_ = hasBelow
+	if !hasAbove {
+		t.Errorf("hasAbove: got false, want true (offset > 0)")
+	}
+	if !hasBelow {
+		t.Errorf("hasBelow: got false, want true (nodes beyond visible)")
+	}
+	// Sanity check: cursor must fall within the range of fitting nodes.
+	consumed, cursorFits := countFit(offset, nodeCount, cursor, contentRows, heightFn)
+	if !cursorFits {
+		t.Errorf("cursor %d should fit in [%d, %d)", cursor, offset, consumed)
+	}
+	if cursor < offset || cursor >= consumed {
+		t.Errorf("cursor %d outside fitting range [%d, %d)", cursor, offset, consumed)
+	}
 }
 
 func TestBuildSidebarLines_CardMode_EmitsSeparatorsBetween(t *testing.T) {
@@ -1220,6 +1239,39 @@ func TestBuildSidebarLines_CardMode_EmitsSeparatorsBetween(t *testing.T) {
 	}
 	if strings.TrimSpace(stripANSI(lines[7])) == "" {
 		t.Errorf("line 7 (last card row 2) should not be blank: %q", lines[7])
+	}
+}
+
+func TestBuildSidebarLines_CardMode_NoSeparatorBeforeScrollHint(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		nodes: []SidebarNode{
+			{Session: "alpha"}, {Session: "beta"}, {Session: "gamma"}, {Session: "delta"},
+		},
+		sessions: []session.Session{
+			{DisplayName: "alpha", IsLive: true},
+			{DisplayName: "beta", IsLive: true},
+			{DisplayName: "gamma", IsLive: true},
+			{DisplayName: "delta", IsLive: true},
+		},
+	}
+	centered := func(t string) string { return "▼" }
+	// Render only first 2 cards with hasBelow=true. contentRows budget = 6 (2 cards × 3 rows each).
+	// Expected lines (with hasBelow appending the ▼ hint): alpha-r1, alpha-r2, blank, beta-r1, beta-r2, then ▼.
+	// No blank between beta-r2 and ▼.
+	lines := s.buildSidebarLines(0, 6, false, true, false, 40, centered)
+	if len(lines) != 6 {
+		t.Fatalf("expected 6 lines, got %d: %v", len(lines), lines)
+	}
+	if strings.TrimSpace(stripANSI(lines[2])) != "" {
+		t.Errorf("line 2 should be separator between cards, got %q", lines[2])
+	}
+	if strings.TrimSpace(stripANSI(lines[4])) == "" {
+		t.Errorf("line 4 (beta r2) should not be blank: %q", lines[4])
+	}
+	if !strings.Contains(lines[5], "▼") {
+		t.Errorf("line 5 should be ▼ hint, got %q", lines[5])
 	}
 }
 

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1520,3 +1520,21 @@ func TestRenderSessionCard_FocusedAndUnfocusedRow2_RightGroupAligns(t *testing.T
 			wFocused, wUnfocused, row2Focused, row2Unfocused)
 	}
 }
+
+func TestRenderSession_DispatchesByView(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎"}, config.ProcessesConfig{}, nil)
+	mkModel := func(view string) SidebarModel {
+		return SidebarModel{
+			cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: view, Width: 40}},
+			sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+		}
+	}
+	rowOut := mkModel(config.SidebarViewRow).renderSession(SidebarNode{Session: "alpha"}, false, false, 40)
+	cardOut := mkModel(config.SidebarViewCard).renderSession(SidebarNode{Session: "alpha"}, false, false, 40)
+	if strings.Contains(rowOut, "\n") {
+		t.Errorf("row view should be single line: %q", rowOut)
+	}
+	if !strings.Contains(cardOut, "\n") {
+		t.Errorf("card view should be multi-line: %q", cardOut)
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -58,6 +58,7 @@ var (
 
 	// Selection
 	selectedBG       lipgloss.Style
+	selectedSession  lipgloss.Style
 	selectedInactive lipgloss.Style
 
 	// Tree connectors
@@ -118,6 +119,7 @@ func initStyles(t Theme, procs config.ProcessesConfig, ignoredProcs []string) {
 	statValueStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
 
 	selectedBG = lipgloss.NewStyle().Background(t.ColorSelected).Foreground(t.ColorFgPrimary)
+	selectedSession = lipgloss.NewStyle().Foreground(t.ColorSession).Background(t.ColorSelected)
 	selectedInactive = lipgloss.NewStyle().Foreground(t.ColorSession)
 
 	treeConnectorStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)


### PR DESCRIPTION
## Context

The sidebar currently renders each session as a single row. With more indicators (proc label, git, todos, last-seen, state), the row becomes cramped on narrow widths and forces truncation of the session name. This PR adds an opt-in two-row "card" view that gives state and metadata their own line.

The new view is controlled by `sidebar.session_view` with per-mode overrides (`session_view_mode_compact`, `session_view_mode_full`) so users can keep the dense row view in compact mode and switch to cards in full mode (or vice-versa).

## What does this PR do

- **Config**: adds `sidebar.session_view` (`row`/`card`), per-mode overrides, and `sidebar.card_separator` (`none`/`blank`/`rule`). Validates inputs and warns on invalid values. Exports `SidebarViewRow`/`SidebarViewCard`/`CardSeparator*` constants from `internal/config`. Documents fields in README and `demux config init` template.
- **Sidebar**: dispatches to `renderSessionCard` when card view is resolved. Card layout:
  - **header row**: focus glyph, active indicator, session icon, name (marquee on focus when overflow), watch indicator
  - **status row**: state icon + label (left) and proc/git/todo/last-seen (right) with justify-between spacing
- **Variable-height nodes**: introduces `nodeHeight()` and a reusable `countFit()` walker so `sidebarViewport` and `clampViewport` handle 2-row cards (with optional separator row) without dropping the cursor.
- **Card separator**: `blank` (default) emits an empty row between cards; `rule` emits a horizontal `─` in the border color; `none` packs cards flush.
- **Polish**: focus glyph hidden on unselected cards, 1-space right padding preserved on the status row when unfocused, em-dash removed from comments, viewport math tightened to suppress a spurious separator row before the `▼` scroll hint.
- **Refactor**: extracts `visualWidth`, `selectedSession`, `activeIndicator`/`activeIconChar` helpers; simplifies the right-group indicator collection; renames `renderCardRow1`/`Row2` → `renderCardHeader`/`Status`.

<img width="714" height="851" alt="image" src="https://github.com/user-attachments/assets/3f94964b-d95b-4615-92e2-23ffeb436a8f" />

## Manual QA

- [ ] `go test ./...` — all 616 tests pass.
- [ ] Run \`demux\` with default config; sidebar still renders single-row sessions, no regression in cursor scroll, marquee, or filter shortcuts.
- [ ] Set \`session_view = \"card\"\` in \`~/.config/demux/demux.toml\`; relaunch. Verify each session renders as 2 rows + blank separator.
- [ ] Resize terminal narrow (≤30 cols); confirm card name truncates rather than wrapping or overflowing the border.
- [ ] Set \`card_separator = \"none\"\`; verify no row between cards.
- [ ] Set \`card_separator = \"rule\"\`; verify horizontal line renders in border color.
- [ ] Toggle compact mode (\`Ctrl-c\`) with \`session_view = \"card\"\` and \`session_view_mode_compact = \"row\"\`; confirm compact mode falls back to row layout while full mode stays card.
- [ ] Scroll the cursor to the bottom of a long session list in card view; verify the last visible card is not followed by a stray separator row before the \`▼\` hint.
- [ ] Attach to one of the sessions; the active indicator (\`►\`) renders on its card header in the session color.
- [ ] Focus the sidebar pane and move the cursor across cards; verify highlight bar spans the full card width on both header and status rows and the focus glyph only appears on the selected card.
- [ ] Set an invalid value (e.g. \`session_view = \"big\"\`); confirm stderr warning and fallback to \`row\`.