### PR TITLE
feat(sticky): sticky sidebar — follow, slots, MRU, hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,73 @@ shells = ["zsh", "bash", "sh", "fish", "dash", "nu", "pwsh"]
 
 </details>
 
+## Sticky sidebar
+
+The sticky sidebar is a per-client tmux pane that runs `demux --sticky`
+(compact mode + card session view, with the quit binding disabled) and
+physically follows you between tmux sessions. It is created and dismissed
+through the `demux sidebar` subcommand and is **off by default**.
+
+### Lifecycle
+
+```bash
+demux sidebar toggle   # show if hidden, hide if shown
+demux sidebar show     # idempotent: create if missing
+demux sidebar hide     # idempotent: kill if present
+```
+
+All three require the invoking shell to be inside tmux (`$TMUX` set). Running
+them outside tmux exits with status 1.
+
+Internally, `demux sidebar follow` is invoked by a tmux hook on
+`client-session-changed`; it physically moves the existing pane (preserving
+its current width) into the newly attached session.
+
+### Enable the auto-show + follow hooks
+
+Run `demux hooks init --tool tmux` and paste the snippet into your
+`~/.tmux.conf`, then reload tmux:
+
+```bash
+demux hooks init --tool tmux >> ~/.tmux.conf
+tmux source ~/.tmux.conf
+```
+
+The snippet now includes two extra lines:
+
+- `set-hook -ga client-session-changed "run-shell 'demux sidebar follow ...'"`
+  moves the sidebar pane to whichever session you switch into.
+- `set-hook -ga client-attached "run-shell 'demux sidebar show ...'"`
+  creates the sidebar pane automatically when you attach a tmux client.
+
+If you prefer to manage the sidebar manually with `demux sidebar toggle`,
+remove the `client-attached` line. The `client-session-changed` line is
+required for the "follow" behavior; without it the sidebar stays in
+whichever session it was created in.
+
+### Configuration
+
+```toml
+[sidebar.sticky]
+# Initial width (columns) the first time the pane is created. After that,
+# resize it normally with tmux (e.g. `prefix + <` or mouse drag); the width
+# is preserved on every session move.
+width = 35
+```
+
+### Notes and limitations
+
+- The sticky sidebar is **per-client**: each attached client owns its own
+  pane. Two clients attached to the same session may end up with two sidebar
+  panes side by side; close either with `prefix x`.
+- The sidebar follows session switches, not window switches. Within a single
+  session, switching windows leaves the sidebar in whichever window it last
+  landed in.
+- Tmux 2.6 or newer is required (uses the `-f` flag on `split-window` /
+  `join-pane`).
+- `demux --sticky` is not intended for interactive standalone use; the quit
+  binding is disabled. Use `demux sidebar hide` to dismiss it.
+
 ## Sessions
 
 Define sessions in `~/.config/demux/sessions.toml`. Sensitive or machine-specific entries (e.g. paths that differ per machine) can go in `~/.config/demux/private.toml` instead, which you can safely exclude from version control.

--- a/README.md
+++ b/README.md
@@ -691,36 +691,67 @@ which shows up as a one-frame flicker.
 Set `[sidebar.sticky] slots = true` and the sidebar switches to a different
 strategy:
 
-- A **slot pane** is created in every window (one extra pane each, running
-  `demux sidebar slot` as a quiet placeholder).
+- Up to **8 slot panes** are maintained server-wide, in the most recently used
+  windows (plus the current window's own sidebar pane). Each slot runs
+  `demux sidebar slot` as a quiet placeholder.
 - Each slot is tagged with the tmux user option `@demux_slot=1` and titled
   `demux-slot` so you can recognize it (visible if you have
   `set -g pane-border-status top` in your tmux config).
-- On window/session switch, the active sidebar pane is **swapped** with the
-  destination window's slot via `swap-pane -d`. No layout rebuild, no
-  flicker. Width is preserved via a follow-up `resize-pane`.
+- On window/session switch to a window that already has a slot, the active
+  sidebar pane is **swapped** with that slot via `swap-pane -d`. No layout
+  rebuild, no flicker. Width is preserved via a follow-up `resize-pane`.
+- Switching to a window that fell out of the MRU triggers a one-time
+  `split-window` to recreate its slot, then the swap; that window enters the
+  MRU and is flicker-free on subsequent visits.
+
+#### Reserved-set priority
+
+After each switch, demux recomputes which windows keep a placeholder slot.
+Priority (highest first), capped at 8 total:
+
+1. The current session's `window_last_flag=1` window (tmux's "last window").
+2. The client's last-attached session's active window.
+3. Other windows in the current session, ordered by MRU then tmux index.
+4. Cross-session windows from the MRU.
+
+The current window itself is excluded (it holds the sidebar, not a
+placeholder). Slots in windows that fall out of the reserved set are killed
+to free their PTY.
+
+#### Pre-join on demux navigation
+
+When you connect to a session or pane through the demux TUI (`o`, `Enter`),
+demux installs the destination's slot **before** issuing the tmux switch, so
+the after-select-window follow swaps in without any flicker even for windows
+not currently in the MRU.
 
 Lifecycle for slots mode:
 
 ```bash
-demux sidebar show              # installs slots + activates current window's slot
+demux sidebar show              # installs slots in MRU + activates current window's slot
 demux sidebar hide              # removes every slot pane (full teardown)
-demux sidebar slots install     # idempotent: ensure every window has a slot
+demux sidebar slots install     # idempotent: ensure every reserved window has a slot
 demux sidebar slots uninstall   # remove every slot pane
 ```
 
 The tmux snippet from `demux hooks init --tool tmux` already includes an
-`after-new-window` hook that auto-creates a slot in any newly created window
-(no-op when `slots = false`).
+`after-new-window` hook that reconciles the slot set when a new window
+appears (no-op when `slots = false`).
 
 Trade-offs:
 
-- Cost: one extra pane per window. Each runs a tiny demux process that
-  ignores `SIGINT`/`SIGTERM` so casual Ctrl+C doesn't kill the slot. Use
-  `prefix x` (tmux kill-pane) or `demux sidebar slots uninstall` to remove.
+- Cost: at most 8 placeholder panes + 1 active sidebar pane server-wide,
+  regardless of how many windows you have open. Each placeholder runs a tiny
+  demux process that ignores `SIGINT`/`SIGTERM` so casual Ctrl+C doesn't kill
+  the slot. Use `prefix x` (tmux kill-pane) or `demux sidebar slots
+  uninstall` to remove.
 - Slots in windows whose pane layout doesn't naturally accommodate a left
   column will resize the existing panes to make room. Run `slots uninstall`
   to revert.
+- Why 8? macOS caps total PTYs at `kern.tty.ptmx_max=511` by default; a
+  server-wide one-slot-per-window scheme exhausts that cap fast on heavy
+  multi-session setups. 8 covers typical navigation patterns while leaving
+  comfortable headroom.
 
 ### Notes and limitations
 

--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@ Lifecycle for slots mode:
 
 ```bash
 demux sidebar show              # installs slots + activates current window's slot
-demux sidebar hide              # deactivates (slot stays as placeholder)
+demux sidebar hide              # removes every slot pane (full teardown)
 demux sidebar slots install     # idempotent: ensure every window has a slot
 demux sidebar slots uninstall   # remove every slot pane
 ```

--- a/README.md
+++ b/README.md
@@ -678,7 +678,49 @@ and window it was created in.
 # resize it normally with tmux (e.g. `prefix + <` or mouse drag); the width
 # is preserved on every session move.
 width = 35
+# Opt in to slots mode (see below).
+slots = false
 ```
+
+### Slots mode (opt-in, no follow flicker)
+
+By default, `follow` uses `join-pane` to physically move the sidebar pane
+across sessions and windows. Tmux briefly redraws the destination layout,
+which shows up as a one-frame flicker.
+
+Set `[sidebar.sticky] slots = true` and the sidebar switches to a different
+strategy:
+
+- A **slot pane** is created in every window (one extra pane each, running
+  `demux sidebar slot` as a quiet placeholder).
+- Each slot is tagged with the tmux user option `@demux_slot=1` and titled
+  `demux-slot` so you can recognize it (visible if you have
+  `set -g pane-border-status top` in your tmux config).
+- On window/session switch, the active sidebar pane is **swapped** with the
+  destination window's slot via `swap-pane -d`. No layout rebuild, no
+  flicker. Width is preserved via a follow-up `resize-pane`.
+
+Lifecycle for slots mode:
+
+```bash
+demux sidebar show              # installs slots + activates current window's slot
+demux sidebar hide              # deactivates (slot stays as placeholder)
+demux sidebar slots install     # idempotent: ensure every window has a slot
+demux sidebar slots uninstall   # remove every slot pane
+```
+
+The tmux snippet from `demux hooks init --tool tmux` already includes an
+`after-new-window` hook that auto-creates a slot in any newly created window
+(no-op when `slots = false`).
+
+Trade-offs:
+
+- Cost: one extra pane per window. Each runs a tiny demux process that
+  ignores `SIGINT`/`SIGTERM` so casual Ctrl+C doesn't kill the slot. Use
+  `prefix x` (tmux kill-pane) or `demux sidebar slots uninstall` to remove.
+- Slots in windows whose pane layout doesn't naturally accommodate a left
+  column will resize the existing panes to make room. Run `slots uninstall`
+  to revert.
 
 ### Notes and limitations
 
@@ -686,7 +728,8 @@ width = 35
   pane. Two clients attached to the same session may end up with two sidebar
   panes side by side; close either with `prefix x`.
 - The sidebar follows both session and window switches; focus is preserved
-  on the user's previously active pane via the `-d` flag on `join-pane`.
+  on the user's previously active pane via the `-d` flag on `join-pane` /
+  `swap-pane`.
 - Tmux 2.6 or newer is required (uses the `-f` flag on `split-window` /
   `join-pane`).
 - `demux --sticky` is not intended for interactive standalone use; the quit

--- a/README.md
+++ b/README.md
@@ -656,17 +656,19 @@ demux hooks init --tool tmux >> ~/.tmux.conf
 tmux source ~/.tmux.conf
 ```
 
-The snippet now includes two extra lines:
+The snippet now includes three extra lines:
 
 - `set-hook -ga client-session-changed "run-shell 'demux sidebar follow ...'"`
   moves the sidebar pane to whichever session you switch into.
+- `set-hook -ga after-select-window "run-shell 'demux sidebar follow ...'"`
+  moves the sidebar pane to whichever window you switch into (same session).
 - `set-hook -ga client-attached "run-shell 'demux sidebar show ...'"`
   creates the sidebar pane automatically when you attach a tmux client.
 
 If you prefer to manage the sidebar manually with `demux sidebar toggle`,
-remove the `client-attached` line. The `client-session-changed` line is
-required for the "follow" behavior; without it the sidebar stays in
-whichever session it was created in.
+remove the `client-attached` line. The two `follow` lines are required for
+the "follow" behavior; without them the sidebar stays in whichever session
+and window it was created in.
 
 ### Configuration
 
@@ -683,9 +685,8 @@ width = 35
 - The sticky sidebar is **per-client**: each attached client owns its own
   pane. Two clients attached to the same session may end up with two sidebar
   panes side by side; close either with `prefix x`.
-- The sidebar follows session switches, not window switches. Within a single
-  session, switching windows leaves the sidebar in whichever window it last
-  landed in.
+- The sidebar follows both session and window switches; focus is preserved
+  on the user's previously active pane via the `-d` flag on `join-pane`.
 - Tmux 2.6 or newer is required (uses the `-f` flag on `split-window` /
   `join-pane`).
 - `demux --sticky` is not intended for interactive standalone use; the quit

--- a/README.md
+++ b/README.md
@@ -656,17 +656,20 @@ demux hooks init --tool tmux >> ~/.tmux.conf
 tmux source ~/.tmux.conf
 ```
 
-The snippet now includes three extra lines:
+The snippet now includes four extra lines:
 
 - `set-hook -ga client-session-changed "run-shell 'demux sidebar follow ...'"`
   moves the sidebar pane to whichever session you switch into.
 - `set-hook -ga after-select-window "run-shell 'demux sidebar follow ...'"`
   moves the sidebar pane to whichever window you switch into (same session).
+- `set-hook -ga after-new-window "run-shell 'demux sidebar follow ...'"`
+  moves the sidebar pane into a window you just created. tmux does not fire
+  `after-select-window` for `new-window`, so this hook is needed separately.
 - `set-hook -ga client-attached "run-shell 'demux sidebar show ...'"`
   creates the sidebar pane automatically when you attach a tmux client.
 
 If you prefer to manage the sidebar manually with `demux sidebar toggle`,
-remove the `client-attached` line. The two `follow` lines are required for
+remove the `client-attached` line. The three `follow` lines are required for
 the "follow" behavior; without them the sidebar stays in whichever session
 and window it was created in.
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -94,6 +94,17 @@ session_view_mode_full = ""
 #   rule   — horizontal rule ('─') in the border color
 card_separator = "blank"
 
+# Sticky sidebar - a per-client tmux pane that runs 'demux --sticky' and
+# follows the attached client across session switches.
+# Controlled via:
+#   demux sidebar toggle   (or show/hide)
+# See README "Sticky sidebar" section for the tmux hook snippet that auto-shows
+# the sidebar on attach.
+[sidebar.sticky]
+# Initial width (columns) the first time the pane is created. After that, the
+# user resizes the pane normally; the width is preserved on every session move.
+width = 35
+
 # Sidebar process labels — render a single highest-count label per session.
 # Globs match either the process name or any whitespace-separated token of the
 # full cmdline (case-insensitive). Only the pane root and its direct children

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -104,6 +104,11 @@ card_separator = "blank"
 # Initial width (columns) the first time the pane is created. After that, the
 # user resizes the pane normally; the width is preserved on every session move.
 width = 35
+# Opt in to slots mode: pre-create a reserved sidebar pane in every window
+# (tagged with the @demux_slot tmux option and titled "demux-slot"). The
+# sticky sidebar swaps between slots on window/session switch, avoiding the
+# brief layout flicker of join-pane. Cost: one extra pane per window.
+# slots = false
 
 # Sidebar process labels — render a single highest-count label per session.
 # Globs match either the process name or any whitespace-separated token of the

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rtalexk/demux/internal/db"
 	demuxlog "github.com/rtalexk/demux/internal/log"
+	"github.com/rtalexk/demux/internal/sticky"
 	"github.com/spf13/cobra"
 )
 
@@ -161,7 +162,19 @@ var eventPaneClosedCmd = &cobra.Command{
 func applyPaneClosed(d *db.DB, paneID string) error {
 	demuxlog.Debug("pane_closed", "pane_id", paneID)
 	t := db.Target{Type: db.TargetTypePane, ID: paneID, PaneID: paneID}
-	return d.StateClear(t)
+	if err := d.StateClear(t); err != nil {
+		return err
+	}
+	if err := sticky.ClearStickyEnvForPane(stickyTmuxForEvents(), paneID); err != nil {
+		demuxlog.Warn("pane_closed: sticky env cleanup failed", "pane_id", paneID, "err", err)
+	}
+	return nil
+}
+
+// stickyTmuxForEvents is a swappable real-tmux instance so tests can inject a
+// fake without going through global state.
+var stickyTmuxForEvents = func() sticky.Tmux {
+	return sticky.New().T
 }
 
 func init() {

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -145,6 +145,7 @@ func applyHookErrorDB(d *db.DB, targetID, tool, hook, message string) error {
 }
 
 var eventPaneClosedPaneID string
+var eventPaneClosedWindowID string
 
 var eventPaneClosedCmd = &cobra.Command{
 	Use:   "pane_closed",
@@ -155,18 +156,24 @@ var eventPaneClosedCmd = &cobra.Command{
 			return err
 		}
 		defer d.Close()
-		return applyPaneClosed(d, eventPaneClosedPaneID)
+		return applyPaneClosed(d, eventPaneClosedPaneID, eventPaneClosedWindowID)
 	},
 }
 
-func applyPaneClosed(d *db.DB, paneID string) error {
-	demuxlog.Debug("pane_closed", "pane_id", paneID)
+func applyPaneClosed(d *db.DB, paneID, windowID string) error {
+	demuxlog.Debug("pane_closed", "pane_id", paneID, "window_id", windowID)
 	t := db.Target{Type: db.TargetTypePane, ID: paneID, PaneID: paneID}
 	if err := d.StateClear(t); err != nil {
 		return err
 	}
-	if err := sticky.ClearStickyEnvForPane(stickyTmuxForEvents(), paneID); err != nil {
+	tmuxClient := stickyTmuxForEvents()
+	if err := sticky.ClearStickyEnvForPane(tmuxClient, paneID); err != nil {
 		demuxlog.Warn("pane_closed: sticky env cleanup failed", "pane_id", paneID, "err", err)
+	}
+	if windowID != "" {
+		if err := (&sticky.Sticky{T: tmuxClient}).HandleWindowAfterKill(windowID); err != nil {
+			demuxlog.Warn("pane_closed: orphan slot cleanup failed", "window_id", windowID, "err", err)
+		}
 	}
 	return nil
 }
@@ -193,6 +200,7 @@ func init() {
 	eventHookErrorCmd.MarkFlagRequired("hook")
 
 	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedPaneID, "pane", "", "Stable pane ID (%N format) of the closed pane (required)")
+	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedWindowID, "window", "", "Stable window ID (@N format) of the killed pane's window (optional)")
 	eventPaneClosedCmd.MarkFlagRequired("pane")
 
 	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneClosedCmd)

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -144,6 +144,20 @@ func applyHookErrorDB(d *db.DB, targetID, tool, hook, message string) error {
 	return nil
 }
 
+var eventPaneExitingPaneID string
+var eventPaneExitingWindowID string
+
+var eventPaneExitingCmd = &cobra.Command{
+	Use:   "pane_exiting",
+	Short: "Eject sidebar if it would be stranded by an exiting pane (called by pane-exited hook)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := loadConfig()
+		t := stickyTmuxForEvents()
+		s := &sticky.Sticky{T: t}
+		return s.EjectSidebarIfAloneAfterExit(eventPaneExitingPaneID, eventPaneExitingWindowID, cfg.Sidebar.Sticky.Width)
+	},
+}
+
 var eventPaneClosedPaneID string
 var eventPaneClosedWindowID string
 
@@ -216,10 +230,15 @@ func init() {
 	eventHookErrorCmd.Flags().BoolVar(&hookErrorSetStateError, "set-state-error", false, "Set the target state to error (requires --target-id)")
 	eventHookErrorCmd.MarkFlagRequired("hook")
 
+	eventPaneExitingCmd.Flags().StringVar(&eventPaneExitingPaneID, "pane", "", "Stable pane ID (%N format) of the exiting pane (required)")
+	eventPaneExitingCmd.Flags().StringVar(&eventPaneExitingWindowID, "window", "", "Stable window ID (@N format) of the exiting pane's window (required)")
+	eventPaneExitingCmd.MarkFlagRequired("pane")
+	eventPaneExitingCmd.MarkFlagRequired("window")
+
 	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedPaneID, "pane", "", "Stable pane ID (%N format) of the closed pane (required)")
 	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedWindowID, "window", "", "Stable window ID (@N format) of the killed pane's window (optional)")
 	eventPaneClosedCmd.MarkFlagRequired("pane")
 
-	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneClosedCmd)
+	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd)
 	rootCmd.AddCommand(eventCmd)
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -162,18 +162,27 @@ var eventPaneClosedCmd = &cobra.Command{
 
 func applyPaneClosed(d *db.DB, paneID, windowID string) error {
 	demuxlog.Debug("pane_closed", "pane_id", paneID, "window_id", windowID)
-	t := db.Target{Type: db.TargetTypePane, ID: paneID, PaneID: paneID}
-	if err := d.StateClear(t); err != nil {
-		return err
+	if paneID != "" {
+		t := db.Target{Type: db.TargetTypePane, ID: paneID, PaneID: paneID}
+		if err := d.StateClear(t); err != nil {
+			return err
+		}
 	}
 	tmuxClient := stickyTmuxForEvents()
-	if err := sticky.ClearStickyEnvForPane(tmuxClient, paneID); err != nil {
-		demuxlog.Warn("pane_closed: sticky env cleanup failed", "pane_id", paneID, "err", err)
-	}
-	if windowID != "" {
-		if err := (&sticky.Sticky{T: tmuxClient}).HandleWindowAfterKill(windowID); err != nil {
-			demuxlog.Warn("pane_closed: orphan slot cleanup failed", "window_id", windowID, "err", err)
+	if paneID != "" {
+		if err := sticky.ClearStickyEnvForPane(tmuxClient, paneID); err != nil {
+			demuxlog.Warn("pane_closed: sticky env cleanup failed", "pane_id", paneID, "err", err)
 		}
+	}
+	// tmux >= 3.5 leaves #{hook_pane} / #{hook_window} empty for
+	// after-kill-pane, so we cannot rely on the targeted paths above. Always
+	// run a server-wide sweep: stale env vars first, then orphan windows.
+	s := &sticky.Sticky{T: tmuxClient}
+	if err := s.SweepStaleStickyEnv(); err != nil {
+		demuxlog.Warn("pane_closed: stale env sweep failed", "err", err)
+	}
+	if err := s.SweepOrphanWindows(); err != nil {
+		demuxlog.Warn("pane_closed: orphan window sweep failed", "err", err)
 	}
 	return nil
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -177,11 +177,19 @@ func applyPaneClosed(d *db.DB, paneID, windowID string) error {
 	// tmux >= 3.5 leaves #{hook_pane} / #{hook_window} empty for
 	// after-kill-pane, so we cannot rely on the targeted paths above. Always
 	// run a server-wide sweep: stale env vars first, then orphan windows.
+	//
+	// This handler can re-enter itself: the sweep's kill-pane calls re-fire
+	// after-kill-pane, and the hook's run-shell is synchronous, so the nested
+	// handler runs to completion before kill-pane returns. The sweep is built
+	// to be idempotent under that re-entry (see HandleWindowAfterKill), so no
+	// lock is needed - and a lock would in fact deadlock against the nested,
+	// synchronous handler.
 	s := &sticky.Sticky{T: tmuxClient}
 	if err := s.SweepStaleStickyEnv(); err != nil {
 		demuxlog.Warn("pane_closed: stale env sweep failed", "err", err)
 	}
-	if err := s.SweepOrphanWindows(); err != nil {
+	width := loadConfig().Sidebar.Sticky.Width
+	if err := s.SweepOrphanWindows(width); err != nil {
 		demuxlog.Warn("pane_closed: orphan window sweep failed", "err", err)
 	}
 	return nil

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -135,7 +135,7 @@ func TestApplyPaneClosed_DeletesPaneState(t *testing.T) {
 
 	pt := db.Target{Type: db.TargetTypePane, ID: "%7", PaneID: "%7", WindowID: "@0", SessionID: "$0"}
 	d.StateSet(pt, "claude", db.StateWorking, "", db.SourceTool, false, nil)
-	if err := applyPaneClosed(d, "%7"); err != nil {
+	if err := applyPaneClosed(d, "%7", ""); err != nil {
 		t.Fatal(err)
 	}
 	st, _ := d.StateByID(pt)
@@ -148,7 +148,7 @@ func TestApplyPaneClosed_NoopUnknownPane(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	if err := applyPaneClosed(d, "%99"); err != nil {
+	if err := applyPaneClosed(d, "%99", ""); err != nil {
 		t.Errorf("unknown pane_id should be a no-op, got: %v", err)
 	}
 }
@@ -220,7 +220,7 @@ func TestApplyPaneClosed_ClearsStickyEnvVar(t *testing.T) {
 	stickyTmuxForEvents = func() sticky.Tmux { return fake }
 	defer func() { stickyTmuxForEvents = orig }()
 
-	if err := applyPaneClosed(d, "%42"); err != nil {
+	if err := applyPaneClosed(d, "%42", ""); err != nil {
 		t.Fatal(err)
 	}
 	sawUnset := false

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/sticky"
 )
 
 func paneTarget(paneID, windowID, sessionID string) db.Target {
@@ -178,5 +180,56 @@ func TestApplyHookError_InvalidTargetIDIsNoop(t *testing.T) {
 	states, _ := d.StateList(0, "")
 	if len(states) != 0 {
 		t.Errorf("expected no states for invalid target, got %d", len(states))
+	}
+}
+
+// fakeStickyTmux is a minimal recorder for sticky.Tmux used in event tests.
+type fakeStickyTmux struct {
+	outputs map[string]string
+	errs    map[string]error
+	runs    [][]string
+}
+
+func (f *fakeStickyTmux) Run(args ...string) error {
+	f.runs = append(f.runs, append([]string(nil), args...))
+	return nil
+}
+
+func (f *fakeStickyTmux) Output(args ...string) (string, error) {
+	key := strings.Join(args, " ")
+	if err, ok := f.errs[key]; ok {
+		return "", err
+	}
+	return f.outputs[key], nil
+}
+
+var _ sticky.Tmux = (*fakeStickyTmux)(nil)
+
+func TestApplyPaneClosed_ClearsStickyEnvVar(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+	pt := db.Target{Type: db.TargetTypePane, ID: "%42", PaneID: "%42"}
+	d.StateSet(pt, "claude", db.StateWorking, "", db.SourceTool, false, nil)
+
+	fake := &fakeStickyTmux{
+		outputs: map[string]string{
+			"show-environment -g": "DEMUX_STICKY_PANE__dev_ttys001=%42\nOTHER=keep\n",
+		},
+	}
+	orig := stickyTmuxForEvents
+	stickyTmuxForEvents = func() sticky.Tmux { return fake }
+	defer func() { stickyTmuxForEvents = orig }()
+
+	if err := applyPaneClosed(d, "%42"); err != nil {
+		t.Fatal(err)
+	}
+	sawUnset := false
+	for _, r := range fake.runs {
+		if strings.Join(r, " ") == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			sawUnset = true
+		}
+	}
+	if !sawUnset {
+		t.Errorf("expected sticky env unset for %%42, got runs: %v", fake.runs)
 	}
 }

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -160,6 +160,11 @@ set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null
 # (within the same session). join-pane uses -d so user focus is preserved.
 set-hook -ga after-select-window "run-shell 'demux sidebar follow 2>/dev/null; true'"
 
+# Sticky sidebar - moves the demux sidebar pane into a newly created window.
+# tmux does NOT fire after-select-window for new-window, so this separate hook
+# is required for the sidebar to follow when you create a window.
+set-hook -ga after-new-window "run-shell 'demux sidebar follow 2>/dev/null; true'"
+
 # Sticky sidebar (slots mode) - ensures every newly created window gets a
 # sidebar slot pane. No-op when [sidebar.sticky] slots = false or when no
 # slots have been installed yet.

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -150,6 +150,13 @@ set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_
 # #{hook_pane} is the killed pane's ID; #{pane_id} is the new active pane after
 # the kill — using #{pane_id} here would clear the wrong pane's state.
 set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true'"
+
+# Sticky sidebar - moves the demux sidebar pane to the newly attached session.
+set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null; true'"
+
+# Sticky sidebar auto-show on client attach. Remove this line if you prefer
+# to toggle the sticky sidebar manually with 'demux sidebar toggle'.
+set-hook -ga client-attached "run-shell 'demux sidebar show 2>/dev/null; true'"
 # ──────────────────────────────────────────────────────────────────────────────
 `
 

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -153,6 +153,14 @@ set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_
 # (e.g. the user closed the last non-slot pane) and clean it up.
 set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
 
+# Sticky sidebar - proactively ejects the sidebar when the process running in a
+# pane exits and the sidebar would be the only pane left in that window. Fires
+# BEFORE after-kill-pane (while the exiting pane is still present), which makes
+# the sidebar return to the previous window without any stranded-sidebar flicker.
+# Complements after-kill-pane for cases where that hook is unreliable (e.g.
+# natural process exits in some tmux versions).
+set-hook -ga pane-exited "run-shell 'demux event pane_exiting --pane=#{pane_id} --window=#{window_id} 2>/dev/null; true'"
+
 # Sticky sidebar - moves the demux sidebar pane to the newly active session.
 set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null; true'"
 

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -148,8 +148,10 @@ set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_
 
 # Removes Demux state when a pane is closed (prevents stale state accumulation).
 # #{hook_pane} is the killed pane's ID; #{pane_id} is the new active pane after
-# the kill — using #{pane_id} here would clear the wrong pane's state.
-set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true'"
+# the kill - using #{pane_id} here would clear the wrong pane's state.
+# #{hook_window} lets demux detect a window left with only a sidebar slot pane
+# (e.g. the user closed the last non-slot pane) and clean it up.
+set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
 
 # Sticky sidebar - moves the demux sidebar pane to the newly active session.
 set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null; true'"

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -158,6 +158,11 @@ set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null
 # (within the same session). join-pane uses -d so user focus is preserved.
 set-hook -ga after-select-window "run-shell 'demux sidebar follow 2>/dev/null; true'"
 
+# Sticky sidebar (slots mode) - ensures every newly created window gets a
+# sidebar slot pane. No-op when [sidebar.sticky] slots = false or when no
+# slots have been installed yet.
+set-hook -ga after-new-window "run-shell 'demux sidebar slots ensure 2>/dev/null; true'"
+
 # Sticky sidebar auto-show on client attach. Remove this line if you prefer
 # to toggle the sticky sidebar manually with 'demux sidebar toggle'.
 set-hook -ga client-attached "run-shell 'demux sidebar show 2>/dev/null; true'"

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -159,7 +159,7 @@ set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pa
 # the sidebar return to the previous window without any stranded-sidebar flicker.
 # Complements after-kill-pane for cases where that hook is unreliable (e.g.
 # natural process exits in some tmux versions).
-set-hook -ga pane-exited "run-shell 'demux event pane_exiting --pane=#{pane_id} --window=#{window_id} 2>/dev/null; true'"
+set-hook -ga pane-exited "run-shell 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
 
 # Sticky sidebar - moves the demux sidebar pane to the newly active session.
 set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null; true'"

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -151,8 +151,12 @@ set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_
 # the kill — using #{pane_id} here would clear the wrong pane's state.
 set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true'"
 
-# Sticky sidebar - moves the demux sidebar pane to the newly attached session.
+# Sticky sidebar - moves the demux sidebar pane to the newly active session.
 set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null; true'"
+
+# Sticky sidebar - moves the demux sidebar pane to the newly active window
+# (within the same session). join-pane uses -d so user focus is preserved.
+set-hook -ga after-select-window "run-shell 'demux sidebar follow 2>/dev/null; true'"
 
 # Sticky sidebar auto-show on client attach. Remove this line if you prefer
 # to toggle the sticky sidebar manually with 'demux sidebar toggle'.

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -47,6 +47,24 @@ func TestTmuxHooksSnippet_ContainsAfterKillPane(t *testing.T) {
 	}
 }
 
+func TestTmuxHooksSnippet_ContainsPaneExitedHook(t *testing.T) {
+	if !strings.Contains(tmuxHooksSnippet, "pane-exited") {
+		t.Error("snippet should include pane-exited hook for proactive sidebar eject")
+	}
+	if !strings.Contains(tmuxHooksSnippet, "pane_exiting") {
+		t.Error("pane-exited hook should call demux event pane_exiting")
+	}
+	// Must use #{hook_pane}/#{hook_window}, not #{pane_id}/#{window_id}: in global
+	// hooks #{pane_id} resolves to the surviving pane (focus already shifted), not
+	// the one that triggered pane-exited.
+	if !strings.Contains(tmuxHooksSnippet, "--pane=#{hook_pane}") {
+		t.Error("pane_exiting hook must pass --pane=#{hook_pane}, not --pane=#{pane_id}")
+	}
+	if !strings.Contains(tmuxHooksSnippet, "--window=#{hook_window}") {
+		t.Error("pane_exiting hook must pass --window=#{hook_window}, not --window=#{window_id}")
+	}
+}
+
 func TestTmuxHooksSnippet_PaneFocusIncludesPaneID(t *testing.T) {
 	if !strings.Contains(tmuxHooksSnippet, "--pane-id=#{pane_id}") {
 		t.Error("pane_focus hooks should pass --pane-id=#{pane_id}")

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -65,6 +65,12 @@ func TestTmuxHooksSnippet_ContainsStickyFollowHook(t *testing.T) {
 	}
 }
 
+func TestTmuxHooksSnippet_ContainsStickyWindowFollowHook(t *testing.T) {
+	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga after-select-window") {
+		t.Error("snippet should include after-select-window -ga hook for sticky window follow")
+	}
+}
+
 func TestTmuxHooksSnippet_ContainsStickyAutoShowHook(t *testing.T) {
 	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga client-attached") {
 		t.Error("snippet should include client-attached hook for sticky auto-show")

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -71,6 +71,15 @@ func TestTmuxHooksSnippet_ContainsStickyWindowFollowHook(t *testing.T) {
 	}
 }
 
+func TestTmuxHooksSnippet_ContainsStickySlotsEnsureHook(t *testing.T) {
+	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga after-new-window") {
+		t.Error("snippet should include after-new-window -ga hook for slots ensure")
+	}
+	if !strings.Contains(tmuxHooksSnippet, "demux sidebar slots ensure") {
+		t.Error("after-new-window hook should call 'demux sidebar slots ensure'")
+	}
+}
+
 func TestTmuxHooksSnippet_ContainsStickyAutoShowHook(t *testing.T) {
 	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga client-attached") {
 		t.Error("snippet should include client-attached hook for sticky auto-show")

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -53,6 +53,27 @@ func TestTmuxHooksSnippet_PaneFocusIncludesPaneID(t *testing.T) {
 	}
 }
 
+func TestTmuxHooksSnippet_ContainsStickyFollowHook(t *testing.T) {
+	if !strings.Contains(tmuxHooksSnippet, "client-session-changed") {
+		t.Error("snippet should still include client-session-changed hook")
+	}
+	if !strings.Contains(tmuxHooksSnippet, "demux sidebar follow") {
+		t.Error("snippet should include 'demux sidebar follow' hook for sticky sidebar")
+	}
+	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga client-session-changed") {
+		t.Error("sticky follow hook should use -ga (append), not -g (overwrite)")
+	}
+}
+
+func TestTmuxHooksSnippet_ContainsStickyAutoShowHook(t *testing.T) {
+	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga client-attached") {
+		t.Error("snippet should include client-attached hook for sticky auto-show")
+	}
+	if !strings.Contains(tmuxHooksSnippet, "demux sidebar show") {
+		t.Error("snippet should call 'demux sidebar show' on client-attached")
+	}
+}
+
 func TestTmuxParentIDs_ParsesTabSeparatedOutput(t *testing.T) {
 	// parseTmuxTabOutput is the same logic used by tmuxParentIDs:
 	// split on tab, expect [windowID, sessionID].

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -80,6 +80,23 @@ func TestTmuxHooksSnippet_ContainsStickySlotsEnsureHook(t *testing.T) {
 	}
 }
 
+func TestTmuxHooksSnippet_ContainsStickyNewWindowFollowHook(t *testing.T) {
+	// after-select-window does NOT fire when a window is created via new-window
+	// (tmux fires after-new-window instead), so a separate after-new-window
+	// follow hook is required for the sidebar to follow into a fresh window.
+	found := false
+	for _, line := range strings.Split(tmuxHooksSnippet, "\n") {
+		if strings.Contains(line, "set-hook -ga after-new-window") &&
+			strings.Contains(line, "demux sidebar follow") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("snippet should bind 'demux sidebar follow' to after-new-window so the sidebar follows into newly created windows")
+	}
+}
+
 func TestTmuxHooksSnippet_ContainsStickyAutoShowHook(t *testing.T) {
 	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga client-attached") {
 		t.Error("snippet should include client-attached hook for sticky auto-show")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 var formatFlag string
 var compactFlag bool
 var searchFlag bool
+var stickyFlag bool
 var logLevelFlag string
 
 var rootCmd = &cobra.Command{
@@ -60,6 +61,13 @@ var rootCmd = &cobra.Command{
 		if searchFlag {
 			cfg.Sidebar.FocusSearchOnOpen = true
 		}
+		if stickyFlag {
+			cfg.Mode = "compact"
+			cfg.Sidebar.SessionView = config.SidebarViewCard
+			cfg.Sidebar.SessionViewModeCompact = config.SidebarViewCard
+			cfg.Sidebar.SessionViewModeFull = config.SidebarViewCard
+			cfg.StickyMode = true
+		}
 		dbPath, err := db.DefaultPath()
 		if err != nil {
 			return err
@@ -90,6 +98,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logLevelFlag, "log-level", "", "Log level: off|error|warn|info|debug (overrides config)")
 	rootCmd.PersistentFlags().BoolVar(&compactFlag, "compact", false, "Launch in compact mode (sidebar + search only)")
 	rootCmd.PersistentFlags().BoolVar(&searchFlag, "search", false, "Start with focus in the search input")
+	rootCmd.PersistentFlags().BoolVar(&stickyFlag, "sticky", false, "Sticky sidebar mode: forces compact + card view, disables quit (used by `demux sidebar`)")
 }
 
 func loadConfig() config.Config {

--- a/cmd/session_connect.go
+++ b/cmd/session_connect.go
@@ -92,7 +92,7 @@ func resolveConnectTarget(sessions []session.Session, name string) (*session.Ses
 }
 
 func loadMergedSessions() ([]session.Session, session.SessionsConfig, error) {
-	panes, _ := tmux.ListPanes()  // Soft fallback: zero live sessions on error
+	panes, _ := tmux.ListPanes() // Soft fallback: zero live sessions on error
 	cfgPath, err := config.DefaultPath()
 	if err != nil {
 		return nil, session.SessionsConfig{}, fmt.Errorf("config dir: %w", err)

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/rtalexk/demux/internal/sticky"
 	"github.com/spf13/cobra"
@@ -63,7 +65,23 @@ var sidebarFollowCmd = &cobra.Command{
 	},
 }
 
+var sidebarSlotCmd = &cobra.Command{
+	Use:    "slot",
+	Short:  "Internal: placeholder process for an inactive sticky sidebar slot",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		signal.Ignore(syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+		fmt.Print("\x1b[2J\x1b[H\n\n")
+		fmt.Println("  demux sidebar slot")
+		fmt.Println()
+		fmt.Println("  Reserved by [sidebar.sticky] slots.")
+		fmt.Println("  Activate this window's slot with")
+		fmt.Println("  `demux sidebar show`.")
+		select {}
+	},
+}
+
 func init() {
-	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarFollowCmd)
+	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarFollowCmd, sidebarSlotCmd)
 	rootCmd.AddCommand(sidebarCmd)
 }

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -95,7 +95,7 @@ var sidebarSlotsUninstallCmd = &cobra.Command{
 
 var sidebarSlotsEnsureCmd = &cobra.Command{
 	Use:    "ensure",
-	Short:  "Internal: ensure the current window has a sidebar slot (called by tmux hook)",
+	Short:  "Internal: reconcile slot panes against the MRU budget (called by tmux hook)",
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := loadConfig()
@@ -111,7 +111,16 @@ var sidebarSlotsEnsureCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return s.EnsureSlotInWindow(strings.TrimSpace(target), cfg.Sidebar.Sticky.Width)
+		parts := strings.SplitN(strings.TrimSpace(target), ":", 2)
+		if len(parts) < 2 {
+			return nil
+		}
+		_ = s.PruneMRU()
+		reserved, err := s.ComputeReservedWindows(parts[1], parts[0])
+		if err != nil {
+			return err
+		}
+		return s.ReconcileSlots(reserved, parts[1], cfg.Sidebar.Sticky.Width)
 	},
 }
 

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"os/signal"
 	"strings"
 	"syscall"
@@ -129,15 +131,35 @@ var sidebarSlotCmd = &cobra.Command{
 	Short:  "Internal: placeholder process for an inactive sticky sidebar slot",
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		signal.Ignore(syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
-		fmt.Print("\x1b[2J\x1b[H\n\n")
-		fmt.Println("  demux sidebar slot")
-		fmt.Println()
-		fmt.Println("  Reserved by [sidebar.sticky] slots.")
-		fmt.Println("  Activate this window's slot with")
-		fmt.Println("  `demux sidebar show`.")
-		select {}
+		runSidebarSlotPlaceholder(cmd.OutOrStdout())
+		return nil
 	},
+}
+
+// runSidebarSlotPlaceholder is the body of `demux sidebar slot`: it paints a
+// static placeholder screen in the slot's tmux pane and blocks until the pane
+// is torn down.
+//
+// SIGINT is ignored so an accidental Ctrl-C while the slot pane is focused
+// cannot destroy the reserved slot. SIGHUP and SIGTERM are deliberately NOT
+// ignored: tmux delivers SIGHUP (by closing the pane's pty) when it kills the
+// pane, and the placeholder MUST exit then so its pty device is released back
+// to the system. Previously all three signals were ignored, which orphaned
+// these processes onto launchd and leaked one pty each until the host hit
+// kern.tty.ptmx_max and could no longer fork new terminals.
+func runSidebarSlotPlaceholder(w io.Writer) {
+	signal.Ignore(syscall.SIGINT)
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGHUP, syscall.SIGTERM)
+
+	fmt.Fprint(w, "\x1b[2J\x1b[H\n\n")
+	fmt.Fprintln(w, "  demux sidebar slot")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Reserved by [sidebar.sticky] slots.")
+	fmt.Fprintln(w, "  Activate this window's slot with")
+	fmt.Fprintln(w, "  `demux sidebar show`.")
+
+	<-done
 }
 
 func init() {

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -11,7 +11,12 @@ import (
 )
 
 // stickyClient is overridable in tests so we can inject a fake Tmux.
-var stickyClient = func() *sticky.Sticky { return sticky.New() }
+var stickyClient = func() *sticky.Sticky {
+	cfg := loadConfig()
+	s := sticky.New()
+	s.Slots = cfg.Sidebar.Sticky.Slots
+	return s
+}
 
 var sidebarCmd = &cobra.Command{
 	Use:   "sidebar",

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rtalexk/demux/internal/sticky"
+	"github.com/spf13/cobra"
+)
+
+// stickyClient is overridable in tests so we can inject a fake Tmux.
+var stickyClient = func() *sticky.Sticky { return sticky.New() }
+
+var sidebarCmd = &cobra.Command{
+	Use:   "sidebar",
+	Short: "Manage the sticky sidebar tmux pane",
+	Long: `Manage the per-client sticky sidebar tmux pane that runs
+'demux --sticky' and follows the attached client across session switches.
+
+These commands require the invoking shell to be inside tmux.`,
+}
+
+func sidebarShowOpts() sticky.ShowOpts {
+	cfg := loadConfig()
+	return sticky.ShowOpts{
+		Width: cfg.Sidebar.Sticky.Width,
+		Cmd:   "demux --sticky",
+	}
+}
+
+var sidebarShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Create the sticky sidebar pane if it does not already exist",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return stickyClient().Show(sidebarShowOpts())
+	},
+}
+
+var sidebarHideCmd = &cobra.Command{
+	Use:   "hide",
+	Short: "Kill the sticky sidebar pane if it is currently shown",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return stickyClient().Hide()
+	},
+}
+
+var sidebarToggleCmd = &cobra.Command{
+	Use:   "toggle",
+	Short: "Show the sticky sidebar pane if hidden, hide it if shown",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return stickyClient().Toggle(sidebarShowOpts())
+	},
+}
+
+var sidebarFollowCmd = &cobra.Command{
+	Use:    "follow",
+	Short:  "Internal: move the sticky sidebar pane to the current session",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := stickyClient().Follow(); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "demux sidebar follow: %v\n", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarFollowCmd)
+	rootCmd.AddCommand(sidebarCmd)
+}

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/rtalexk/demux/internal/sticky"
@@ -65,6 +66,50 @@ var sidebarFollowCmd = &cobra.Command{
 	},
 }
 
+var sidebarSlotsCmd = &cobra.Command{
+	Use:   "slots",
+	Short: "Manage per-window sidebar slots (sidebar.sticky.slots mode)",
+}
+
+var sidebarSlotsInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Create a sidebar slot pane in every existing window",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := loadConfig()
+		return stickyClient().InstallSlotsInAllWindows(cfg.Sidebar.Sticky.Width)
+	},
+}
+
+var sidebarSlotsUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Kill every sidebar slot pane",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return stickyClient().UninstallSlots()
+	},
+}
+
+var sidebarSlotsEnsureCmd = &cobra.Command{
+	Use:    "ensure",
+	Short:  "Internal: ensure the current window has a sidebar slot (called by tmux hook)",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := loadConfig()
+		if !cfg.Sidebar.Sticky.Slots {
+			return nil
+		}
+		s := stickyClient()
+		any, err := s.AnySlotExists()
+		if err != nil || !any {
+			return err
+		}
+		target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+		if err != nil {
+			return err
+		}
+		return s.EnsureSlotInWindow(strings.TrimSpace(target), cfg.Sidebar.Sticky.Width)
+	},
+}
+
 var sidebarSlotCmd = &cobra.Command{
 	Use:    "slot",
 	Short:  "Internal: placeholder process for an inactive sticky sidebar slot",
@@ -82,6 +127,7 @@ var sidebarSlotCmd = &cobra.Command{
 }
 
 func init() {
-	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarFollowCmd, sidebarSlotCmd)
+	sidebarSlotsCmd.AddCommand(sidebarSlotsInstallCmd, sidebarSlotsUninstallCmd, sidebarSlotsEnsureCmd)
+	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarFollowCmd, sidebarSlotCmd, sidebarSlotsCmd)
 	rootCmd.AddCommand(sidebarCmd)
 }

--- a/cmd/sidebar_test.go
+++ b/cmd/sidebar_test.go
@@ -28,3 +28,13 @@ func TestSidebarCmd_FollowIsHidden(t *testing.T) {
 		t.Errorf("follow should be hidden from --help")
 	}
 }
+
+func TestSidebarCmd_SlotIsHidden(t *testing.T) {
+	cmd, _, _ := rootCmd.Find([]string{"sidebar", "slot"})
+	if cmd == nil {
+		t.Fatal("slot subcommand missing")
+	}
+	if !cmd.Hidden {
+		t.Errorf("slot should be hidden from --help")
+	}
+}

--- a/cmd/sidebar_test.go
+++ b/cmd/sidebar_test.go
@@ -29,6 +29,25 @@ func TestSidebarCmd_FollowIsHidden(t *testing.T) {
 	}
 }
 
+func TestSidebarCmd_SlotsSubcommands(t *testing.T) {
+	for _, sub := range []string{"install", "uninstall", "ensure"} {
+		cmd, _, _ := rootCmd.Find([]string{"sidebar", "slots", sub})
+		if cmd == nil || cmd.Name() != sub {
+			t.Errorf("expected `demux sidebar slots %s`, got %v", sub, cmd)
+		}
+	}
+}
+
+func TestSidebarCmd_SlotsEnsureHidden(t *testing.T) {
+	cmd, _, _ := rootCmd.Find([]string{"sidebar", "slots", "ensure"})
+	if cmd == nil {
+		t.Fatal("ensure subcommand missing")
+	}
+	if !cmd.Hidden {
+		t.Errorf("slots ensure should be hidden from --help")
+	}
+}
+
 func TestSidebarCmd_SlotIsHidden(t *testing.T) {
 	cmd, _, _ := rootCmd.Find([]string{"sidebar", "slot"})
 	if cmd == nil {

--- a/cmd/sidebar_test.go
+++ b/cmd/sidebar_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestSidebarCmd_Registered(t *testing.T) {
+	if cmd, _, _ := rootCmd.Find([]string{"sidebar"}); cmd == nil || cmd.Use != "sidebar" {
+		t.Fatal("expected `demux sidebar` command to be registered")
+	}
+}
+
+func TestSidebarCmd_Subcommands(t *testing.T) {
+	for _, sub := range []string{"toggle", "show", "hide", "follow"} {
+		cmd, _, _ := rootCmd.Find([]string{"sidebar", sub})
+		if cmd == nil || cmd.Name() != sub {
+			t.Errorf("expected `demux sidebar %s`, got %v", sub, cmd)
+		}
+	}
+}
+
+func TestSidebarCmd_FollowIsHidden(t *testing.T) {
+	cmd, _, _ := rootCmd.Find([]string{"sidebar", "follow"})
+	if cmd == nil {
+		t.Fatal("follow subcommand missing")
+	}
+	if !cmd.Hidden {
+		t.Errorf("follow should be hidden from --help")
+	}
+}

--- a/cmd/sidebar_test.go
+++ b/cmd/sidebar_test.go
@@ -1,7 +1,13 @@
 package cmd
 
 import (
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestSidebarCmd_Registered(t *testing.T) {
@@ -55,5 +61,114 @@ func TestSidebarCmd_SlotIsHidden(t *testing.T) {
 	}
 	if !cmd.Hidden {
 		t.Errorf("slot should be hidden from --help")
+	}
+}
+
+// TestMain re-enters this test binary as the `demux sidebar slot` placeholder
+// when DEMUX_TEST_SLOT is set, so the lifecycle tests below can drive a real
+// process with real OS signal handlers.
+func TestMain(m *testing.M) {
+	if os.Getenv("DEMUX_TEST_SLOT") == "1" {
+		runSidebarSlotPlaceholder(os.Stdout)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// startSlotHelper spawns this test binary as a slot placeholder and returns
+// once the placeholder has installed its signal handlers, detected by its
+// banner reaching stdout (the banner is printed after the handlers are set).
+// The returned channel receives the process's exit.
+func startSlotHelper(t *testing.T) (*exec.Cmd, <-chan error) {
+	t.Helper()
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	c := exec.Command(os.Args[0])
+	c.Env = append(os.Environ(), "DEMUX_TEST_SLOT=1")
+	c.Stdout = pw
+	if err := c.Start(); err != nil {
+		t.Fatalf("start slot helper: %v", err)
+	}
+	pw.Close() // child holds its own copy; drop ours so reads see EOF on exit
+
+	exited := make(chan error, 1)
+	go func() { exited <- c.Wait() }()
+
+	ready := make(chan struct{})
+	go func() {
+		buf := make([]byte, 4096)
+		var seen strings.Builder
+		for {
+			n, err := pr.Read(buf)
+			seen.Write(buf[:n])
+			if strings.Contains(seen.String(), "Reserved by") {
+				close(ready)
+				io.Copy(io.Discard, pr) // drain so the child never blocks on write
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		c.Process.Kill()
+		t.Fatal("slot placeholder never painted its banner")
+	}
+
+	t.Cleanup(func() {
+		c.Process.Kill()
+		pr.Close()
+	})
+	return c, exited
+}
+
+func assertExitsOnSignal(t *testing.T, sig syscall.Signal) {
+	t.Helper()
+	c, exited := startSlotHelper(t)
+
+	if err := c.Process.Signal(sig); err != nil {
+		t.Fatalf("send %v: %v", sig, err)
+	}
+	select {
+	case <-exited:
+		// Process exited: its controlling pty is released back to the system.
+	case <-time.After(5 * time.Second):
+		t.Fatalf("slot placeholder ignored %v and did not exit; "+
+			"a tmux pane close would orphan it and leak its pty", sig)
+	}
+}
+
+// A slot placeholder must exit when tmux tears down its pane: tmux closes the
+// pane's pty, which delivers SIGHUP to the placeholder.
+func TestSidebarSlotPlaceholder_ExitsOnSIGHUP(t *testing.T) {
+	assertExitsOnSignal(t, syscall.SIGHUP)
+}
+
+// An explicit `kill` / `tmux kill-pane` path delivers SIGTERM; the placeholder
+// must honor it too so the pty is not leaked.
+func TestSidebarSlotPlaceholder_ExitsOnSIGTERM(t *testing.T) {
+	assertExitsOnSignal(t, syscall.SIGTERM)
+}
+
+// SIGINT is intentionally ignored: an accidental Ctrl-C while the slot pane is
+// focused must not destroy the reserved slot.
+func TestSidebarSlotPlaceholder_IgnoresSIGINT(t *testing.T) {
+	c, exited := startSlotHelper(t)
+
+	if err := c.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("send SIGINT: %v", err)
+	}
+	select {
+	case <-exited:
+		t.Fatal("slot placeholder exited on SIGINT; accidental Ctrl-C must not destroy the slot")
+	case <-time.After(750 * time.Millisecond):
+		// Still alive: correct.
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -293,6 +293,11 @@ type Config struct {
 	Git               GitConfig         `toml:"git"`
 	Theme             ThemeConfig       `toml:"theme"`
 	PathAliases       []PathAlias       `toml:"path_aliases"`
+
+	// StickyMode is in-memory only (TOML tag "-"). Set by the --sticky flag on
+	// the root command; the TUI uses it to strip the quit binding and force
+	// compact + card session view.
+	StickyMode bool `toml:"-"`
 }
 
 func Default() Config {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -239,21 +239,26 @@ func normalizeSessionView(value, key, emptyDefault string) string {
 	}
 }
 
+type SidebarStickyConfig struct {
+	Width int `toml:"width"`
+}
+
 type SidebarConfig struct {
-	DefaultFilter          string         `toml:"default_filter"`
-	FocusOnOpen            string         `toml:"focus_on_open"`
-	FocusSearchOnOpen      bool           `toml:"focus_search_on_open"`
-	SearchSort             string         `toml:"search_sort"`
-	ShowLastSeen           bool           `toml:"show_last_seen"`
-	ActiveSessionIcon      string         `toml:"active_session_icon"`
-	Sort                   []string       `toml:"sort"`
-	SwitchFocus            string         `toml:"switch_focus"`
-	Width                  int            `toml:"width"`
-	SessionView            string         `toml:"session_view"`
-	SessionViewModeCompact string         `toml:"session_view_mode_compact"`
-	SessionViewModeFull    string         `toml:"session_view_mode_full"`
-	CardSeparator          string         `toml:"card_separator"`
-	Processes              []ProcessLabel `toml:"processes"`
+	DefaultFilter          string              `toml:"default_filter"`
+	FocusOnOpen            string              `toml:"focus_on_open"`
+	FocusSearchOnOpen      bool                `toml:"focus_search_on_open"`
+	SearchSort             string              `toml:"search_sort"`
+	ShowLastSeen           bool                `toml:"show_last_seen"`
+	ActiveSessionIcon      string              `toml:"active_session_icon"`
+	Sort                   []string            `toml:"sort"`
+	SwitchFocus            string              `toml:"switch_focus"`
+	Width                  int                 `toml:"width"`
+	SessionView            string              `toml:"session_view"`
+	SessionViewModeCompact string              `toml:"session_view_mode_compact"`
+	SessionViewModeFull    string              `toml:"session_view_mode_full"`
+	CardSeparator          string              `toml:"card_separator"`
+	Processes              []ProcessLabel      `toml:"processes"`
+	Sticky                 SidebarStickyConfig `toml:"sticky"`
 }
 
 type ProcessListConfig struct {
@@ -308,6 +313,7 @@ func Default() Config {
 			ActiveSessionIcon: DefaultActiveSessionIcon,
 			SessionView:       SidebarViewRow,
 			CardSeparator:     CardSeparatorBlank,
+			Sticky:            SidebarStickyConfig{Width: DefaultStickySidebarWidth},
 		},
 		StatusBar: StatusBarConfig{Show: true},
 		Log:       LogConfig{Level: "warn"},
@@ -435,6 +441,13 @@ func Load(path string) (Config, error) {
 	cfg.Sidebar.SessionViewModeCompact = normalizeSessionView(cfg.Sidebar.SessionViewModeCompact, "sidebar.session_view_mode_compact", "")
 	cfg.Sidebar.SessionViewModeFull = normalizeSessionView(cfg.Sidebar.SessionViewModeFull, "sidebar.session_view_mode_full", "")
 	cfg.Sidebar.CardSeparator = normalizeCardSeparator(cfg.Sidebar.CardSeparator)
+
+	if cfg.Sidebar.Sticky.Width < MinStickySidebarWidth {
+		fmt.Fprintf(os.Stderr,
+			"demux: clamping sidebar.sticky.width %d below minimum %d; using %d\n",
+			cfg.Sidebar.Sticky.Width, MinStickySidebarWidth, MinStickySidebarWidth)
+		cfg.Sidebar.Sticky.Width = MinStickySidebarWidth
+	}
 
 	filteredProcs := cfg.Sidebar.Processes[:0]
 	for _, p := range cfg.Sidebar.Processes {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -240,7 +240,8 @@ func normalizeSessionView(value, key, emptyDefault string) string {
 }
 
 type SidebarStickyConfig struct {
-	Width int `toml:"width"`
+	Width int  `toml:"width"`
+	Slots bool `toml:"slots"`
 }
 
 type SidebarConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -837,6 +837,54 @@ func TestLoadFromFile_SessionViewModeInvalidWarnsAndClears(t *testing.T) {
 	}
 }
 
+func TestSidebarSticky_DefaultWidth(t *testing.T) {
+	cfg := config.Default()
+	if cfg.Sidebar.Sticky.Width != config.DefaultStickySidebarWidth {
+		t.Errorf("default sticky width: want %d, got %d", config.DefaultStickySidebarWidth, cfg.Sidebar.Sticky.Width)
+	}
+}
+
+func TestSidebarSticky_LoadOverridesDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := "[sidebar.sticky]\nwidth = 50\n"
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Sidebar.Sticky.Width != 50 {
+		t.Errorf("override sticky width: want 50, got %d", cfg.Sidebar.Sticky.Width)
+	}
+}
+
+func TestSidebarSticky_LoadClampsBelowMinimum(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := "[sidebar.sticky]\nwidth = 4\n"
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	origStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+	cfg, err := config.Load(path)
+	w.Close()
+	out, _ := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Sidebar.Sticky.Width != config.MinStickySidebarWidth {
+		t.Errorf("clamp: want %d, got %d", config.MinStickySidebarWidth, cfg.Sidebar.Sticky.Width)
+	}
+	if !strings.Contains(string(out), "sidebar.sticky.width") {
+		t.Errorf("expected stderr warning mentioning sidebar.sticky.width, got: %s", out)
+	}
+}
+
 func TestResolvedSessionView(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -885,6 +885,29 @@ func TestSidebarSticky_LoadClampsBelowMinimum(t *testing.T) {
 	}
 }
 
+func TestSidebarSticky_DefaultSlotsFalse(t *testing.T) {
+	cfg := config.Default()
+	if cfg.Sidebar.Sticky.Slots {
+		t.Errorf("default slots: want false, got true")
+	}
+}
+
+func TestSidebarSticky_LoadEnablesSlots(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := "[sidebar.sticky]\nslots = true\n"
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Sidebar.Sticky.Slots {
+		t.Errorf("slots: want true, got false")
+	}
+}
+
 func TestResolvedSessionView(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -27,6 +27,13 @@ const (
 	MinSidebarWidth = 10
 	// MinGitTimeoutWarnMs is the threshold below which a git timeout warning is issued.
 	MinGitTimeoutWarnMs = 50
+
+	// DefaultStickySidebarWidth is the initial width (in columns) used the first
+	// time the sticky sidebar pane is created. After creation, the user resizes
+	// the pane normally; Follow preserves whatever width is current at move time.
+	DefaultStickySidebarWidth = 35
+	// MinStickySidebarWidth is the minimum accepted value for Sidebar.Sticky.Width.
+	MinStickySidebarWidth = 10
 )
 
 // TickInterval is the TUI refresh tick derived from the default refresh interval.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -55,6 +55,9 @@ func (c Config) Validate() []ValidationIssue {
 	if c.Sidebar.Width < MinSidebarWidth {
 		add("error", "sidebar.width", fmt.Sprintf("must be ≥ 10, got %d", c.Sidebar.Width))
 	}
+	if c.Sidebar.Sticky.Width < MinStickySidebarWidth {
+		add("error", "sidebar.sticky.width", fmt.Sprintf("must be ≥ %d, got %d", MinStickySidebarWidth, c.Sidebar.Sticky.Width))
+	}
 
 	// Git timeout
 	if c.Git.TimeoutMs > 0 && c.Git.TimeoutMs < MinGitTimeoutWarnMs {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -51,6 +51,22 @@ func TestValidate_bad_log_level(t *testing.T) {
 	}
 }
 
+func TestValidate_StickySidebarWidthBelowMin(t *testing.T) {
+	cfg := config.Default()
+	cfg.Sidebar.Sticky.Width = 5
+	issues := cfg.Validate()
+	found := false
+	for _, i := range issues {
+		if i.Field == "sidebar.sticky.width" && i.Level == "error" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected error for sidebar.sticky.width below %d; got: %+v", config.MinStickySidebarWidth, issues)
+	}
+}
+
 // helpers
 func filterLevel(issues []config.ValidationIssue, level string) []config.ValidationIssue {
 	var out []config.ValidationIssue

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -60,13 +60,17 @@ func (s *Sticky) Follow() error {
 	if len(currParts) < 2 {
 		return fmt.Errorf("unexpected current target %q", curr)
 	}
-	if paneWindow == currParts[1] {
-		return nil
-	}
+	currSession, currWindow := currParts[0], currParts[1]
 	widthStr, _ := s.T.Output("display-message", "-p", "-t", val, "#{pane_width}")
 	width, _ := strconv.Atoi(strings.TrimSpace(widthStr))
 	if width <= 0 {
 		width = config.DefaultStickySidebarWidth
+	}
+	if paneWindow == currWindow {
+		if s.Slots {
+			s.maintainSlotsBudget(currWindow, currSession, width)
+		}
+		return nil
 	}
 	if s.Slots {
 		if err := s.followSlotsMode(val, curr, width); err != nil {
@@ -74,12 +78,27 @@ func (s *Sticky) Follow() error {
 		}
 		s.ejectFocusIfOnSidebar(val)
 		s.pokeRefresh(val)
+		_ = s.PushMRU(paneWindow)
+		s.maintainSlotsBudget(currWindow, currSession, width)
 		return nil
 	}
 	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-d", "-l", strconv.Itoa(width), "-s", val, "-t", curr)
 	s.ejectFocusIfOnSidebar(val)
 	s.pokeRefresh(val)
 	return nil
+}
+
+// maintainSlotsBudget prunes stale MRU entries, recomputes the reserved set
+// for currWindow/currSession, and reconciles slot panes so only reserved
+// windows hold placeholder slots. Best-effort: errors are swallowed so the
+// hook driving Follow never crashes navigation.
+func (s *Sticky) maintainSlotsBudget(currWindow, currSession string, width int) {
+	_ = s.PruneMRU()
+	reserved, err := s.ComputeReservedWindows(currWindow, currSession)
+	if err != nil {
+		return
+	}
+	_ = s.ReconcileSlots(reserved, currWindow, width)
 }
 
 // ejectFocusIfOnSidebar moves the client focus to the next pane in the

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -72,14 +72,17 @@ func (s *Sticky) Follow() error {
 	return nil
 }
 
-// pokeRefresh sends the TUI's force-refresh key ("R") to the sticky pane so
-// it picks up the new active session/window immediately instead of waiting
-// for its next refresh tick.
+// pokeRefresh sends F12 to the sticky pane. The TUI binds F12 (only
+// reachable via this poke; not in the user-facing key list) to a
+// refresh-plus-refocus action so the sidebar both picks up the new active
+// session immediately AND snaps the cursor back to it. The auto-refresh
+// tick still uses the plain refresh path so the user can browse the
+// sidebar between window switches without their cursor being yanked.
 func (s *Sticky) pokeRefresh(paneID string) {
 	if paneID == "" {
 		return
 	}
-	_ = s.T.Run("send-keys", "-t", paneID, "R")
+	_ = s.T.Run("send-keys", "-t", paneID, "F12")
 }
 
 // followSlotsMode swaps the active sidebar pane with the destination window's

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -1,0 +1,63 @@
+package sticky
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rtalexk/demux/internal/config"
+)
+
+// Follow moves the sticky sidebar pane into the current client's session,
+// preserving the pane's current width. It is a no-op when:
+//   - no sidebar is tracked for this client,
+//   - the tracked pane is gone (user runs `show` to recreate),
+//   - the pane is already in the current session.
+//
+// join-pane failures are swallowed so the tmux hook that drives Follow never
+// crashes user navigation.
+func (s *Sticky) Follow() error {
+	tty, err := s.CurrentClientTTY()
+	if err != nil {
+		return err
+	}
+	key := EnvKey(tty)
+	val, set, err := s.ReadEnv(key)
+	if err != nil {
+		return err
+	}
+	if !set || val == "" {
+		return nil
+	}
+	alive, err := s.PaneAlive(val)
+	if err != nil {
+		return err
+	}
+	if !alive {
+		return nil
+	}
+	curr, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	if err != nil {
+		return fmt.Errorf("tmux display-message current target: %w", err)
+	}
+	curr = strings.TrimSpace(curr)
+	paneSession, err := s.T.Output("display-message", "-p", "-t", val, "#{session_id}")
+	if err != nil {
+		return fmt.Errorf("tmux display-message pane session: %w", err)
+	}
+	paneSession = strings.TrimSpace(paneSession)
+	currParts := strings.SplitN(curr, ":", 2)
+	if len(currParts) < 2 {
+		return fmt.Errorf("unexpected current target %q", curr)
+	}
+	if paneSession == currParts[0] {
+		return nil
+	}
+	widthStr, _ := s.T.Output("display-message", "-p", "-t", val, "#{pane_width}")
+	width, _ := strconv.Atoi(strings.TrimSpace(widthStr))
+	if width <= 0 {
+		width = config.DefaultStickySidebarWidth
+	}
+	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-l", strconv.Itoa(width), "-s", val, "-t", curr)
+	return nil
+}

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -8,12 +8,14 @@ import (
 	"github.com/rtalexk/demux/internal/config"
 )
 
-// Follow moves the sticky sidebar pane into the current client's session,
-// preserving the pane's current width. It is a no-op when:
+// Follow moves the sticky sidebar pane into the current client's window
+// (which implies the current session too), preserving the pane's current
+// width. It is a no-op when:
 //   - no sidebar is tracked for this client,
 //   - the tracked pane is gone (user runs `show` to recreate),
-//   - the pane is already in the current session.
+//   - the pane is already in the current window.
 //
+// join-pane uses -d so user focus stays in the non-sidebar pane after the move.
 // join-pane failures are swallowed so the tmux hook that drives Follow never
 // crashes user navigation.
 func (s *Sticky) Follow() error {
@@ -41,16 +43,16 @@ func (s *Sticky) Follow() error {
 		return fmt.Errorf("tmux display-message current target: %w", err)
 	}
 	curr = strings.TrimSpace(curr)
-	paneSession, err := s.T.Output("display-message", "-p", "-t", val, "#{session_id}")
+	paneWindow, err := s.T.Output("display-message", "-p", "-t", val, "#{window_id}")
 	if err != nil {
-		return fmt.Errorf("tmux display-message pane session: %w", err)
+		return fmt.Errorf("tmux display-message pane window: %w", err)
 	}
-	paneSession = strings.TrimSpace(paneSession)
+	paneWindow = strings.TrimSpace(paneWindow)
 	currParts := strings.SplitN(curr, ":", 2)
 	if len(currParts) < 2 {
 		return fmt.Errorf("unexpected current target %q", curr)
 	}
-	if paneSession == currParts[0] {
+	if paneWindow == currParts[1] {
 		return nil
 	}
 	widthStr, _ := s.T.Output("display-message", "-p", "-t", val, "#{pane_width}")
@@ -58,6 +60,6 @@ func (s *Sticky) Follow() error {
 	if width <= 0 {
 		width = config.DefaultStickySidebarWidth
 	}
-	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-l", strconv.Itoa(width), "-s", val, "-t", curr)
+	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-d", "-l", strconv.Itoa(width), "-s", val, "-t", curr)
 	return nil
 }

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -60,6 +60,34 @@ func (s *Sticky) Follow() error {
 	if width <= 0 {
 		width = config.DefaultStickySidebarWidth
 	}
+	if s.Slots {
+		return s.followSlotsMode(val, curr, width)
+	}
 	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-d", "-l", strconv.Itoa(width), "-s", val, "-t", curr)
+	return nil
+}
+
+// followSlotsMode swaps the active sidebar pane with the destination window's
+// slot pane (zero-flicker compared to join-pane), then resizes the swapped
+// pane to preserve the user's chosen width.
+func (s *Sticky) followSlotsMode(activePane, currTarget string, width int) error {
+	slot, err := s.FindSlotInWindow(currTarget)
+	if err != nil {
+		return err
+	}
+	if slot == "" {
+		if err := s.EnsureSlotInWindow(currTarget, width); err != nil {
+			return nil
+		}
+		slot, err = s.FindSlotInWindow(currTarget)
+		if err != nil || slot == "" {
+			return nil
+		}
+	}
+	if slot == activePane {
+		return nil
+	}
+	_ = s.T.Run("swap-pane", "-d", "-s", activePane, "-t", slot)
+	_ = s.T.Run("resize-pane", "-t", activePane, "-x", strconv.Itoa(width))
 	return nil
 }

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -61,10 +61,25 @@ func (s *Sticky) Follow() error {
 		width = config.DefaultStickySidebarWidth
 	}
 	if s.Slots {
-		return s.followSlotsMode(val, curr, width)
+		if err := s.followSlotsMode(val, curr, width); err != nil {
+			return err
+		}
+		s.pokeRefresh(val)
+		return nil
 	}
 	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-d", "-l", strconv.Itoa(width), "-s", val, "-t", curr)
+	s.pokeRefresh(val)
 	return nil
+}
+
+// pokeRefresh sends the TUI's force-refresh key ("R") to the sticky pane so
+// it picks up the new active session/window immediately instead of waiting
+// for its next refresh tick.
+func (s *Sticky) pokeRefresh(paneID string) {
+	if paneID == "" {
+		return
+	}
+	_ = s.T.Run("send-keys", "-t", paneID, "R")
 }
 
 // followSlotsMode swaps the active sidebar pane with the destination window's

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -46,21 +46,15 @@ func (s *Sticky) Follow() error {
 		}
 		return nil
 	}
-	curr, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	curr, currSession, currWindow, err := s.currentTarget()
 	if err != nil {
-		return fmt.Errorf("tmux display-message current target: %w", err)
+		return err
 	}
-	curr = strings.TrimSpace(curr)
 	paneWindow, err := s.T.Output("display-message", "-p", "-t", val, "#{window_id}")
 	if err != nil {
 		return fmt.Errorf("tmux display-message pane window: %w", err)
 	}
 	paneWindow = strings.TrimSpace(paneWindow)
-	currParts := strings.SplitN(curr, ":", 2)
-	if len(currParts) < 2 {
-		return fmt.Errorf("unexpected current target %q", curr)
-	}
-	currSession, currWindow := currParts[0], currParts[1]
 	widthStr, _ := s.T.Output("display-message", "-p", "-t", val, "#{pane_width}")
 	width, _ := strconv.Atoi(strings.TrimSpace(widthStr))
 	if width <= 0 {

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -64,12 +64,32 @@ func (s *Sticky) Follow() error {
 		if err := s.followSlotsMode(val, curr, width); err != nil {
 			return err
 		}
+		s.ejectFocusIfOnSidebar(val)
 		s.pokeRefresh(val)
 		return nil
 	}
 	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-d", "-l", strconv.Itoa(width), "-s", val, "-t", curr)
+	s.ejectFocusIfOnSidebar(val)
 	s.pokeRefresh(val)
 	return nil
+}
+
+// ejectFocusIfOnSidebar moves the client focus to the next pane in the
+// current window when the sidebar pane is the active pane. Matches tmux's
+// `prefix + o`. Without this, sticky-mode users who left focus inside the
+// sidebar before switching tmux windows would still be inside the sidebar
+// after the follow.
+func (s *Sticky) ejectFocusIfOnSidebar(sidebarPane string) {
+	if sidebarPane == "" {
+		return
+	}
+	out, err := s.T.Output("display-message", "-p", "#{pane_id}")
+	if err != nil {
+		return
+	}
+	if strings.TrimSpace(out) == sidebarPane {
+		_ = s.T.Run("select-pane", "-t", ":.+")
+	}
 }
 
 // pokeRefresh sends F12 to the sticky pane. The TUI binds F12 (only

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -36,6 +36,14 @@ func (s *Sticky) Follow() error {
 		return err
 	}
 	if !alive {
+		// The tracked sticky pane was killed externally (e.g. prefix x).
+		// Clean up the env var, and in slots mode tear down the leftover
+		// placeholder panes so they don't linger in every other window.
+		// Best-effort: ignore errors so the hook never crashes navigation.
+		_ = s.UnsetEnv(key)
+		if s.Slots {
+			_ = s.UninstallSlots()
+		}
 		return nil
 	}
 	curr, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")

--- a/internal/sticky/follow_test.go
+++ b/internal/sticky/follow_test.go
@@ -190,12 +190,12 @@ func TestFollow_PokesRefreshAfterMove(t *testing.T) {
 	}
 	saw := false
 	for _, r := range f.runs {
-		if strings.Join(r, " ") == "send-keys -t %42 R" {
+		if strings.Join(r, " ") == "send-keys -t %42 F12" {
 			saw = true
 		}
 	}
 	if !saw {
-		t.Errorf("expected send-keys -t %%42 R after move, got: %v", f.runs)
+		t.Errorf("expected send-keys -t %%42 F12 after move, got: %v", f.runs)
 	}
 }
 

--- a/internal/sticky/follow_test.go
+++ b/internal/sticky/follow_test.go
@@ -1,0 +1,102 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFollow_EnvUnset_Noop(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "join-pane") {
+			t.Errorf("expected no join-pane (noop), got: %v", r)
+		}
+	}
+}
+
+func TestFollow_PaneAlreadyInCurrentSession_Noop(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["display-message -p -t %42 #{session_id}"] = fakeReply{out: "$1\n"}
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "join-pane") {
+			t.Errorf("expected no join-pane (same session), got: %v", r)
+		}
+	}
+}
+
+func TestFollow_DifferentSession_JoinsWithFFlagAndPreservedWidth(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
+	f.outputs["display-message -p -t %42 #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "48\n"}
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	want := "join-pane -f -h -b -l 48 -s %42 -t $2:@9"
+	found := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want join-pane call %q, got: %v", want, f.runs)
+	}
+}
+
+func TestFollow_InvalidWidth_FallsBackToDefault(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
+	f.outputs["display-message -p -t %42 #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "0\n"}
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	want := "join-pane -f -h -b -l 35 -s %42 -t $2:@9"
+	found := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want fallback-width join-pane call %q, got: %v", want, f.runs)
+	}
+}
+
+func TestFollow_JoinFailure_DoesNotPropagate(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
+	f.outputs["display-message -p -t %42 #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "48\n"}
+	f.runErrs["join-pane -f -h -b -l 48 -s %42 -t $2:@9"] = stderrExitError("target session vanished")
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Errorf("Follow should swallow join-pane failure, got: %v", err)
+	}
+}

--- a/internal/sticky/follow_test.go
+++ b/internal/sticky/follow_test.go
@@ -199,6 +199,52 @@ func TestFollow_PokesRefreshAfterMove(t *testing.T) {
 	}
 }
 
+func TestFollow_EjectsFocusWhenSidebarIsActive(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@3\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "48\n"}
+	// After follow's move, the sidebar pane is the active pane → eject.
+	f.outputs["display-message -p #{pane_id}"] = fakeReply{out: "%42\n"}
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "select-pane -t :.+" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected select-pane -t :.+ to eject focus, got: %v", f.runs)
+	}
+}
+
+func TestFollow_DoesNotEjectFocusWhenSidebarNotActive(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@3\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "48\n"}
+	// Active pane is NOT the sidebar.
+	f.outputs["display-message -p #{pane_id}"] = fakeReply{out: "%99\n"}
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "select-pane -t :.+" {
+			t.Errorf("did not expect select-pane when sidebar isn't active, got: %v", f.runs)
+		}
+	}
+}
+
 func TestFollow_JoinFailure_DoesNotPropagate(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}

--- a/internal/sticky/follow_test.go
+++ b/internal/sticky/follow_test.go
@@ -176,6 +176,29 @@ func TestFollow_SlotsMode_NoSlotInTarget_CreatesOne(t *testing.T) {
 	}
 }
 
+func TestFollow_PokesRefreshAfterMove(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@3\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "48\n"}
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "send-keys -t %42 R" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected send-keys -t %%42 R after move, got: %v", f.runs)
+	}
+}
+
 func TestFollow_JoinFailure_DoesNotPropagate(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}

--- a/internal/sticky/follow_test.go
+++ b/internal/sticky/follow_test.go
@@ -199,6 +199,39 @@ func TestFollow_PokesRefreshAfterMove(t *testing.T) {
 	}
 }
 
+func TestFollow_DeadTrackedPane_CleansSlotsAndEnv(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	// Tracked pane %42 is no longer in list-panes.
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%1\n%2\n"}
+	// UninstallSlots will scan tags; placeholder slots remain in other windows.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n%60 1\n"}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	var unset, kill50, kill60 bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			unset = true
+		}
+		if j == "kill-pane -t %50" {
+			kill50 = true
+		}
+		if j == "kill-pane -t %60" {
+			kill60 = true
+		}
+	}
+	if !unset {
+		t.Errorf("expected env var unset on dead pane, got: %v", f.runs)
+	}
+	if !kill50 || !kill60 {
+		t.Errorf("expected leftover slots %%50 and %%60 killed, got: %v", f.runs)
+	}
+}
+
 func TestFollow_EjectsFocusWhenSidebarIsActive(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}

--- a/internal/sticky/follow_test.go
+++ b/internal/sticky/follow_test.go
@@ -20,21 +20,45 @@ func TestFollow_EnvUnset_Noop(t *testing.T) {
 	}
 }
 
-func TestFollow_PaneAlreadyInCurrentSession_Noop(t *testing.T) {
+func TestFollow_PaneAlreadyInCurrentWindow_Noop(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
 	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
-	f.outputs["display-message -p -t %42 #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@7\n"}
 	s := &Sticky{T: f}
 	if err := s.Follow(); err != nil {
 		t.Fatalf("Follow: %v", err)
 	}
 	for _, r := range f.runs {
 		if strings.HasPrefix(strings.Join(r, " "), "join-pane") {
-			t.Errorf("expected no join-pane (same session), got: %v", r)
+			t.Errorf("expected no join-pane (same window), got: %v", r)
 		}
+	}
+}
+
+func TestFollow_DifferentWindowSameSession_JoinsAndKeepsFocus(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@9\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@7\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "48\n"}
+	s := &Sticky{T: f}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	want := "join-pane -f -h -b -d -l 48 -s %42 -t $1:@9"
+	found := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want join-pane call %q, got: %v", want, f.runs)
 	}
 }
 
@@ -44,13 +68,13 @@ func TestFollow_DifferentSession_JoinsWithFFlagAndPreservedWidth(t *testing.T) {
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
 	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
-	f.outputs["display-message -p -t %42 #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@3\n"}
 	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "48\n"}
 	s := &Sticky{T: f}
 	if err := s.Follow(); err != nil {
 		t.Fatalf("Follow: %v", err)
 	}
-	want := "join-pane -f -h -b -l 48 -s %42 -t $2:@9"
+	want := "join-pane -f -h -b -d -l 48 -s %42 -t $2:@9"
 	found := false
 	for _, r := range f.runs {
 		if strings.Join(r, " ") == want {
@@ -68,13 +92,13 @@ func TestFollow_InvalidWidth_FallsBackToDefault(t *testing.T) {
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
 	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
-	f.outputs["display-message -p -t %42 #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@3\n"}
 	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "0\n"}
 	s := &Sticky{T: f}
 	if err := s.Follow(); err != nil {
 		t.Fatalf("Follow: %v", err)
 	}
-	want := "join-pane -f -h -b -l 35 -s %42 -t $2:@9"
+	want := "join-pane -f -h -b -d -l 35 -s %42 -t $2:@9"
 	found := false
 	for _, r := range f.runs {
 		if strings.Join(r, " ") == want {
@@ -92,9 +116,9 @@ func TestFollow_JoinFailure_DoesNotPropagate(t *testing.T) {
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
 	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
-	f.outputs["display-message -p -t %42 #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@3\n"}
 	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "48\n"}
-	f.runErrs["join-pane -f -h -b -l 48 -s %42 -t $2:@9"] = stderrExitError("target session vanished")
+	f.runErrs["join-pane -f -h -b -d -l 48 -s %42 -t $2:@9"] = stderrExitError("target session vanished")
 	s := &Sticky{T: f}
 	if err := s.Follow(); err != nil {
 		t.Errorf("Follow should swallow join-pane failure, got: %v", err)

--- a/internal/sticky/follow_test.go
+++ b/internal/sticky/follow_test.go
@@ -110,6 +110,72 @@ func TestFollow_InvalidWidth_FallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestFollow_SlotsMode_SwapsAndResizes(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@9\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@7\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "50\n"}
+	f.outputs["list-panes -t $1:@9 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n%51 \n"}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	var sawSwap, sawResize, sawJoin bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "swap-pane -d -s %42 -t %50" {
+			sawSwap = true
+		}
+		if j == "resize-pane -t %42 -x 50" {
+			sawResize = true
+		}
+		if strings.HasPrefix(j, "join-pane") {
+			sawJoin = true
+		}
+	}
+	if !sawSwap {
+		t.Errorf("expected swap-pane -d -s %%42 -t %%50, got: %v", f.runs)
+	}
+	if !sawResize {
+		t.Errorf("expected resize-pane -t %%42 -x 50, got: %v", f.runs)
+	}
+	if sawJoin {
+		t.Errorf("expected no join-pane in slots mode, got: %v", f.runs)
+	}
+}
+
+func TestFollow_SlotsMode_NoSlotInTarget_CreatesOne(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@9\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@7\n"}
+	f.outputs["display-message -p -t %42 #{pane_width}"] = fakeReply{out: "50\n"}
+	// Window @9 has no slot initially.
+	f.outputs["list-panes -t $1:@9 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%9 \n"}
+	f.outputs["split-window -f -h -b -d -l 50 -t $1:@9 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%55\n"}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.Follow(); err != nil {
+		t.Fatalf("Follow: %v", err)
+	}
+	// The slot is created. The follow-up FindSlotInWindow call uses the same
+	// list-panes mock (unchanged), so it returns no slot and Follow returns
+	// without swap. The important assertion is: a new slot was tagged.
+	sawTag := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "set-option -p -t %55 @demux_slot 1" {
+			sawTag = true
+		}
+	}
+	if !sawTag {
+		t.Errorf("expected new slot to be tagged in target window, got: %v", f.runs)
+	}
+}
+
 func TestFollow_JoinFailure_DoesNotPropagate(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}

--- a/internal/sticky/gc.go
+++ b/internal/sticky/gc.go
@@ -2,7 +2,6 @@ package sticky
 
 import (
 	"fmt"
-	"strings"
 )
 
 // ClearStickyEnvForPane scans every tmux server-global env var and unsets any
@@ -16,23 +15,14 @@ import (
 // In split mode there are no slot-tagged panes, so the uninstall pass is a
 // no-op.
 func ClearStickyEnvForPane(t Tmux, paneID string) error {
-	out, err := t.Output("show-environment", "-g")
+	envs, err := listStickyPaneEnv(t)
 	if err != nil {
 		return fmt.Errorf("tmux show-environment -g: %w", err)
 	}
 	matched := false
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, envKeyPrefix) {
-			continue
-		}
-		eq := strings.IndexByte(line, '=')
-		if eq < 0 {
-			continue
-		}
-		k, v := line[:eq], line[eq+1:]
-		if v == paneID {
-			_ = t.Run("set-environment", "-gu", k)
+	for _, e := range envs {
+		if e.pane == paneID {
+			_ = t.Run("set-environment", "-gu", e.key)
 			matched = true
 		}
 	}

--- a/internal/sticky/gc.go
+++ b/internal/sticky/gc.go
@@ -1,0 +1,32 @@
+package sticky
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ClearStickyEnvForPane scans every tmux server-global env var and unsets any
+// DEMUX_STICKY_PANE_* whose value matches paneID. Intended to be called from
+// the `after-kill-pane` hook path so a manual prefix-x on the sticky pane
+// cleanly converts to "sticky off for that client".
+func ClearStickyEnvForPane(t Tmux, paneID string) error {
+	out, err := t.Output("show-environment", "-g")
+	if err != nil {
+		return fmt.Errorf("tmux show-environment -g: %w", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, envKeyPrefix) {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		k, v := line[:eq], line[eq+1:]
+		if v == paneID {
+			_ = t.Run("set-environment", "-gu", k)
+		}
+	}
+	return nil
+}

--- a/internal/sticky/gc.go
+++ b/internal/sticky/gc.go
@@ -9,11 +9,18 @@ import (
 // DEMUX_STICKY_PANE_* whose value matches paneID. Intended to be called from
 // the `after-kill-pane` hook path so a manual prefix-x on the sticky pane
 // cleanly converts to "sticky off for that client".
+//
+// If at least one env var matched the killed pane (i.e. the user killed an
+// active sticky sidebar), any remaining slot panes are also uninstalled so
+// slots mode does not leave orphan placeholders across the other windows.
+// In split mode there are no slot-tagged panes, so the uninstall pass is a
+// no-op.
 func ClearStickyEnvForPane(t Tmux, paneID string) error {
 	out, err := t.Output("show-environment", "-g")
 	if err != nil {
 		return fmt.Errorf("tmux show-environment -g: %w", err)
 	}
+	matched := false
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, envKeyPrefix) {
@@ -26,7 +33,11 @@ func ClearStickyEnvForPane(t Tmux, paneID string) error {
 		k, v := line[:eq], line[eq+1:]
 		if v == paneID {
 			_ = t.Run("set-environment", "-gu", k)
+			matched = true
 		}
+	}
+	if matched {
+		_ = (&Sticky{T: t}).UninstallSlots()
 	}
 	return nil
 }

--- a/internal/sticky/gc_test.go
+++ b/internal/sticky/gc_test.go
@@ -1,0 +1,52 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClearStickyEnvForPane_MatchUnsets(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: strings.Join([]string{
+		"SOMETHING_ELSE=value",
+		"DEMUX_STICKY_PANE__dev_ttys001=%42",
+		"DEMUX_STICKY_PANE__dev_ttys003=%99",
+		"",
+	}, "\n")}
+	if err := ClearStickyEnvForPane(f, "%42"); err != nil {
+		t.Fatalf("ClearStickyEnvForPane: %v", err)
+	}
+	sawUnset := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			sawUnset = true
+		}
+		if strings.Join(r, " ") == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys003" {
+			t.Errorf("unexpected unset of non-matching key: %v", r)
+		}
+	}
+	if !sawUnset {
+		t.Errorf("expected unset of DEMUX_STICKY_PANE__dev_ttys001, got: %v", f.runs)
+	}
+}
+
+func TestClearStickyEnvForPane_NoMatch_NoUnset(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%99\n"}
+	if err := ClearStickyEnvForPane(f, "%42"); err != nil {
+		t.Fatalf("ClearStickyEnvForPane: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "set-environment") {
+			t.Errorf("expected no unset, got: %v", r)
+		}
+	}
+}
+
+func TestClearStickyEnvForPane_TmuxError_ReturnsError(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{err: stderrExitError("no server\n")}
+	if err := ClearStickyEnvForPane(f, "%42"); err == nil {
+		t.Error("expected error to surface")
+	}
+}

--- a/internal/sticky/gc_test.go
+++ b/internal/sticky/gc_test.go
@@ -43,6 +43,55 @@ func TestClearStickyEnvForPane_NoMatch_NoUnset(t *testing.T) {
 	}
 }
 
+func TestClearStickyEnvForPane_MatchAlsoUninstallsRemainingSlots(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	// UninstallSlots will run list-panes -aF; placeholder slots remain.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n%60 1\n%99 \n"}
+	if err := ClearStickyEnvForPane(f, "%42"); err != nil {
+		t.Fatalf("ClearStickyEnvForPane: %v", err)
+	}
+	var unset, kill50, kill60, killNonSlot bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			unset = true
+		}
+		if j == "kill-pane -t %50" {
+			kill50 = true
+		}
+		if j == "kill-pane -t %60" {
+			kill60 = true
+		}
+		if j == "kill-pane -t %99" {
+			killNonSlot = true
+		}
+	}
+	if !unset {
+		t.Errorf("expected env unset, got: %v", f.runs)
+	}
+	if !kill50 || !kill60 {
+		t.Errorf("expected slot panes %%50 and %%60 killed, got: %v", f.runs)
+	}
+	if killNonSlot {
+		t.Errorf("did not expect non-slot pane %%99 to be killed, got: %v", f.runs)
+	}
+}
+
+func TestClearStickyEnvForPane_NoMatch_NoUninstall(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%99\n"}
+	if err := ClearStickyEnvForPane(f, "%42"); err != nil {
+		t.Fatalf("ClearStickyEnvForPane: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane") {
+			t.Errorf("expected no kill-pane when no env match, got: %v", r)
+		}
+	}
+}
+
 func TestClearStickyEnvForPane_TmuxError_ReturnsError(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["show-environment -g"] = fakeReply{err: stderrExitError("no server\n")}

--- a/internal/sticky/hide.go
+++ b/internal/sticky/hide.go
@@ -20,6 +20,11 @@ func (s *Sticky) Hide() error {
 		return nil
 	}
 	if s.Slots {
+		// Kill the active sidebar pane first so the user perceives an
+		// instant dismissal, then sweep the remaining placeholder slots.
+		if val != "" {
+			_ = s.T.Run("kill-pane", "-t", val)
+		}
 		_ = s.UninstallSlots()
 	} else if val != "" {
 		_ = s.T.Run("kill-pane", "-t", val)

--- a/internal/sticky/hide.go
+++ b/internal/sticky/hide.go
@@ -1,12 +1,11 @@
 package sticky
 
-// Hide deactivates the sticky sidebar pane for the current client.
+// Hide tears down the sticky sidebar for the current client.
 //
-// In split mode the pane is killed. In slots mode the pane is respawned with
-// the slot placeholder so the slot stays in place (matching the rest of the
-// windows). The env var is always cleared so the next Show treats the
-// sidebar as inactive. Errors from kill-pane/respawn-pane (typically "pane
-// not found" after a manual kill) are tolerated.
+// In split mode the tracked pane is killed. In slots mode every slot pane on
+// the server is killed (including the active sidebar pane, which itself is
+// tagged @demux_slot). The env var is always cleared so the next Show
+// treats the sidebar as inactive. Errors from kill-pane are tolerated.
 func (s *Sticky) Hide() error {
 	tty, err := s.CurrentClientTTY()
 	if err != nil {
@@ -20,12 +19,10 @@ func (s *Sticky) Hide() error {
 	if !set {
 		return nil
 	}
-	if val != "" {
-		if s.Slots {
-			_ = s.T.Run("respawn-pane", "-k", "-t", val, SlotPlaceholderCmd)
-		} else {
-			_ = s.T.Run("kill-pane", "-t", val)
-		}
+	if s.Slots {
+		_ = s.UninstallSlots()
+	} else if val != "" {
+		_ = s.T.Run("kill-pane", "-t", val)
 	}
 	return s.UnsetEnv(key)
 }

--- a/internal/sticky/hide.go
+++ b/internal/sticky/hide.go
@@ -1,0 +1,23 @@
+package sticky
+
+// Hide removes the sticky sidebar pane for the current client. It is a no-op
+// when no pane is tracked. Errors from kill-pane (typically "pane not found"
+// after a manual kill) are tolerated so the env var is still cleared.
+func (s *Sticky) Hide() error {
+	tty, err := s.CurrentClientTTY()
+	if err != nil {
+		return err
+	}
+	key := EnvKey(tty)
+	val, set, err := s.ReadEnv(key)
+	if err != nil {
+		return err
+	}
+	if !set {
+		return nil
+	}
+	if val != "" {
+		_ = s.T.Run("kill-pane", "-t", val)
+	}
+	return s.UnsetEnv(key)
+}

--- a/internal/sticky/hide.go
+++ b/internal/sticky/hide.go
@@ -1,8 +1,12 @@
 package sticky
 
-// Hide removes the sticky sidebar pane for the current client. It is a no-op
-// when no pane is tracked. Errors from kill-pane (typically "pane not found"
-// after a manual kill) are tolerated so the env var is still cleared.
+// Hide deactivates the sticky sidebar pane for the current client.
+//
+// In split mode the pane is killed. In slots mode the pane is respawned with
+// the slot placeholder so the slot stays in place (matching the rest of the
+// windows). The env var is always cleared so the next Show treats the
+// sidebar as inactive. Errors from kill-pane/respawn-pane (typically "pane
+// not found" after a manual kill) are tolerated.
 func (s *Sticky) Hide() error {
 	tty, err := s.CurrentClientTTY()
 	if err != nil {
@@ -17,7 +21,11 @@ func (s *Sticky) Hide() error {
 		return nil
 	}
 	if val != "" {
-		_ = s.T.Run("kill-pane", "-t", val)
+		if s.Slots {
+			_ = s.T.Run("respawn-pane", "-k", "-t", val, SlotPlaceholderCmd)
+		} else {
+			_ = s.T.Run("kill-pane", "-t", val)
+		}
 	}
 	return s.UnsetEnv(key)
 }

--- a/internal/sticky/hide_test.go
+++ b/internal/sticky/hide_test.go
@@ -50,6 +50,38 @@ func TestHide_EnvSet_KillsPaneAndUnsets(t *testing.T) {
 	}
 }
 
+func TestHide_SlotsMode_RespawnsPlaceholder(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.Hide(); err != nil {
+		t.Fatalf("Hide: %v", err)
+	}
+	var sawRespawn, sawKill, sawUnset bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "respawn-pane -k -t %42 demux sidebar slot" {
+			sawRespawn = true
+		}
+		if strings.HasPrefix(j, "kill-pane") {
+			sawKill = true
+		}
+		if j == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			sawUnset = true
+		}
+	}
+	if !sawRespawn {
+		t.Errorf("expected respawn-pane to placeholder, got: %v", f.runs)
+	}
+	if sawKill {
+		t.Errorf("expected no kill-pane in slots mode, got: %v", f.runs)
+	}
+	if !sawUnset {
+		t.Errorf("expected env unset, got: %v", f.runs)
+	}
+}
+
 func TestHide_KillPaneFailure_StillUnsets(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}

--- a/internal/sticky/hide_test.go
+++ b/internal/sticky/hide_test.go
@@ -50,37 +50,41 @@ func TestHide_EnvSet_KillsPaneAndUnsets(t *testing.T) {
 	}
 }
 
-func TestHide_SlotsMode_UninstallsAllSlots(t *testing.T) {
+func TestHide_SlotsMode_KillsActiveFirstThenSweeps(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
-	// UninstallSlots scans all panes; active (%42) and three other slots.
-	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%42 1\n%50 1\n%60 1\n%99 \n"}
+	// After active is killed, sweep finds only the remaining placeholders.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%50 1\n%60 1\n%99 \n"}
 	s := &Sticky{T: f, Slots: true}
 	if err := s.Hide(); err != nil {
 		t.Fatalf("Hide: %v", err)
 	}
-	wantKills := map[string]bool{
-		"kill-pane -t %42": false,
-		"kill-pane -t %50": false,
-		"kill-pane -t %60": false,
-	}
+	// Find first kill-pane call: must target the active pane (%42).
+	var killOrder []string
 	var sawUnset bool
 	for _, r := range f.runs {
 		j := strings.Join(r, " ")
-		if _, ok := wantKills[j]; ok {
-			wantKills[j] = true
-		}
-		if strings.HasPrefix(j, "kill-pane -t %1") || strings.HasPrefix(j, "kill-pane -t %99") {
-			t.Errorf("kill-pane on non-slot pane: %q", j)
+		if strings.HasPrefix(j, "kill-pane -t ") {
+			killOrder = append(killOrder, strings.TrimPrefix(j, "kill-pane -t "))
 		}
 		if j == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
 			sawUnset = true
 		}
 	}
-	for k, ok := range wantKills {
+	if len(killOrder) == 0 || killOrder[0] != "%42" {
+		t.Errorf("first kill must be active pane %%42, got order: %v", killOrder)
+	}
+	want := map[string]bool{"%42": false, "%50": false, "%60": false}
+	for _, p := range killOrder {
+		if _, ok := want[p]; !ok {
+			t.Errorf("unexpected kill target: %q", p)
+		}
+		want[p] = true
+	}
+	for k, ok := range want {
 		if !ok {
-			t.Errorf("missing expected kill-pane: %s", k)
+			t.Errorf("missing kill-pane for %s", k)
 		}
 	}
 	if !sawUnset {

--- a/internal/sticky/hide_test.go
+++ b/internal/sticky/hide_test.go
@@ -50,32 +50,38 @@ func TestHide_EnvSet_KillsPaneAndUnsets(t *testing.T) {
 	}
 }
 
-func TestHide_SlotsMode_RespawnsPlaceholder(t *testing.T) {
+func TestHide_SlotsMode_UninstallsAllSlots(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	// UninstallSlots scans all panes; active (%42) and three other slots.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%42 1\n%50 1\n%60 1\n%99 \n"}
 	s := &Sticky{T: f, Slots: true}
 	if err := s.Hide(); err != nil {
 		t.Fatalf("Hide: %v", err)
 	}
-	var sawRespawn, sawKill, sawUnset bool
+	wantKills := map[string]bool{
+		"kill-pane -t %42": false,
+		"kill-pane -t %50": false,
+		"kill-pane -t %60": false,
+	}
+	var sawUnset bool
 	for _, r := range f.runs {
 		j := strings.Join(r, " ")
-		if j == "respawn-pane -k -t %42 demux sidebar slot" {
-			sawRespawn = true
+		if _, ok := wantKills[j]; ok {
+			wantKills[j] = true
 		}
-		if strings.HasPrefix(j, "kill-pane") {
-			sawKill = true
+		if strings.HasPrefix(j, "kill-pane -t %1") || strings.HasPrefix(j, "kill-pane -t %99") {
+			t.Errorf("kill-pane on non-slot pane: %q", j)
 		}
 		if j == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
 			sawUnset = true
 		}
 	}
-	if !sawRespawn {
-		t.Errorf("expected respawn-pane to placeholder, got: %v", f.runs)
-	}
-	if sawKill {
-		t.Errorf("expected no kill-pane in slots mode, got: %v", f.runs)
+	for k, ok := range wantKills {
+		if !ok {
+			t.Errorf("missing expected kill-pane: %s", k)
+		}
 	}
 	if !sawUnset {
 		t.Errorf("expected env unset, got: %v", f.runs)

--- a/internal/sticky/hide_test.go
+++ b/internal/sticky/hide_test.go
@@ -1,0 +1,71 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHide_EnvUnset_Noop(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	s := &Sticky{T: f}
+	if err := s.Hide(); err != nil {
+		t.Fatalf("Hide: %v", err)
+	}
+	for _, r := range f.runs {
+		joined := strings.Join(r, " ")
+		if strings.HasPrefix(joined, "kill-pane") {
+			t.Errorf("expected no kill-pane (noop), got: %v", r)
+		}
+		if strings.HasPrefix(joined, "set-environment") {
+			t.Errorf("expected no set-environment (noop), got: %v", r)
+		}
+	}
+}
+
+func TestHide_EnvSet_KillsPaneAndUnsets(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	s := &Sticky{T: f}
+	if err := s.Hide(); err != nil {
+		t.Fatalf("Hide: %v", err)
+	}
+	var sawKill, sawUnset bool
+	for _, r := range f.runs {
+		joined := strings.Join(r, " ")
+		if joined == "kill-pane -t %42" {
+			sawKill = true
+		}
+		if joined == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			sawUnset = true
+		}
+	}
+	if !sawKill {
+		t.Errorf("expected kill-pane call, got runs: %v", f.runs)
+	}
+	if !sawUnset {
+		t.Errorf("expected unset-env call, got runs: %v", f.runs)
+	}
+}
+
+func TestHide_KillPaneFailure_StillUnsets(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.runErrs["kill-pane -t %42"] = stderrExitError("can't find pane: %42\n")
+	s := &Sticky{T: f}
+	if err := s.Hide(); err != nil {
+		t.Fatalf("Hide should tolerate kill-pane failure, got: %v", err)
+	}
+	sawUnset := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			sawUnset = true
+		}
+	}
+	if !sawUnset {
+		t.Errorf("expected env unset even when kill-pane failed, got runs: %v", f.runs)
+	}
+}

--- a/internal/sticky/mru.go
+++ b/internal/sticky/mru.go
@@ -1,0 +1,112 @@
+package sticky
+
+import (
+	"strings"
+)
+
+// MRUEnvKey is the tmux global env var that stores the bounded MRU list of
+// window ids that should receive sidebar slot panes. Head = most recently
+// visited. Comma-separated. Bounded at MRUMaxLen.
+const MRUEnvKey = "DEMUX_STICKY_MRU"
+
+// MRUMaxLen caps both the in-memory MRU history and the placeholder slot
+// budget. Total slot panes on the server is at most MRUMaxLen placeholders
+// plus 1 for the active sidebar in the current window.
+const MRUMaxLen = 8
+
+// ReadMRU returns the MRU window-id list from the tmux global env var. Empty
+// when unset. Entries are returned in MRU order (head = most recent).
+func (s *Sticky) ReadMRU() ([]string, error) {
+	val, set, err := s.ReadEnv(MRUEnvKey)
+	if err != nil {
+		return nil, err
+	}
+	if !set || val == "" {
+		return nil, nil
+	}
+	parts := strings.Split(val, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// WriteMRU persists the MRU list to the tmux env var. An empty list unsets it.
+func (s *Sticky) WriteMRU(list []string) error {
+	if len(list) == 0 {
+		return s.UnsetEnv(MRUEnvKey)
+	}
+	return s.WriteEnv(MRUEnvKey, strings.Join(list, ","))
+}
+
+// PushMRU moves windowID to the head of the MRU list and persists it. Dedupes
+// any existing occurrence. Trims the tail to MRUMaxLen entries. Empty
+// windowID is a no-op.
+func (s *Sticky) PushMRU(windowID string) error {
+	if windowID == "" {
+		return nil
+	}
+	current, err := s.ReadMRU()
+	if err != nil {
+		return err
+	}
+	out := make([]string, 0, len(current)+1)
+	out = append(out, windowID)
+	for _, w := range current {
+		if w == windowID {
+			continue
+		}
+		out = append(out, w)
+		if len(out) >= MRUMaxLen {
+			break
+		}
+	}
+	return s.WriteMRU(out)
+}
+
+// PruneMRU removes window ids that no longer exist on the tmux server from
+// the persisted MRU list. Safe to call before computing the reserved set so
+// stale entries do not consume budget that should go to live windows.
+func (s *Sticky) PruneMRU() error {
+	current, err := s.ReadMRU()
+	if err != nil {
+		return err
+	}
+	if len(current) == 0 {
+		return nil
+	}
+	live, err := s.liveWindowSet()
+	if err != nil {
+		return nil
+	}
+	kept := make([]string, 0, len(current))
+	for _, w := range current {
+		if _, ok := live[w]; ok {
+			kept = append(kept, w)
+		}
+	}
+	if len(kept) == len(current) {
+		return nil
+	}
+	return s.WriteMRU(kept)
+}
+
+// liveWindowSet returns the set of @N window ids currently known to tmux.
+func (s *Sticky) liveWindowSet() (map[string]struct{}, error) {
+	out, err := s.T.Output("list-windows", "-aF", "#{window_id}")
+	if err != nil {
+		return nil, err
+	}
+	live := make(map[string]struct{})
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			live[line] = struct{}{}
+		}
+	}
+	return live, nil
+}

--- a/internal/sticky/mru.go
+++ b/internal/sticky/mru.go
@@ -102,11 +102,8 @@ func (s *Sticky) liveWindowSet() (map[string]struct{}, error) {
 		return nil, err
 	}
 	live := make(map[string]struct{})
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			live[line] = struct{}{}
-		}
+	for _, line := range nonEmptyLines(out) {
+		live[line] = struct{}{}
 	}
 	return live, nil
 }

--- a/internal/sticky/mru_test.go
+++ b/internal/sticky/mru_test.go
@@ -1,0 +1,157 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadMRU_Unset(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{err: stderrExitError("unknown variable: " + MRUEnvKey)}
+	s := &Sticky{T: f}
+	got, err := s.ReadMRU()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty list, got %v", got)
+	}
+}
+
+func TestReadMRU_Set(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@5,@1,@3\n"}
+	s := &Sticky{T: f}
+	got, err := s.ReadMRU()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"@5", "@1", "@3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("ReadMRU: want %v, got %v", want, got)
+	}
+}
+
+func TestPushMRU_Empty_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f}
+	if err := s.PushMRU(""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no env writes, got: %v", f.runs)
+	}
+}
+
+func TestPushMRU_NewEntry(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{err: stderrExitError("unknown variable")}
+	s := &Sticky{T: f}
+	if err := s.PushMRU("@7"); err != nil {
+		t.Fatalf("PushMRU: %v", err)
+	}
+	want := "set-environment -g " + MRUEnvKey + " @7"
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected %q, got: %v", want, f.runs)
+	}
+}
+
+func TestPushMRU_Dedup_MovesToHead(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@1,@2,@3\n"}
+	s := &Sticky{T: f}
+	if err := s.PushMRU("@2"); err != nil {
+		t.Fatalf("PushMRU: %v", err)
+	}
+	want := "set-environment -g " + MRUEnvKey + " @2,@1,@3"
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected %q, got: %v", want, f.runs)
+	}
+}
+
+func TestPushMRU_CapAtMRUMaxLen(t *testing.T) {
+	f := newFakeTmux()
+	// Pre-fill MRU with 8 entries.
+	existing := []string{"@1", "@2", "@3", "@4", "@5", "@6", "@7", "@8"}
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=" + strings.Join(existing, ",") + "\n"}
+	s := &Sticky{T: f}
+	if err := s.PushMRU("@99"); err != nil {
+		t.Fatalf("PushMRU: %v", err)
+	}
+	// Expect @99,@1..@7 (tail @8 evicted).
+	want := "set-environment -g " + MRUEnvKey + " @99,@1,@2,@3,@4,@5,@6,@7"
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected %q, got: %v", want, f.runs)
+	}
+}
+
+func TestPruneMRU_DropsDeadEntries(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@1,@2,@3,@99\n"}
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@3\n"}
+	s := &Sticky{T: f}
+	if err := s.PruneMRU(); err != nil {
+		t.Fatalf("PruneMRU: %v", err)
+	}
+	want := "set-environment -g " + MRUEnvKey + " @1,@3"
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected %q, got: %v", want, f.runs)
+	}
+}
+
+func TestPruneMRU_AllLive_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@1,@2\n"}
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@2\n@5\n"}
+	s := &Sticky{T: f}
+	if err := s.PruneMRU(); err != nil {
+		t.Fatalf("PruneMRU: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "set-environment") {
+			t.Errorf("unexpected env write when all entries live: %v", r)
+		}
+	}
+}
+
+func TestWriteMRU_EmptyUnsets(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f}
+	if err := s.WriteMRU(nil); err != nil {
+		t.Fatalf("WriteMRU: %v", err)
+	}
+	want := "set-environment -gu " + MRUEnvKey
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected %q, got: %v", want, f.runs)
+	}
+}

--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/rtalexk/demux/internal/config"
+	demuxlog "github.com/rtalexk/demux/internal/log"
 )
 
 // HandleWindowAfterKill is invoked from the after-kill-pane hook with the
@@ -52,6 +53,7 @@ func (s *Sticky) HandleWindowAfterKill(windowID string) error {
 		return nil
 	}
 	isSlot := slot == "1"
+	demuxlog.Info("orphan: candidate", "window_id", windowID, "pane_id", orphan, "is_slot", isSlot)
 
 	isSidebar := false
 	if envOut, err := s.T.Output("show-environment", "-g"); err == nil {
@@ -73,7 +75,10 @@ func (s *Sticky) HandleWindowAfterKill(windowID string) error {
 
 	if !isSidebar {
 		if isSlot {
+			demuxlog.Info("orphan: kill placeholder", "window_id", windowID, "pane_id", orphan)
 			_ = s.T.Run("kill-pane", "-t", orphan)
+		} else {
+			demuxlog.Info("orphan: skip (not slot, not sidebar)", "window_id", windowID, "pane_id", orphan)
 		}
 		return nil
 	}
@@ -117,8 +122,10 @@ func (s *Sticky) HandleWindowAfterKill(windowID string) error {
 		target = fallback
 	}
 	if target == "" {
+		demuxlog.Info("orphan: no sibling window in session, skip", "window_id", windowID, "session_id", sessID)
 		return nil
 	}
+	demuxlog.Info("orphan: moving sidebar", "window_id", windowID, "pane_id", orphan, "target", target)
 
 	if targetSlot, _ := s.FindSlotInWindow(target); targetSlot != "" && targetSlot != orphan {
 		_ = s.T.Run("kill-pane", "-t", targetSlot)

--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -8,21 +8,23 @@ import (
 )
 
 // HandleWindowAfterKill is invoked from the after-kill-pane hook with the
-// window id where the kill happened. When that window is left with only a
-// sidebar slot pane (i.e. the user closed the last non-slot pane), we close
-// the window cleanly so a useless slot-only window does not linger:
+// window id where the kill happened. When that window is left with only one
+// pane that is either an active sidebar pane (split mode) or a sidebar slot
+// pane (slots mode), we close the window cleanly so a useless slot-only or
+// sidebar-only window does not linger:
 //
-//   - If the orphan slot is the active sidebar for some client (its pane id
+//   - If the lone pane is the active sidebar for some client (its pane id
 //     appears as a DEMUX_STICKY_PANE_* env value), the sidebar pane is moved
 //     into the last-active sibling window via join-pane. The source window
 //     auto-closes because it ends up with zero panes.
-//   - Otherwise the orphan is a placeholder; it is killed outright and the
-//     source window closes naturally.
+//   - Otherwise, if the lone pane is a slot (placeholder, slots mode), it is
+//     killed outright and the source window closes naturally.
+//   - Otherwise (a regular pane unrelated to sticky), it is left alone.
 //
 // No-op when windowID is empty, when list-panes errors (window already gone),
-// when the window has more than one pane or its lone pane is not a slot, or
-// when the session has no sibling window to receive the sidebar (closing the
-// last window would terminate the session).
+// when the window has more than one pane, or when the session has no sibling
+// window to receive the sidebar (closing the last window would terminate the
+// session).
 func (s *Sticky) HandleWindowAfterKill(windowID string) error {
 	if windowID == "" {
 		return nil
@@ -46,9 +48,10 @@ func (s *Sticky) HandleWindowAfterKill(windowID string) error {
 			slot = strings.TrimSpace(parts[1])
 		}
 	}
-	if count != 1 || slot != "1" {
+	if count != 1 {
 		return nil
 	}
+	isSlot := slot == "1"
 
 	isSidebar := false
 	if envOut, err := s.T.Output("show-environment", "-g"); err == nil {
@@ -69,7 +72,9 @@ func (s *Sticky) HandleWindowAfterKill(windowID string) error {
 	}
 
 	if !isSidebar {
-		_ = s.T.Run("kill-pane", "-t", orphan)
+		if isSlot {
+			_ = s.T.Run("kill-pane", "-t", orphan)
+		}
 		return nil
 	}
 

--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -1,0 +1,134 @@
+package sticky
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/rtalexk/demux/internal/config"
+)
+
+// HandleWindowAfterKill is invoked from the after-kill-pane hook with the
+// window id where the kill happened. When that window is left with only a
+// sidebar slot pane (i.e. the user closed the last non-slot pane), we close
+// the window cleanly so a useless slot-only window does not linger:
+//
+//   - If the orphan slot is the active sidebar for some client (its pane id
+//     appears as a DEMUX_STICKY_PANE_* env value), the sidebar pane is moved
+//     into the last-active sibling window via join-pane. The source window
+//     auto-closes because it ends up with zero panes.
+//   - Otherwise the orphan is a placeholder; it is killed outright and the
+//     source window closes naturally.
+//
+// No-op when windowID is empty, when list-panes errors (window already gone),
+// when the window has more than one pane or its lone pane is not a slot, or
+// when the session has no sibling window to receive the sidebar (closing the
+// last window would terminate the session).
+func (s *Sticky) HandleWindowAfterKill(windowID string) error {
+	if windowID == "" {
+		return nil
+	}
+	panesOut, err := s.T.Output("list-panes", "-t", windowID, "-F", "#{pane_id} #{@demux_slot}")
+	if err != nil {
+		return nil
+	}
+	var orphan, slot string
+	count := 0
+	for _, line := range strings.Split(panesOut, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		count++
+		parts := strings.SplitN(line, " ", 2)
+		orphan = parts[0]
+		slot = ""
+		if len(parts) >= 2 {
+			slot = strings.TrimSpace(parts[1])
+		}
+	}
+	if count != 1 || slot != "1" {
+		return nil
+	}
+
+	isSidebar := false
+	if envOut, err := s.T.Output("show-environment", "-g"); err == nil {
+		for _, line := range strings.Split(envOut, "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, envKeyPrefix) {
+				continue
+			}
+			eq := strings.IndexByte(line, '=')
+			if eq < 0 {
+				continue
+			}
+			if line[eq+1:] == orphan {
+				isSidebar = true
+				break
+			}
+		}
+	}
+
+	if !isSidebar {
+		_ = s.T.Run("kill-pane", "-t", orphan)
+		return nil
+	}
+
+	sessOut, err := s.T.Output("display-message", "-t", windowID, "-p", "#{session_id}")
+	if err != nil {
+		return nil
+	}
+	sessID := strings.TrimSpace(sessOut)
+	winsOut, err := s.T.Output("list-windows", "-t", sessID, "-F", "#{window_id} #{window_last_flag}")
+	if err != nil {
+		return nil
+	}
+	var target, fallback string
+	for _, line := range strings.Split(winsOut, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 1 {
+			continue
+		}
+		wid := parts[0]
+		if wid == windowID {
+			continue
+		}
+		flag := ""
+		if len(parts) >= 2 {
+			flag = strings.TrimSpace(parts[1])
+		}
+		if flag == "1" {
+			target = wid
+			break
+		}
+		if fallback == "" {
+			fallback = wid
+		}
+	}
+	if target == "" {
+		target = fallback
+	}
+	if target == "" {
+		return nil
+	}
+
+	if targetSlot, _ := s.FindSlotInWindow(target); targetSlot != "" && targetSlot != orphan {
+		_ = s.T.Run("kill-pane", "-t", targetSlot)
+	}
+
+	width := config.DefaultStickySidebarWidth
+	if wOut, _ := s.T.Output("display-message", "-p", "-t", orphan, "#{pane_width}"); strings.TrimSpace(wOut) != "" {
+		if w, perr := strconv.Atoi(strings.TrimSpace(wOut)); perr == nil && w > 0 {
+			width = w
+		}
+	}
+
+	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-d",
+		"-l", strconv.Itoa(width),
+		"-s", orphan, "-t", target)
+	_ = s.T.Run("select-window", "-t", target)
+	return nil
+}

--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -44,11 +44,7 @@ func (s *Sticky) HandleWindowAfterKill(windowID string, width int) error {
 	}
 	var orphan, slot string
 	count := 0
-	for _, line := range strings.Split(panesOut, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	for _, line := range nonEmptyLines(panesOut) {
 		count++
 		parts := strings.SplitN(line, " ", 2)
 		orphan = parts[0]

--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -79,25 +79,84 @@ func (s *Sticky) HandleWindowAfterKill(windowID string, width int) error {
 		return nil
 	}
 
-	sessOut, err := s.T.Output("display-message", "-t", windowID, "-p", "#{session_id}")
+	s.moveOrphanSidebar(orphan, windowID, width)
+	return nil
+}
+
+// EjectSidebarIfAloneAfterExit is the proactive companion to
+// HandleWindowAfterKill. It is called from the pane-exited hook BEFORE
+// exitingPaneID is actually destroyed. By excluding exitingPaneID from the
+// pane count it detects that the sidebar will be left alone and relocates it
+// immediately, so the user is not briefly stranded in a sidebar-only window
+// while waiting for after-kill-pane to fire (which may be unreliable for
+// natural process exits in some tmux versions).
+//
+// No-op when the window has more than two panes, when the remaining pane after
+// excluding exitingPaneID is not the tracked sidebar, or when there is no
+// sibling window to receive the sidebar.
+func (s *Sticky) EjectSidebarIfAloneAfterExit(exitingPaneID, windowID string, width int) error {
+	if exitingPaneID == "" || windowID == "" {
+		return nil
+	}
+	panesOut, err := s.T.Output("list-panes", "-t", windowID, "-F", "#{pane_id} #{@demux_slot}")
 	if err != nil {
 		return nil
+	}
+	var orphan string
+	remaining := 0
+	for _, line := range nonEmptyLines(panesOut) {
+		parts := strings.SplitN(line, " ", 2)
+		paneID := parts[0]
+		if paneID == exitingPaneID {
+			continue
+		}
+		remaining++
+		orphan = paneID
+	}
+	if remaining != 1 {
+		return nil
+	}
+	isSidebar := false
+	if envs, err := listStickyPaneEnv(s.T); err == nil {
+		for _, e := range envs {
+			if e.pane == orphan {
+				isSidebar = true
+				break
+			}
+		}
+	}
+	if !isSidebar {
+		return nil
+	}
+	demuxlog.Info("pre-exit: sidebar will be alone, relocating", "window_id", windowID, "pane_id", orphan)
+	s.moveOrphanSidebar(orphan, windowID, width)
+	return nil
+}
+
+// moveOrphanSidebar relocates the sidebar pane (orphan) from windowID to the
+// last-active sibling window. It is shared by HandleWindowAfterKill (called
+// after the last non-sidebar pane is gone) and EjectSidebarIfAloneAfterExit
+// (called while the exiting pane is still present).
+func (s *Sticky) moveOrphanSidebar(orphan, windowID string, width int) {
+	sessOut, err := s.T.Output("display-message", "-t", windowID, "-p", "#{session_id}")
+	if err != nil {
+		return
 	}
 	sessID := strings.TrimSpace(sessOut)
 	target, err := s.siblingWindow(sessID, windowID)
 	if err != nil {
-		return nil
+		return
 	}
 	if target == "" {
 		demuxlog.Info("orphan: no sibling window in session, skip", "window_id", windowID, "session_id", sessID)
-		return nil
+		return
 	}
 	// Defense in depth: if a concurrent pane_closed handler has already moved
 	// the sidebar out of windowID, do not move it a second time.
 	if curWin, curErr := s.T.Output("display-message", "-p", "-t", orphan, "#{window_id}"); curErr == nil {
 		if w := strings.TrimSpace(curWin); w != "" && w != windowID {
 			demuxlog.Info("orphan: sidebar already moved, skip", "pane_id", orphan, "now_window", w)
-			return nil
+			return
 		}
 	}
 
@@ -130,7 +189,6 @@ func (s *Sticky) HandleWindowAfterKill(windowID string, width int) error {
 			"-s", orphan, "-t", target)
 	}
 	_ = s.T.Run("select-window", "-t", target)
-	return nil
 }
 
 // siblingWindow returns a window in sessID other than excludeWindow that can

--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -9,24 +9,32 @@ import (
 )
 
 // HandleWindowAfterKill is invoked from the after-kill-pane hook with the
-// window id where the kill happened. When that window is left with only one
-// pane that is either an active sidebar pane (split mode) or a sidebar slot
-// pane (slots mode), we close the window cleanly so a useless slot-only or
-// sidebar-only window does not linger:
+// window id where the kill happened and the configured sidebar width. When
+// that window is left with only one pane that is either an active sidebar pane
+// (split mode) or a sidebar slot pane (slots mode), we close the window
+// cleanly so a useless slot-only or sidebar-only window does not linger:
 //
 //   - If the lone pane is the active sidebar for some client (its pane id
 //     appears as a DEMUX_STICKY_PANE_* env value), the sidebar pane is moved
-//     into the last-active sibling window via join-pane. The source window
-//     auto-closes because it ends up with zero panes.
+//     into the last-active sibling window, sized to width. When that window
+//     has a placeholder slot the move is a swap-pane (no pane killed, so the
+//     after-kill-pane hook is not re-entered); otherwise it is a join-pane.
+//     The source window auto-closes because it ends up with zero panes.
 //   - Otherwise, if the lone pane is a slot (placeholder, slots mode), it is
 //     killed outright and the source window closes naturally.
 //   - Otherwise (a regular pane unrelated to sticky), it is left alone.
 //
+// width is the caller's configured sidebar width. The orphan pane's own
+// #{pane_width} cannot be used: by the time this hook runs the pane has
+// already reflowed to fill its now-single-pane source window.
+//
 // No-op when windowID is empty, when list-panes errors (window already gone),
-// when the window has more than one pane, or when the session has no sibling
+// when the window has more than one pane, when the session has no sibling
 // window to receive the sidebar (closing the last window would terminate the
-// session).
-func (s *Sticky) HandleWindowAfterKill(windowID string) error {
+// session), or when the sidebar has already been moved out of windowID by a
+// concurrent handler (the function is idempotent under the hook re-firing it
+// triggers itself).
+func (s *Sticky) HandleWindowAfterKill(windowID string, width int) error {
 	if windowID == "" {
 		return nil
 	}
@@ -125,22 +133,43 @@ func (s *Sticky) HandleWindowAfterKill(windowID string) error {
 		demuxlog.Info("orphan: no sibling window in session, skip", "window_id", windowID, "session_id", sessID)
 		return nil
 	}
-	demuxlog.Info("orphan: moving sidebar", "window_id", windowID, "pane_id", orphan, "target", target)
-
-	if targetSlot, _ := s.FindSlotInWindow(target); targetSlot != "" && targetSlot != orphan {
-		_ = s.T.Run("kill-pane", "-t", targetSlot)
-	}
-
-	width := config.DefaultStickySidebarWidth
-	if wOut, _ := s.T.Output("display-message", "-p", "-t", orphan, "#{pane_width}"); strings.TrimSpace(wOut) != "" {
-		if w, perr := strconv.Atoi(strings.TrimSpace(wOut)); perr == nil && w > 0 {
-			width = w
+	// Defense in depth: if a concurrent pane_closed handler has already moved
+	// the sidebar out of windowID, do not move it a second time.
+	if curWin, curErr := s.T.Output("display-message", "-p", "-t", orphan, "#{window_id}"); curErr == nil {
+		if w := strings.TrimSpace(curWin); w != "" && w != windowID {
+			demuxlog.Info("orphan: sidebar already moved, skip", "pane_id", orphan, "now_window", w)
+			return nil
 		}
 	}
 
-	_ = s.T.Run("join-pane", "-f", "-h", "-b", "-d",
-		"-l", strconv.Itoa(width),
-		"-s", orphan, "-t", target)
+	demuxlog.Info("orphan: moving sidebar", "window_id", windowID, "pane_id", orphan, "target", target)
+
+	if width <= 0 {
+		width = config.DefaultStickySidebarWidth
+	}
+
+	targetSlot, _ := s.FindSlotInWindow(target)
+
+	if targetSlot != "" && targetSlot != orphan {
+		// swap-pane moves the sidebar into the target window's slot position
+		// without killing any pane, so it does NOT re-fire after-kill-pane:
+		// no re-entrant handler, no double move, no width corruption. The
+		// placeholder slot ends up parked alone in the (now content-less)
+		// source window.
+		_ = s.T.Run("swap-pane", "-d", "-s", orphan, "-t", targetSlot)
+		_ = s.T.Run("resize-pane", "-t", orphan, "-x", strconv.Itoa(width))
+		// Remove the parked placeholder so the empty source window closes.
+		// This kill re-fires after-kill-pane, but the move is already done so
+		// the nested sweep is a no-op - and the kill happens in the source
+		// window, so it cannot disturb the sidebar geometry in the target.
+		_ = s.T.Run("kill-pane", "-t", targetSlot)
+	} else {
+		// No placeholder slot in the target (split mode, or slots partially
+		// uninstalled): join the sidebar in directly.
+		_ = s.T.Run("join-pane", "-f", "-h", "-b", "-d",
+			"-l", strconv.Itoa(width),
+			"-s", orphan, "-t", target)
+	}
 	_ = s.T.Run("select-window", "-t", target)
 	return nil
 }

--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -84,38 +84,9 @@ func (s *Sticky) HandleWindowAfterKill(windowID string, width int) error {
 		return nil
 	}
 	sessID := strings.TrimSpace(sessOut)
-	winsOut, err := s.T.Output("list-windows", "-t", sessID, "-F", "#{window_id} #{window_last_flag}")
+	target, err := s.siblingWindow(sessID, windowID)
 	if err != nil {
 		return nil
-	}
-	var target, fallback string
-	for _, line := range strings.Split(winsOut, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) < 1 {
-			continue
-		}
-		wid := parts[0]
-		if wid == windowID {
-			continue
-		}
-		flag := ""
-		if len(parts) >= 2 {
-			flag = strings.TrimSpace(parts[1])
-		}
-		if flag == "1" {
-			target = wid
-			break
-		}
-		if fallback == "" {
-			fallback = wid
-		}
-	}
-	if target == "" {
-		target = fallback
 	}
 	if target == "" {
 		demuxlog.Info("orphan: no sibling window in session, skip", "window_id", windowID, "session_id", sessID)
@@ -160,4 +131,30 @@ func (s *Sticky) HandleWindowAfterKill(windowID string, width int) error {
 	}
 	_ = s.T.Run("select-window", "-t", target)
 	return nil
+}
+
+// siblingWindow returns a window in sessID other than excludeWindow that can
+// receive a folded-in sidebar. It prefers the session's last-active window
+// (window_last_flag=1); otherwise it falls back to the first other window in
+// tmux index order. Returns "" when sessID has no other window.
+func (s *Sticky) siblingWindow(sessID, excludeWindow string) (string, error) {
+	out, err := s.T.Output("list-windows", "-t", sessID, "-F", "#{window_id} #{window_last_flag}")
+	if err != nil {
+		return "", err
+	}
+	var fallback string
+	for _, line := range nonEmptyLines(out) {
+		parts := strings.SplitN(line, " ", 2)
+		wid := parts[0]
+		if wid == excludeWindow {
+			continue
+		}
+		if len(parts) >= 2 && strings.TrimSpace(parts[1]) == "1" {
+			return wid, nil
+		}
+		if fallback == "" {
+			fallback = wid
+		}
+	}
+	return fallback, nil
 }

--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -64,17 +64,9 @@ func (s *Sticky) HandleWindowAfterKill(windowID string, width int) error {
 	demuxlog.Info("orphan: candidate", "window_id", windowID, "pane_id", orphan, "is_slot", isSlot)
 
 	isSidebar := false
-	if envOut, err := s.T.Output("show-environment", "-g"); err == nil {
-		for _, line := range strings.Split(envOut, "\n") {
-			line = strings.TrimSpace(line)
-			if !strings.HasPrefix(line, envKeyPrefix) {
-				continue
-			}
-			eq := strings.IndexByte(line, '=')
-			if eq < 0 {
-				continue
-			}
-			if line[eq+1:] == orphan {
+	if envs, err := listStickyPaneEnv(s.T); err == nil {
+		for _, e := range envs {
+			if e.pane == orphan {
 				isSidebar = true
 				break
 			}

--- a/internal/sticky/orphan_test.go
+++ b/internal/sticky/orphan_test.go
@@ -17,7 +17,7 @@ func ranCmd(f *fakeTmux, want string) bool {
 func TestHandleWindowAfterKill_EmptyWindow_NoOp(t *testing.T) {
 	f := newFakeTmux()
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill(""); err != nil {
+	if err := s.HandleWindowAfterKill("", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(f.runs) != 0 {
@@ -29,7 +29,7 @@ func TestHandleWindowAfterKill_WindowAlreadyGone_NoOp(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{err: stderrExitError("can't find window\n")}
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(f.runs) != 0 {
@@ -41,7 +41,7 @@ func TestHandleWindowAfterKill_MultiplePanesLeft_NoOp(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 1\n%11 \n"}
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(f.runs) != 0 {
@@ -53,7 +53,7 @@ func TestHandleWindowAfterKill_SingleNonSlotPane_NoOp(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n"}
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(f.runs) != 0 {
@@ -67,7 +67,7 @@ func TestHandleWindowAfterKill_OrphanPlaceholderInactiveWindow_KillsOnly(t *test
 	// Sidebar is alive elsewhere (%42); env does not point at the orphan %50.
 	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !ranCmd(f, "kill-pane -t %50") {
@@ -93,25 +93,34 @@ func TestHandleWindowAfterKill_OrphanSidebar_MovesToLastActive(t *testing.T) {
 	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@2 0\n@3 1\n@4 0\n"}
 	// Target @3 has a placeholder slot %30 we must remove.
 	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 1\n%31 \n"}
-	// Width capture.
-	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "42\n"}
+	// Sidebar still in its source window: the move has not happened yet.
+	f.outputs["display-message -p -t %50 #{window_id}"] = fakeReply{out: "@5\n"}
 
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 42); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !ranCmd(f, "kill-pane -t %30") {
-		t.Errorf("expected kill-pane for target's placeholder slot %%30, got: %v", f.runs)
+	// The move is a swap-pane (no pane killed, so after-kill-pane is not
+	// re-entered), then a resize to the configured width, then the parked
+	// placeholder is killed in the source window.
+	if !ranCmd(f, "swap-pane -d -s %50 -t %30") {
+		t.Errorf("expected swap-pane moving %%50 into target slot %%30, got: %v", f.runs)
 	}
-	if !ranCmd(f, "join-pane -f -h -b -d -l 42 -s %50 -t @3") {
-		t.Errorf("expected join-pane moving %%50 into @3 with width 42, got: %v", f.runs)
+	if !ranCmd(f, "resize-pane -t %50 -x 42") {
+		t.Errorf("expected resize-pane to configured width 42, got: %v", f.runs)
+	}
+	if !ranCmd(f, "kill-pane -t %30") {
+		t.Errorf("expected kill-pane for the parked placeholder %%30, got: %v", f.runs)
 	}
 	if !ranCmd(f, "select-window -t @3") {
 		t.Errorf("expected select-window -t @3, got: %v", f.runs)
 	}
 	for _, r := range f.runs {
 		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "join-pane") {
+			t.Errorf("expected swap-pane, not join-pane, when target has a slot, got: %v", f.runs)
+		}
 		if j == "kill-pane -t %50" {
 			t.Errorf("did not expect to kill the sidebar pane %%50, got: %v", f.runs)
 		}
@@ -126,14 +135,14 @@ func TestHandleWindowAfterKill_OrphanSidebar_NoLastFlag_UsesFirstSibling(t *test
 	// No window has last_flag=1; fall back to first non-source.
 	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@2 0\n@3 0\n"}
 	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%20 1\n"}
-	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "35\n"}
+	f.outputs["display-message -p -t %50 #{window_id}"] = fakeReply{out: "@5\n"}
 
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !ranCmd(f, "join-pane -f -h -b -d -l 35 -s %50 -t @2") {
-		t.Errorf("expected join-pane to fallback target @2, got: %v", f.runs)
+	if !ranCmd(f, "swap-pane -d -s %50 -t %20") {
+		t.Errorf("expected swap-pane into fallback target slot %%20, got: %v", f.runs)
 	}
 	if !ranCmd(f, "select-window -t @2") {
 		t.Errorf("expected select-window -t @2, got: %v", f.runs)
@@ -148,7 +157,7 @@ func TestHandleWindowAfterKill_OrphanSidebar_SingleWindowInSession_NoOp(t *testi
 	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n"}
 
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, r := range f.runs {
@@ -168,10 +177,10 @@ func TestHandleWindowAfterKill_SplitModeOrphanSidebar_MovesToLastActive(t *testi
 	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@3 1\n"}
 	// Target @3 in split mode has no slot pane.
 	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 \n%31 \n"}
-	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "35\n"}
+	f.outputs["display-message -p -t %50 #{window_id}"] = fakeReply{out: "@5\n"}
 
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, r := range f.runs {
@@ -194,7 +203,7 @@ func TestHandleWindowAfterKill_SingleUntrackedPane_NoOp(t *testing.T) {
 	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 \n"}
 	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%99\n"}
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, r := range f.runs {
@@ -213,10 +222,10 @@ func TestHandleWindowAfterKill_OrphanSidebar_NoTargetSlot_StillJoins(t *testing.
 	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@3 1\n"}
 	// Target window has no slot (slots ecosystem partially uninstalled).
 	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 \n%31 \n"}
-	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "35\n"}
+	f.outputs["display-message -p -t %50 #{window_id}"] = fakeReply{out: "@5\n"}
 
 	s := &Sticky{T: f}
-	if err := s.HandleWindowAfterKill("@5"); err != nil {
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, r := range f.runs {
@@ -227,5 +236,62 @@ func TestHandleWindowAfterKill_OrphanSidebar_NoTargetSlot_StillJoins(t *testing.
 	}
 	if !ranCmd(f, "join-pane -f -h -b -d -l 35 -s %50 -t @3") {
 		t.Errorf("expected join-pane into @3 even without target slot, got: %v", f.runs)
+	}
+}
+
+// Regression: by the time the after-kill-pane hook runs, the orphan sidebar
+// pane has already reflowed to fill its now-single-pane source window, so its
+// live #{pane_width} is the whole window (here 203). The move must be sized
+// from the caller's configured width, never from that expanded measurement -
+// otherwise the sidebar lands at the wrong width.
+func TestHandleWindowAfterKill_OrphanSidebar_UsesConfiguredWidthNotExpandedPane(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%50\n"}
+	f.outputs["display-message -t @5 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@3 1\n"}
+	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 1\n%31 \n"}
+	f.outputs["display-message -p -t %50 #{window_id}"] = fakeReply{out: "@5\n"}
+	// The orphan pane reports the full window width it expanded into.
+	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "203\n"}
+
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ranCmd(f, "resize-pane -t %50 -x 35") {
+		t.Errorf("expected resize to configured width 35, got: %v", f.runs)
+	}
+	for _, r := range f.runs {
+		if strings.Contains(strings.Join(r, " "), "203") {
+			t.Errorf("must not size the move from the expanded pane width 203, got: %v", f.runs)
+		}
+	}
+}
+
+// Regression: HandleWindowAfterKill kills the target window's placeholder slot,
+// which re-fires the after-kill-pane hook and spawns a second, concurrent
+// pane_closed handler. Running join-pane again on a sidebar pane that is
+// already in the target window nearly doubles its width. When the sidebar has
+// already left its source window, the handler must do nothing.
+func TestHandleWindowAfterKill_OrphanSidebar_AlreadyMoved_NoDoubleJoin(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%50\n"}
+	f.outputs["display-message -t @5 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@3 1\n"}
+	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 1\n%31 \n"}
+	// A concurrent handler already moved %50 out of @5 into @3.
+	f.outputs["display-message -p -t %50 #{window_id}"] = fakeReply{out: "@3\n"}
+
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "join-pane") || strings.HasPrefix(j, "kill-pane") || strings.HasPrefix(j, "select-window") {
+			t.Errorf("sidebar already moved; expected no mutations, got: %v", f.runs)
+		}
 	}
 }

--- a/internal/sticky/orphan_test.go
+++ b/internal/sticky/orphan_test.go
@@ -159,6 +159,52 @@ func TestHandleWindowAfterKill_OrphanSidebar_SingleWindowInSession_NoOp(t *testi
 	}
 }
 
+func TestHandleWindowAfterKill_SplitModeOrphanSidebar_MovesToLastActive(t *testing.T) {
+	f := newFakeTmux()
+	// Split mode: lone pane has no @demux_slot tag but IS the active sidebar.
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 \n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%50\n"}
+	f.outputs["display-message -t @5 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@3 1\n"}
+	// Target @3 in split mode has no slot pane.
+	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 \n%31 \n"}
+	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "35\n"}
+
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane") {
+			t.Errorf("split mode: did not expect any kill-pane, got: %v", f.runs)
+		}
+	}
+	if !ranCmd(f, "join-pane -f -h -b -d -l 35 -s %50 -t @3") {
+		t.Errorf("split mode: expected join-pane moving sidebar %%50 into @3, got: %v", f.runs)
+	}
+	if !ranCmd(f, "select-window -t @3") {
+		t.Errorf("split mode: expected select-window -t @3, got: %v", f.runs)
+	}
+}
+
+func TestHandleWindowAfterKill_SingleUntrackedPane_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	// Lone pane is NOT a slot AND NOT the tracked sidebar - leave alone.
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 \n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%99\n"}
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane") || strings.HasPrefix(j, "join-pane") || strings.HasPrefix(j, "select-window") {
+			t.Errorf("expected no mutations for untracked single pane, got: %v", f.runs)
+		}
+	}
+}
+
 func TestHandleWindowAfterKill_OrphanSidebar_NoTargetSlot_StillJoins(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}

--- a/internal/sticky/orphan_test.go
+++ b/internal/sticky/orphan_test.go
@@ -295,3 +295,162 @@ func TestHandleWindowAfterKill_OrphanSidebar_AlreadyMoved_NoDoubleJoin(t *testin
 		}
 	}
 }
+
+// ── EjectSidebarIfAloneAfterExit tests ──────────────────────────────────────
+
+func TestEjectSidebarIfAloneAfterExit_EmptyArgs_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("", "", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs, got: %v", f.runs)
+	}
+}
+
+func TestEjectSidebarIfAloneAfterExit_WindowGone_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{err: stderrExitError("can't find window\n")}
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs, got: %v", f.runs)
+	}
+}
+
+func TestEjectSidebarIfAloneAfterExit_MoreThanTwoPanes_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	// Window has 3 panes: exiting + sidebar + another.
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n%42 \n%99 \n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs for 3-pane window, got: %v", f.runs)
+	}
+}
+
+func TestEjectSidebarIfAloneAfterExit_OnlyExitingPane_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	// Window has only the exiting pane (no sidebar). Remaining count = 0.
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no runs when remaining count = 0, got: %v", f.runs)
+	}
+}
+
+func TestEjectSidebarIfAloneAfterExit_RemainingIsNotSidebar_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	// Window has exiting pane + a regular (non-sidebar) pane.
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n%20 \n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no runs when remaining pane is not sidebar, got: %v", f.runs)
+	}
+}
+
+func TestEjectSidebarIfAloneAfterExit_SidebarAlone_MovesToLastActive(t *testing.T) {
+	f := newFakeTmux()
+	// Ephemeral window @2: lazygit pane %10 is exiting, sidebar %42 would be left alone.
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n%42 \n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["display-message -t @2 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@2 0\n@1 1\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@2\n"}
+	// Target @1 has no slot pane (split mode).
+	f.outputs["list-panes -t @1 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 \n%31 \n"}
+
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ranCmd(f, "join-pane -f -h -b -d -l 35 -s %42 -t @1") {
+		t.Errorf("expected join-pane moving sidebar %%42 into @1, got: %v", f.runs)
+	}
+	if !ranCmd(f, "select-window -t @1") {
+		t.Errorf("expected select-window -t @1, got: %v", f.runs)
+	}
+}
+
+func TestEjectSidebarIfAloneAfterExit_SlotsMode_SwapsIntoTargetSlot(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n%42 1\n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["display-message -t @2 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@2 0\n@1 1\n"}
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@2\n"}
+	// Target @1 has a placeholder slot %30.
+	f.outputs["list-panes -t @1 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 1\n%31 \n"}
+
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ranCmd(f, "swap-pane -d -s %42 -t %30") {
+		t.Errorf("expected swap-pane into target slot %%30, got: %v", f.runs)
+	}
+	if !ranCmd(f, "resize-pane -t %42 -x 35") {
+		t.Errorf("expected resize-pane, got: %v", f.runs)
+	}
+	if !ranCmd(f, "kill-pane -t %30") {
+		t.Errorf("expected kill-pane for parked placeholder, got: %v", f.runs)
+	}
+	if !ranCmd(f, "select-window -t @1") {
+		t.Errorf("expected select-window -t @1, got: %v", f.runs)
+	}
+}
+
+func TestEjectSidebarIfAloneAfterExit_NoSiblingWindow_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n%42 \n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["display-message -t @2 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	// Only window in session.
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@2 0\n"}
+
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "join-pane") || strings.HasPrefix(j, "select-window") {
+			t.Errorf("expected no move when no sibling window, got: %v", f.runs)
+		}
+	}
+}
+
+func TestEjectSidebarIfAloneAfterExit_AlreadyMoved_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n%42 \n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["display-message -t @2 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@2 0\n@1 1\n"}
+	// Sidebar already in target window (concurrent handler moved it first).
+	f.outputs["display-message -p -t %42 #{window_id}"] = fakeReply{out: "@1\n"}
+
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "join-pane") || strings.HasPrefix(j, "select-window") {
+			t.Errorf("sidebar already moved: expected no mutation, got: %v", f.runs)
+		}
+	}
+}

--- a/internal/sticky/orphan_test.go
+++ b/internal/sticky/orphan_test.go
@@ -1,0 +1,185 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func ranCmd(f *fakeTmux, want string) bool {
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestHandleWindowAfterKill_EmptyWindow_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill(""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs, got: %v", f.runs)
+	}
+}
+
+func TestHandleWindowAfterKill_WindowAlreadyGone_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{err: stderrExitError("can't find window\n")}
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs, got: %v", f.runs)
+	}
+}
+
+func TestHandleWindowAfterKill_MultiplePanesLeft_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 1\n%11 \n"}
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs, got: %v", f.runs)
+	}
+}
+
+func TestHandleWindowAfterKill_SingleNonSlotPane_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n"}
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs, got: %v", f.runs)
+	}
+}
+
+func TestHandleWindowAfterKill_OrphanPlaceholderInactiveWindow_KillsOnly(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+	// Sidebar is alive elsewhere (%42); env does not point at the orphan %50.
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ranCmd(f, "kill-pane -t %50") {
+		t.Errorf("expected kill-pane for orphan placeholder, got: %v", f.runs)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "join-pane") || strings.HasPrefix(j, "select-window") {
+			t.Errorf("did not expect %q for inactive placeholder, got: %v", j, f.runs)
+		}
+	}
+}
+
+func TestHandleWindowAfterKill_OrphanSidebar_MovesToLastActive(t *testing.T) {
+	f := newFakeTmux()
+	// Source window @5 has only the sidebar slot (which is the active sidebar).
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+	// Env: sidebar tracked at %50.
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%50\n"}
+	// Session lookup.
+	f.outputs["display-message -t @5 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	// Sibling windows; @3 is last-active.
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@2 0\n@3 1\n@4 0\n"}
+	// Target @3 has a placeholder slot %30 we must remove.
+	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 1\n%31 \n"}
+	// Width capture.
+	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "42\n"}
+
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !ranCmd(f, "kill-pane -t %30") {
+		t.Errorf("expected kill-pane for target's placeholder slot %%30, got: %v", f.runs)
+	}
+	if !ranCmd(f, "join-pane -f -h -b -d -l 42 -s %50 -t @3") {
+		t.Errorf("expected join-pane moving %%50 into @3 with width 42, got: %v", f.runs)
+	}
+	if !ranCmd(f, "select-window -t @3") {
+		t.Errorf("expected select-window -t @3, got: %v", f.runs)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "kill-pane -t %50" {
+			t.Errorf("did not expect to kill the sidebar pane %%50, got: %v", f.runs)
+		}
+	}
+}
+
+func TestHandleWindowAfterKill_OrphanSidebar_NoLastFlag_UsesFirstSibling(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%50\n"}
+	f.outputs["display-message -t @5 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	// No window has last_flag=1; fall back to first non-source.
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@2 0\n@3 0\n"}
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%20 1\n"}
+	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "35\n"}
+
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ranCmd(f, "join-pane -f -h -b -d -l 35 -s %50 -t @2") {
+		t.Errorf("expected join-pane to fallback target @2, got: %v", f.runs)
+	}
+	if !ranCmd(f, "select-window -t @2") {
+		t.Errorf("expected select-window -t @2, got: %v", f.runs)
+	}
+}
+
+func TestHandleWindowAfterKill_OrphanSidebar_SingleWindowInSession_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%50\n"}
+	f.outputs["display-message -t @5 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n"}
+
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "join-pane") || strings.HasPrefix(j, "kill-pane") || strings.HasPrefix(j, "select-window") {
+			t.Errorf("did not expect %q for single-window session, got: %v", j, f.runs)
+		}
+	}
+}
+
+func TestHandleWindowAfterKill_OrphanSidebar_NoTargetSlot_StillJoins(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%50\n"}
+	f.outputs["display-message -t @5 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@5 0\n@3 1\n"}
+	// Target window has no slot (slots ecosystem partially uninstalled).
+	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 \n%31 \n"}
+	f.outputs["display-message -p -t %50 #{pane_width}"] = fakeReply{out: "35\n"}
+
+	s := &Sticky{T: f}
+	if err := s.HandleWindowAfterKill("@5"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane") {
+			t.Errorf("did not expect kill-pane when no target slot exists, got: %v", f.runs)
+		}
+	}
+	if !ranCmd(f, "join-pane -f -h -b -d -l 35 -s %50 -t @3") {
+		t.Errorf("expected join-pane into @3 even without target slot, got: %v", f.runs)
+	}
+}

--- a/internal/sticky/prepare.go
+++ b/internal/sticky/prepare.go
@@ -1,0 +1,45 @@
+package sticky
+
+import (
+	"strings"
+)
+
+// PrepareWindow is called by the TUI right before it issues a tmux switch to
+// targetWindowID. In slots mode it pre-installs a slot pane in the target
+// window so the after-select-window hook's follow can swap the sidebar in
+// without a one-time split-window flicker.
+//
+// Steps: push target to the head of the MRU, prune stale entries, recompute
+// the reserved set against the still-current window, and reconcile slot
+// panes. Reconcile will install the slot in target (it sits at MRU head, so
+// it's reserved) and evict any non-reserved slot that fell out of budget.
+//
+// No-op when slots mode is disabled, when no sidebar is active anywhere on
+// the server, or when targetWindowID is empty. Best-effort overall: callers
+// should not block their switch on this returning an error.
+func (s *Sticky) PrepareWindow(targetWindowID string, width int) error {
+	if !s.Slots || targetWindowID == "" {
+		return nil
+	}
+	any, err := s.AnySlotExists()
+	if err != nil || !any {
+		return err
+	}
+	if err := s.PushMRU(targetWindowID); err != nil {
+		return err
+	}
+	curr, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	if err != nil {
+		return nil
+	}
+	parts := strings.SplitN(strings.TrimSpace(curr), ":", 2)
+	if len(parts) < 2 {
+		return nil
+	}
+	_ = s.PruneMRU()
+	reserved, err := s.ComputeReservedWindows(parts[1], parts[0])
+	if err != nil {
+		return err
+	}
+	return s.ReconcileSlots(reserved, parts[1], width)
+}

--- a/internal/sticky/prepare.go
+++ b/internal/sticky/prepare.go
@@ -1,9 +1,5 @@
 package sticky
 
-import (
-	"strings"
-)
-
 // PrepareWindow is called by the TUI right before it issues a tmux switch to
 // targetWindowID. In slots mode it pre-installs a slot pane in the target
 // window so the after-select-window hook's follow can swap the sidebar in
@@ -28,18 +24,14 @@ func (s *Sticky) PrepareWindow(targetWindowID string, width int) error {
 	if err := s.PushMRU(targetWindowID); err != nil {
 		return err
 	}
-	curr, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	_, session, window, err := s.currentTarget()
 	if err != nil {
-		return nil
-	}
-	parts := strings.SplitN(strings.TrimSpace(curr), ":", 2)
-	if len(parts) < 2 {
 		return nil
 	}
 	_ = s.PruneMRU()
-	reserved, err := s.ComputeReservedWindows(parts[1], parts[0])
+	reserved, err := s.ComputeReservedWindows(window, session)
 	if err != nil {
 		return err
 	}
-	return s.ReconcileSlots(reserved, parts[1], width)
+	return s.ReconcileSlots(reserved, window, width)
 }

--- a/internal/sticky/prepare_test.go
+++ b/internal/sticky/prepare_test.go
@@ -1,0 +1,87 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrepareWindow_SlotsDisabled_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f, Slots: false}
+	if err := s.PrepareWindow("@5", 35); err != nil {
+		t.Fatalf("PrepareWindow: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs, got: %v", f.runs)
+	}
+}
+
+func TestPrepareWindow_EmptyTarget_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f, Slots: true}
+	if err := s.PrepareWindow("", 35); err != nil {
+		t.Fatalf("PrepareWindow: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs, got: %v", f.runs)
+	}
+}
+
+func TestPrepareWindow_NoActiveSidebar_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	// AnySlotExists returns false.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%2 \n"}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.PrepareWindow("@5", 35); err != nil {
+		t.Fatalf("PrepareWindow: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "set-environment") || strings.HasPrefix(j, "split-window") {
+			t.Errorf("expected no env writes / no splits, got: %v", r)
+		}
+	}
+}
+
+func TestPrepareWindow_PushesMRUAndReconciles(t *testing.T) {
+	f := newFakeTmux()
+	// Sidebar active somewhere.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%99 1\n"}
+	// MRU pre-seeded with @5 at head (simulating the just-pushed state -
+	// fakeTmux does not propagate writes back to scripted reads).
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@5\n"}
+	// Current window/session.
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@1\n"}
+	// Reservation queries.
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@5\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@1 1\n"}
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	// Reconcile pane scan: only @1 has a slot today (the sidebar).
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@1 %99 1\n"}
+	// EnsureSlotInWindow on @5 should split.
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%5 \n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t @5 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%50\n"}
+
+	s := &Sticky{T: f, Slots: true}
+	if err := s.PrepareWindow("@5", 35); err != nil {
+		t.Fatalf("PrepareWindow: %v", err)
+	}
+	sawPush := false
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "set-environment -g "+MRUEnvKey+" @5") {
+			sawPush = true
+		}
+	}
+	if !sawPush {
+		t.Errorf("expected MRU push for @5, got: %v", f.runs)
+	}
+	sawTag := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "set-option -p -t %50 @demux_slot 1" {
+			sawTag = true
+		}
+	}
+	if !sawTag {
+		t.Errorf("expected new slot %%50 tagged in @5, got: %v", f.runs)
+	}
+}

--- a/internal/sticky/reconcile.go
+++ b/internal/sticky/reconcile.go
@@ -1,9 +1,5 @@
 package sticky
 
-import (
-	"strings"
-)
-
 // ReconcileSlots brings the server's set of slot panes into agreement with
 // reserved + currentWindow. For each window in reserved that lacks a slot, a
 // placeholder is installed via EnsureSlotInWindow. For each window that has
@@ -25,19 +21,8 @@ func (s *Sticky) ReconcileSlots(reserved []string, currentWindow string, width i
 		return err
 	}
 	existing := make(map[string]string)
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, " ", 3)
-		if len(parts) < 3 {
-			continue
-		}
-		wid, pid, slot := parts[0], parts[1], strings.TrimSpace(parts[2])
-		if slot != "1" {
-			continue
-		}
+	for _, row := range slotLines(out, 3) {
+		wid, pid := row[0], row[1]
 		if _, has := existing[wid]; !has {
 			existing[wid] = pid
 		}

--- a/internal/sticky/reconcile.go
+++ b/internal/sticky/reconcile.go
@@ -1,0 +1,64 @@
+package sticky
+
+import (
+	"strings"
+)
+
+// ReconcileSlots brings the server's set of slot panes into agreement with
+// reserved + currentWindow. For each window in reserved that lacks a slot, a
+// placeholder is installed via EnsureSlotInWindow. For each window that has
+// a slot but is neither reserved nor currentWindow, the slot is killed.
+//
+// currentWindow's slot (the active sidebar) is never touched here - that is
+// the caller's responsibility via Show / Follow / swap-pane.
+//
+// width is the column count passed to EnsureSlotInWindow when creating new
+// slots.
+func (s *Sticky) ReconcileSlots(reserved []string, currentWindow string, width int) error {
+	reservedSet := make(map[string]struct{}, len(reserved))
+	for _, w := range reserved {
+		reservedSet[w] = struct{}{}
+	}
+
+	out, err := s.T.Output("list-panes", "-aF", "#{window_id} #{pane_id} #{@demux_slot}")
+	if err != nil {
+		return err
+	}
+	existing := make(map[string]string)
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 3)
+		if len(parts) < 3 {
+			continue
+		}
+		wid, pid, slot := parts[0], parts[1], strings.TrimSpace(parts[2])
+		if slot != "1" {
+			continue
+		}
+		if _, has := existing[wid]; !has {
+			existing[wid] = pid
+		}
+	}
+
+	for wid, pid := range existing {
+		if wid == currentWindow {
+			continue
+		}
+		if _, ok := reservedSet[wid]; ok {
+			continue
+		}
+		_ = s.T.Run("kill-pane", "-t", pid)
+	}
+
+	for _, wid := range reserved {
+		if _, has := existing[wid]; has {
+			continue
+		}
+		_ = s.EnsureSlotInWindow(wid, width)
+	}
+
+	return nil
+}

--- a/internal/sticky/reconcile_test.go
+++ b/internal/sticky/reconcile_test.go
@@ -1,0 +1,93 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReconcileSlots_InstallsMissing(t *testing.T) {
+	f := newFakeTmux()
+	// No existing slot panes.
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: ""}
+	// EnsureSlotInWindow will call FindSlotInWindow then split-window.
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%500 \n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t @5 -P -F #{pane_id} "+SlotPlaceholderCmd] = fakeReply{out: "%900\n"}
+
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots([]string{"@5"}, "@1", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	saw := false
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "set-option -p -t %900 "+SlotMarker) {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected slot marker set on new pane, got: %v", f.runs)
+	}
+}
+
+func TestReconcileSlots_EvictsNonReserved(t *testing.T) {
+	f := newFakeTmux()
+	// @1 (reserved), @2 (NOT reserved), @3 (current, has slot, must NOT be killed).
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@1 %10 1\n@2 %20 1\n@3 %30 1\n"}
+	// @1 already has slot - no install path needed.
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots([]string{"@1"}, "@3", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	var killed10, killed20, killed30 bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "kill-pane -t %10" {
+			killed10 = true
+		}
+		if j == "kill-pane -t %20" {
+			killed20 = true
+		}
+		if j == "kill-pane -t %30" {
+			killed30 = true
+		}
+	}
+	if killed10 {
+		t.Errorf("did not expect kill of reserved %%10")
+	}
+	if !killed20 {
+		t.Errorf("expected kill of non-reserved %%20, got: %v", f.runs)
+	}
+	if killed30 {
+		t.Errorf("did not expect kill of current-window slot %%30")
+	}
+}
+
+func TestReconcileSlots_NoOpWhenAlreadyMatching(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@1 %10 1\n@2 %20 1\n"}
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots([]string{"@1", "@2"}, "@3", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane") || strings.HasPrefix(j, "split-window") {
+			t.Errorf("expected no mutations, got: %v", r)
+		}
+	}
+}
+
+func TestReconcileSlots_IgnoresNonSlotPanes(t *testing.T) {
+	f := newFakeTmux()
+	// Mix of slot and non-slot panes; only slots should be considered.
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@5 %50 1\n@5 %51 \n@6 %60 \n"}
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots([]string{"@5"}, "@1", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane") || strings.HasPrefix(j, "split-window") {
+			t.Errorf("expected no mutations when reserved already covered, got: %v", r)
+		}
+	}
+}

--- a/internal/sticky/reservation.go
+++ b/internal/sticky/reservation.go
@@ -117,11 +117,7 @@ func (s *Sticky) listCurrentSessionWindows(currentSession string) ([]string, str
 	}
 	var windows []string
 	var lastFlag string
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	for _, line := range nonEmptyLines(out) {
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) < 1 {
 			continue

--- a/internal/sticky/reservation.go
+++ b/internal/sticky/reservation.go
@@ -1,0 +1,162 @@
+package sticky
+
+import (
+	"strings"
+)
+
+// ComputeReservedWindows returns the window ids that should hold a sidebar
+// slot pane right now, capped at MRUMaxLen. The current window is excluded
+// (it holds the active sidebar pane, which is accounted for separately).
+//
+// Priority fill order (highest first):
+//  1. window_last_flag=1 in current session (the tmux "last-window").
+//  2. Active window of the client's last session (cross-session).
+//  3. Other windows in the current session, ordered by MRU then tmux index.
+//  4. Cross-session windows from MRU, in MRU order.
+//
+// Stops once MRUMaxLen entries are collected. Stale MRU entries (dead window
+// ids) are silently skipped, but PruneMRU should be invoked separately to
+// trim them from the persisted env var.
+func (s *Sticky) ComputeReservedWindows(currentWindow, currentSession string) ([]string, error) {
+	reserved := make([]string, 0, MRUMaxLen)
+	seen := map[string]struct{}{}
+	if currentWindow != "" {
+		seen[currentWindow] = struct{}{}
+	}
+
+	add := func(w string) bool {
+		if w == "" {
+			return false
+		}
+		if _, ok := seen[w]; ok {
+			return false
+		}
+		seen[w] = struct{}{}
+		reserved = append(reserved, w)
+		return len(reserved) >= MRUMaxLen
+	}
+
+	live, err := s.liveWindowSet()
+	if err != nil {
+		return nil, err
+	}
+
+	currentSessionWindows, currentLast, err := s.listCurrentSessionWindows(currentSession)
+	if err != nil {
+		return nil, err
+	}
+
+	if currentLast != "" {
+		if _, ok := live[currentLast]; ok {
+			if add(currentLast) {
+				return reserved, nil
+			}
+		}
+	}
+
+	lastSessionActive, err := s.lastSessionActiveWindow(currentSession)
+	if err == nil && lastSessionActive != "" {
+		if _, ok := live[lastSessionActive]; ok {
+			if add(lastSessionActive) {
+				return reserved, nil
+			}
+		}
+	}
+
+	mru, err := s.ReadMRU()
+	if err != nil {
+		return nil, err
+	}
+	currentSet := map[string]struct{}{}
+	for _, w := range currentSessionWindows {
+		currentSet[w] = struct{}{}
+	}
+
+	for _, w := range mru {
+		if _, ok := currentSet[w]; !ok {
+			continue
+		}
+		if _, ok := live[w]; !ok {
+			continue
+		}
+		if add(w) {
+			return reserved, nil
+		}
+	}
+	for _, w := range currentSessionWindows {
+		if _, ok := live[w]; !ok {
+			continue
+		}
+		if add(w) {
+			return reserved, nil
+		}
+	}
+
+	for _, w := range mru {
+		if _, ok := live[w]; !ok {
+			continue
+		}
+		if add(w) {
+			return reserved, nil
+		}
+	}
+
+	return reserved, nil
+}
+
+// listCurrentSessionWindows returns the window ids in currentSession in tmux
+// index order, plus the id of the window with window_last_flag=1 (or "" if
+// none).
+func (s *Sticky) listCurrentSessionWindows(currentSession string) ([]string, string, error) {
+	if currentSession == "" {
+		return nil, "", nil
+	}
+	out, err := s.T.Output("list-windows", "-t", currentSession, "-F", "#{window_id} #{window_last_flag}")
+	if err != nil {
+		return nil, "", err
+	}
+	var windows []string
+	var lastFlag string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 1 {
+			continue
+		}
+		wid := parts[0]
+		windows = append(windows, wid)
+		if len(parts) >= 2 && strings.TrimSpace(parts[1]) == "1" {
+			lastFlag = wid
+		}
+	}
+	return windows, lastFlag, nil
+}
+
+// lastSessionActiveWindow returns the window id of the active window in the
+// client's last session, or "" when there is no last session, the last
+// session equals currentSession, or tmux cannot resolve it. Best-effort.
+func (s *Sticky) lastSessionActiveWindow(currentSession string) (string, error) {
+	name, err := s.T.Output("display-message", "-p", "#{client_last_session}")
+	if err != nil {
+		return "", err
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", nil
+	}
+	out, err := s.T.Output("display-message", "-t", name, "-p", "#{session_id} #{window_id}")
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Fields(strings.TrimSpace(out))
+	if len(parts) < 2 {
+		return "", nil
+	}
+	if parts[0] == currentSession {
+		return "", nil
+	}
+	return parts[1], nil
+}

--- a/internal/sticky/reservation_test.go
+++ b/internal/sticky/reservation_test.go
@@ -1,0 +1,113 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeReservedWindows_LastWindowAndLastSession(t *testing.T) {
+	f := newFakeTmux()
+	// Live windows server-wide.
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@2\n@3\n@10\n@11\n"}
+	// Current session has @1 (active, current), @2 (last_flag=1), @3.
+	f.outputs["list-windows -t $A -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@1 0\n@2 1\n@3 0\n"}
+	// Last session resolves to @10.
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "other\n"}
+	f.outputs["display-message -t other -p #{session_id} #{window_id}"] = fakeReply{out: "$B @10\n"}
+	// MRU empty.
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{err: stderrExitError("unknown variable")}
+
+	s := &Sticky{T: f}
+	got, err := s.ComputeReservedWindows("@1", "$A")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expected ordering: @2 (last-window), @10 (last-session-active), @3 (current session other).
+	want := []string{"@2", "@10", "@3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestComputeReservedWindows_MRUFillsAfterCurrentSession(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@2\n@3\n@20\n@21\n@22\n"}
+	// Current session has only @1 (current), @2 (last_flag).
+	f.outputs["list-windows -t $A -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@1 0\n@2 1\n"}
+	// No last session.
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	// MRU lists cross-session windows.
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@21,@22,@20\n"}
+
+	s := &Sticky{T: f}
+	got, err := s.ComputeReservedWindows("@1", "$A")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expected: @2 (last-window), then MRU cross-session order @21, @22, @20.
+	want := []string{"@2", "@21", "@22", "@20"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestComputeReservedWindows_ExcludesCurrentAndDedupes(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@2\n@3\n"}
+	f.outputs["list-windows -t $A -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@1 1\n@2 0\n@3 0\n"}
+	// last_flag=1 is @1 which is current; should be skipped.
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@1,@2,@1,@3\n"}
+
+	s := &Sticky{T: f}
+	got, err := s.ComputeReservedWindows("@1", "$A")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"@2", "@3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestComputeReservedWindows_CapsAtMRUMaxLen(t *testing.T) {
+	f := newFakeTmux()
+	// 12 windows total.
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@2\n@3\n@4\n@5\n@6\n@7\n@8\n@9\n@10\n@11\n@12\n"}
+	// Current session has many windows.
+	f.outputs["list-windows -t $A -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@1 0\n@2 1\n@3 0\n@4 0\n@5 0\n@6 0\n@7 0\n@8 0\n@9 0\n@10 0\n@11 0\n@12 0\n"}
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{err: stderrExitError("unknown variable")}
+
+	s := &Sticky{T: f}
+	got, err := s.ComputeReservedWindows("@1", "$A")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != MRUMaxLen {
+		t.Errorf("want %d entries, got %d (%v)", MRUMaxLen, len(got), got)
+	}
+	// Head must be @2 (last-window).
+	if got[0] != "@2" {
+		t.Errorf("head want @2, got %s", got[0])
+	}
+}
+
+func TestComputeReservedWindows_SkipsDeadEntries(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@3\n"}
+	f.outputs["list-windows -t $A -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@1 0\n@3 1\n"}
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	// MRU contains a dead @99.
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@99,@3\n"}
+
+	s := &Sticky{T: f}
+	got, err := s.ComputeReservedWindows("@1", "$A")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"@3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -1,0 +1,64 @@
+package sticky
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ShowOpts controls a Show invocation.
+type ShowOpts struct {
+	// Width is the initial pane width in columns. Honoured only when the pane
+	// is being created (i.e. no live pane is already tracked).
+	Width int
+	// Cmd is the shell command to run inside the new pane.
+	Cmd string
+}
+
+// Show ensures a sticky sidebar pane exists for the current client. If one is
+// already tracked and the pane is alive, Show is a no-op. Otherwise it splits
+// the current window with a full-height left column of opts.Width columns and
+// records the new pane id.
+func (s *Sticky) Show(opts ShowOpts) error {
+	if err := s.VersionOK(); err != nil {
+		return err
+	}
+	tty, err := s.CurrentClientTTY()
+	if err != nil {
+		return err
+	}
+	key := EnvKey(tty)
+	val, set, err := s.ReadEnv(key)
+	if err != nil {
+		return err
+	}
+	if set && val != "" {
+		alive, err := s.PaneAlive(val)
+		if err != nil {
+			return err
+		}
+		if alive {
+			return nil
+		}
+	}
+	target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	if err != nil {
+		return fmt.Errorf("tmux display-message current target: %w", err)
+	}
+	target = strings.TrimSpace(target)
+	out, err := s.T.Output(
+		"split-window", "-f", "-h", "-b",
+		"-l", strconv.Itoa(opts.Width),
+		"-t", target,
+		"-P", "-F", "#{pane_id}",
+		opts.Cmd,
+	)
+	if err != nil {
+		return fmt.Errorf("tmux split-window: %w", err)
+	}
+	newPane := strings.TrimSpace(out)
+	if newPane == "" {
+		return fmt.Errorf("tmux split-window returned empty pane id")
+	}
+	return s.WriteEnv(key, newPane)
+}

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -52,11 +52,10 @@ func (s *Sticky) Show(opts ShowOpts) error {
 }
 
 func (s *Sticky) showSplitMode(key string, opts ShowOpts) error {
-	target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	target, _, _, err := s.currentTarget()
 	if err != nil {
-		return fmt.Errorf("tmux display-message current target: %w", err)
+		return err
 	}
-	target = strings.TrimSpace(target)
 	out, err := s.T.Output(
 		"split-window", "-f", "-h", "-b",
 		"-l", strconv.Itoa(opts.Width),
@@ -78,11 +77,10 @@ func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
 	// Activate the current window's slot first so the user sees demux
 	// appear immediately, then create placeholder slots in the remaining
 	// windows in the background.
-	target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	target, currSession, currWindow, err := s.currentTarget()
 	if err != nil {
-		return fmt.Errorf("tmux display-message current target: %w", err)
+		return err
 	}
-	target = strings.TrimSpace(target)
 	if err := s.EnsureSlotInWindow(target, opts.Width); err != nil {
 		return err
 	}
@@ -102,13 +100,6 @@ func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
 	// Install slots only in the MRU-reserved set (capped at MRUMaxLen).
 	// Current window already has its own slot (the sidebar), so we pass it
 	// in explicitly so reconcile won't touch it.
-	parts := strings.SplitN(target, ":", 2)
-	currWindow := target
-	currSession := ""
-	if len(parts) == 2 {
-		currSession = parts[0]
-		currWindow = parts[1]
-	}
 	reserved, err := s.ComputeReservedWindows(currWindow, currSession)
 	if err == nil {
 		_ = s.ReconcileSlots(reserved, currWindow, opts.Width)

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -75,23 +75,32 @@ func (s *Sticky) showSplitMode(key string, opts ShowOpts) error {
 }
 
 func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
-	if err := s.InstallSlotsInAllWindows(opts.Width); err != nil {
-		return err
-	}
+	// Activate the current window's slot first so the user sees demux
+	// appear immediately, then create placeholder slots in the remaining
+	// windows in the background.
 	target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
 	if err != nil {
 		return fmt.Errorf("tmux display-message current target: %w", err)
 	}
 	target = strings.TrimSpace(target)
+	if err := s.EnsureSlotInWindow(target, opts.Width); err != nil {
+		return err
+	}
 	slot, err := s.FindSlotInWindow(target)
 	if err != nil {
 		return err
 	}
 	if slot == "" {
-		return fmt.Errorf("no slot in current window after install")
+		return fmt.Errorf("no slot in current window after ensure")
 	}
 	if err := s.T.Run("respawn-pane", "-k", "-t", slot, opts.Cmd); err != nil {
 		return fmt.Errorf("tmux respawn-pane: %w", err)
 	}
-	return s.WriteEnv(key, slot)
+	if err := s.WriteEnv(key, slot); err != nil {
+		return err
+	}
+	// Best-effort: install slots in remaining windows. Current already has
+	// one (@demux_slot=1), so it's skipped by EnsureSlotInWindow.
+	_ = s.InstallSlotsInAllWindows(opts.Width)
+	return nil
 }

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -99,8 +99,19 @@ func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
 	if err := s.WriteEnv(key, slot); err != nil {
 		return err
 	}
-	// Best-effort: install slots in remaining windows. Current already has
-	// one (@demux_slot=1), so it's skipped by EnsureSlotInWindow.
-	_ = s.InstallSlotsInAllWindows(opts.Width)
+	// Install slots only in the MRU-reserved set (capped at MRUMaxLen).
+	// Current window already has its own slot (the sidebar), so we pass it
+	// in explicitly so reconcile won't touch it.
+	parts := strings.SplitN(target, ":", 2)
+	currWindow := target
+	currSession := ""
+	if len(parts) == 2 {
+		currSession = parts[0]
+		currWindow = parts[1]
+	}
+	reserved, err := s.ComputeReservedWindows(currWindow, currSession)
+	if err == nil {
+		_ = s.ReconcileSlots(reserved, currWindow, opts.Width)
+	}
 	return nil
 }

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -19,6 +19,10 @@ type ShowOpts struct {
 // already tracked and the pane is alive, Show is a no-op. Otherwise it splits
 // the current window with a full-height left column of opts.Width columns and
 // records the new pane id.
+//
+// In slots mode (s.Slots==true), Show first installs a slot pane in every
+// window, then respawns the current window's slot with opts.Cmd to make it
+// the active sidebar pane.
 func (s *Sticky) Show(opts ShowOpts) error {
 	if err := s.VersionOK(); err != nil {
 		return err
@@ -41,6 +45,13 @@ func (s *Sticky) Show(opts ShowOpts) error {
 			return nil
 		}
 	}
+	if s.Slots {
+		return s.showSlotsMode(key, opts)
+	}
+	return s.showSplitMode(key, opts)
+}
+
+func (s *Sticky) showSplitMode(key string, opts ShowOpts) error {
 	target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
 	if err != nil {
 		return fmt.Errorf("tmux display-message current target: %w", err)
@@ -61,4 +72,26 @@ func (s *Sticky) Show(opts ShowOpts) error {
 		return fmt.Errorf("tmux split-window returned empty pane id")
 	}
 	return s.WriteEnv(key, newPane)
+}
+
+func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
+	if err := s.InstallSlotsInAllWindows(opts.Width); err != nil {
+		return err
+	}
+	target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	if err != nil {
+		return fmt.Errorf("tmux display-message current target: %w", err)
+	}
+	target = strings.TrimSpace(target)
+	slot, err := s.FindSlotInWindow(target)
+	if err != nil {
+		return err
+	}
+	if slot == "" {
+		return fmt.Errorf("no slot in current window after install")
+	}
+	if err := s.T.Run("respawn-pane", "-k", "-t", slot, opts.Cmd); err != nil {
+		return fmt.Errorf("tmux respawn-pane: %w", err)
+	}
+	return s.WriteEnv(key, slot)
 }

--- a/internal/sticky/show_test.go
+++ b/internal/sticky/show_test.go
@@ -93,9 +93,16 @@ func TestShow_SlotsMode_ActivatesCurrentSlotBeforeOtherWindows(t *testing.T) {
 	// Current window has no slot. After split + tag, list-panes returns it tagged.
 	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%10 1\n"}
 	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%10\n"}
-	f.outputs["list-windows -aF #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n$1:@8\n"}
-	f.outputs["list-panes -t $1:@8 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%2 \n"}
-	f.outputs["split-window -f -h -b -d -l 35 -t $1:@8 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%11\n"}
+	// Reservation queries.
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@7\n@8\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@7 0\n@8 1\n"}
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{err: stderrExitError("unknown variable\n")}
+	// Reconcile: list slot panes - none yet for @8.
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@7 %10 1\n"}
+	// EnsureSlotInWindow for @8: list-panes shows no slot, split installs %11.
+	f.outputs["list-panes -t @8 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%2 \n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t @8 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%11\n"}
 	s := &Sticky{T: f, Slots: true}
 	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
 		t.Fatalf("Show: %v", err)

--- a/internal/sticky/show_test.go
+++ b/internal/sticky/show_test.go
@@ -84,40 +84,46 @@ func TestShow_OldTmux_Errors(t *testing.T) {
 	}
 }
 
-func TestShow_SlotsMode_InstallsAndRespawnsCurrentSlot(t *testing.T) {
+func TestShow_SlotsMode_ActivatesCurrentSlotBeforeOtherWindows(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
-	f.outputs["list-windows -aF #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n$1:@8\n"}
-	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	// Current window has no slot. After split + tag, list-panes returns it tagged.
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%10 1\n"}
 	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%10\n"}
+	f.outputs["list-windows -aF #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n$1:@8\n"}
 	f.outputs["list-panes -t $1:@8 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%2 \n"}
 	f.outputs["split-window -f -h -b -d -l 35 -t $1:@8 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%11\n"}
-	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
-	// After install, current-window slot lookup re-runs list-panes.
-	// First call already returned "%1 ", but now @demux_slot tag is set on %10.
-	// Override to reflect updated state.
-	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%10 1\n"}
 	s := &Sticky{T: f, Slots: true}
 	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
 		t.Fatalf("Show: %v", err)
 	}
-	var sawRespawn, sawRecord bool
-	for _, r := range f.runs {
-		j := strings.Join(r, " ")
-		if j == "respawn-pane -k -t %10 demux --sticky" {
-			sawRespawn = true
+	// Verify respawn-pane (activate current) and env-var set happen BEFORE
+	// the @8 slot tag (which only runs during the later InstallSlotsInAllWindows).
+	idx := func(target string) int {
+		for i, r := range f.runs {
+			if strings.Join(r, " ") == target {
+				return i
+			}
 		}
-		if j == "set-environment -g DEMUX_STICKY_PANE__dev_ttys001 %10" {
-			sawRecord = true
-		}
+		return -1
 	}
-	if !sawRespawn {
-		t.Errorf("expected respawn-pane on current window's slot, got: %v", f.runs)
+	iRespawn := idx("respawn-pane -k -t %10 demux --sticky")
+	iRecord := idx("set-environment -g DEMUX_STICKY_PANE__dev_ttys001 %10")
+	iOtherTag := idx("set-option -p -t %11 @demux_slot 1")
+	if iRespawn < 0 {
+		t.Fatalf("expected respawn-pane on current slot, got: %v", f.runs)
 	}
-	if !sawRecord {
-		t.Errorf("expected env var to record active slot pane id, got: %v", f.runs)
+	if iRecord < 0 {
+		t.Fatalf("expected env-var record, got: %v", f.runs)
+	}
+	if iOtherTag < 0 {
+		t.Fatalf("expected slot tag on other window's new pane, got: %v", f.runs)
+	}
+	if !(iRespawn < iRecord && iRecord < iOtherTag) {
+		t.Errorf("expected order respawn < record < other-window-tag, got %d/%d/%d", iRespawn, iRecord, iOtherTag)
 	}
 }
 

--- a/internal/sticky/show_test.go
+++ b/internal/sticky/show_test.go
@@ -84,6 +84,43 @@ func TestShow_OldTmux_Errors(t *testing.T) {
 	}
 }
 
+func TestShow_SlotsMode_InstallsAndRespawnsCurrentSlot(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["list-windows -aF #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n$1:@8\n"}
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%10\n"}
+	f.outputs["list-panes -t $1:@8 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%2 \n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@8 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%11\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	// After install, current-window slot lookup re-runs list-panes.
+	// First call already returned "%1 ", but now @demux_slot tag is set on %10.
+	// Override to reflect updated state.
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%10 1\n"}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	var sawRespawn, sawRecord bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "respawn-pane -k -t %10 demux --sticky" {
+			sawRespawn = true
+		}
+		if j == "set-environment -g DEMUX_STICKY_PANE__dev_ttys001 %10" {
+			sawRecord = true
+		}
+	}
+	if !sawRespawn {
+		t.Errorf("expected respawn-pane on current window's slot, got: %v", f.runs)
+	}
+	if !sawRecord {
+		t.Errorf("expected env var to record active slot pane id, got: %v", f.runs)
+	}
+}
+
 func TestShow_SplitFailure_Surfaces(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}

--- a/internal/sticky/show_test.go
+++ b/internal/sticky/show_test.go
@@ -1,0 +1,98 @@
+package sticky
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestShow_EnvUnset_CreatesPane(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable: DEMUX_STICKY_PANE__dev_ttys001\n")}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["split-window -f -h -b -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+	s := &Sticky{T: f}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	found := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "set-environment -g DEMUX_STICKY_PANE__dev_ttys001 %88" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected set-environment call recording pane id, got runs: %v", f.runs)
+	}
+}
+
+func TestShow_EnvSetAndPaneAlive_Noop(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%1\n%42\n"}
+	s := &Sticky{T: f}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "set-environment") {
+			t.Errorf("expected no set-environment call (noop), got: %v", r)
+		}
+		if strings.HasPrefix(strings.Join(r, " "), "split-window") {
+			t.Errorf("expected no split-window call (noop), got: %v", r)
+		}
+	}
+}
+
+func TestShow_EnvSetButPaneDead_Recreates(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%1\n%2\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
+	f.outputs["split-window -f -h -b -l 35 -t $2:@9 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%99\n"}
+	s := &Sticky{T: f}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	found := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "set-environment -g DEMUX_STICKY_PANE__dev_ttys001 %99" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected env var rewrite to new pane id, got runs: %v", f.runs)
+	}
+}
+
+func TestShow_OldTmux_Errors(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 2.4\n"}
+	s := &Sticky{T: f}
+	err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"})
+	if err == nil {
+		t.Fatal("expected error on tmux < 2.6")
+	}
+	if !strings.Contains(err.Error(), "too old") {
+		t.Errorf("expected version error, got: %v", err)
+	}
+}
+
+func TestShow_SplitFailure_Surfaces(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["split-window -f -h -b -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{err: errors.New("can't split")}
+	s := &Sticky{T: f}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err == nil {
+		t.Error("expected split-window failure to surface")
+	}
+}

--- a/internal/sticky/slots.go
+++ b/internal/sticky/slots.go
@@ -1,0 +1,145 @@
+package sticky
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SlotMarker is the tmux user-option set on every sidebar slot pane. Used to
+// recognize slots when listing panes ("@demux_slot" -> "1").
+const SlotMarker = "@demux_slot"
+
+// SlotPaneTitle is the human-readable pane title applied to slot panes so
+// they're recognizable when `pane-border-status` is on.
+const SlotPaneTitle = "demux-slot"
+
+// SlotPlaceholderCmd is the command run inside an inactive slot pane.
+const SlotPlaceholderCmd = "demux sidebar slot"
+
+// FindSlotInWindow returns the pane id of the slot in target window, or ""
+// if the window has no slot pane.
+func (s *Sticky) FindSlotInWindow(target string) (string, error) {
+	out, err := s.T.Output("list-panes", "-t", target, "-F", "#{pane_id} #{@demux_slot}")
+	if err != nil {
+		return "", fmt.Errorf("tmux list-panes: %w", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if strings.TrimSpace(parts[1]) == "1" {
+			return parts[0], nil
+		}
+	}
+	return "", nil
+}
+
+// AnySlotExists reports whether any pane on the server is tagged as a sidebar
+// slot. Used by the after-new-window hook to decide whether to ensure a slot
+// in a freshly created window (only if the sidebar is already active for the
+// session).
+func (s *Sticky) AnySlotExists() (bool, error) {
+	out, err := s.T.Output("list-panes", "-aF", "#{pane_id} #{@demux_slot}")
+	if err != nil {
+		return false, fmt.Errorf("tmux list-panes: %w", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if strings.TrimSpace(parts[1]) == "1" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// EnsureSlotInWindow creates a sidebar slot pane in the target window if none
+// exists. The new pane runs SlotPlaceholderCmd, gets the SlotMarker option,
+// and is given a human-readable title.
+func (s *Sticky) EnsureSlotInWindow(target string, width int) error {
+	existing, err := s.FindSlotInWindow(target)
+	if err != nil {
+		return err
+	}
+	if existing != "" {
+		return nil
+	}
+	out, err := s.T.Output(
+		"split-window", "-f", "-h", "-b", "-d",
+		"-l", strconv.Itoa(width),
+		"-t", target,
+		"-P", "-F", "#{pane_id}",
+		SlotPlaceholderCmd,
+	)
+	if err != nil {
+		return fmt.Errorf("tmux split-window slot: %w", err)
+	}
+	pane := strings.TrimSpace(out)
+	if pane == "" {
+		return fmt.Errorf("tmux split-window slot returned empty pane id")
+	}
+	if err := s.T.Run("set-option", "-p", "-t", pane, SlotMarker, "1"); err != nil {
+		return fmt.Errorf("tmux set-option %s: %w", SlotMarker, err)
+	}
+	// Title is cosmetic; failure is non-fatal.
+	_ = s.T.Run("select-pane", "-t", pane, "-T", SlotPaneTitle)
+	return nil
+}
+
+// InstallSlotsInAllWindows ensures every window on the server has a sidebar
+// slot pane at the given width. Idempotent.
+func (s *Sticky) InstallSlotsInAllWindows(width int) error {
+	out, err := s.T.Output("list-windows", "-aF", "#{session_id}:#{window_id}")
+	if err != nil {
+		return fmt.Errorf("tmux list-windows: %w", err)
+	}
+	var firstErr error
+	for _, line := range strings.Split(out, "\n") {
+		target := strings.TrimSpace(line)
+		if target == "" {
+			continue
+		}
+		if err := s.EnsureSlotInWindow(target, width); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// UninstallSlots kills every pane tagged as a sidebar slot.
+func (s *Sticky) UninstallSlots() error {
+	out, err := s.T.Output("list-panes", "-aF", "#{pane_id} #{@demux_slot}")
+	if err != nil {
+		return fmt.Errorf("tmux list-panes: %w", err)
+	}
+	var kills []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if strings.TrimSpace(parts[1]) == "1" {
+			kills = append(kills, parts[0])
+		}
+	}
+	for _, p := range kills {
+		_ = s.T.Run("kill-pane", "-t", p)
+	}
+	return nil
+}

--- a/internal/sticky/slots.go
+++ b/internal/sticky/slots.go
@@ -24,11 +24,7 @@ const SlotPlaceholderCmd = "demux sidebar slot"
 // lines with too few fields are skipped.
 func slotLines(out string, fieldCount int) [][]string {
 	var rows [][]string
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	for _, line := range nonEmptyLines(out) {
 		parts := strings.SplitN(line, " ", fieldCount)
 		if len(parts) < fieldCount {
 			continue
@@ -106,11 +102,7 @@ func (s *Sticky) InstallSlotsInAllWindows(width int) error {
 		return fmt.Errorf("tmux list-windows: %w", err)
 	}
 	var firstErr error
-	for _, line := range strings.Split(out, "\n") {
-		target := strings.TrimSpace(line)
-		if target == "" {
-			continue
-		}
+	for _, target := range nonEmptyLines(out) {
 		if err := s.EnsureSlotInWindow(target, width); err != nil && firstErr == nil {
 			firstErr = err
 		}

--- a/internal/sticky/slots.go
+++ b/internal/sticky/slots.go
@@ -17,6 +17,29 @@ const SlotPaneTitle = "demux-slot"
 // SlotPlaceholderCmd is the command run inside an inactive slot pane.
 const SlotPlaceholderCmd = "demux sidebar slot"
 
+// slotLines parses `tmux list-panes -F` output whose format string ends with
+// "#{@demux_slot}". fieldCount is the total number of space-separated fields
+// per line, including that trailing slot tag. For each line tagged "1" it
+// returns the leading fields (everything before the tag); other lines and
+// lines with too few fields are skipped.
+func slotLines(out string, fieldCount int) [][]string {
+	var rows [][]string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", fieldCount)
+		if len(parts) < fieldCount {
+			continue
+		}
+		if strings.TrimSpace(parts[fieldCount-1]) == "1" {
+			rows = append(rows, parts[:fieldCount-1])
+		}
+	}
+	return rows
+}
+
 // FindSlotInWindow returns the pane id of the slot in target window, or ""
 // if the window has no slot pane.
 func (s *Sticky) FindSlotInWindow(target string) (string, error) {
@@ -24,18 +47,8 @@ func (s *Sticky) FindSlotInWindow(target string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("tmux list-panes: %w", err)
 	}
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) < 2 {
-			continue
-		}
-		if strings.TrimSpace(parts[1]) == "1" {
-			return parts[0], nil
-		}
+	for _, row := range slotLines(out, 2) {
+		return row[0], nil
 	}
 	return "", nil
 }
@@ -49,20 +62,7 @@ func (s *Sticky) AnySlotExists() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("tmux list-panes: %w", err)
 	}
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) < 2 {
-			continue
-		}
-		if strings.TrimSpace(parts[1]) == "1" {
-			return true, nil
-		}
-	}
-	return false, nil
+	return len(slotLines(out, 2)) > 0, nil
 }
 
 // EnsureSlotInWindow creates a sidebar slot pane in the target window if none
@@ -124,22 +124,8 @@ func (s *Sticky) UninstallSlots() error {
 	if err != nil {
 		return fmt.Errorf("tmux list-panes: %w", err)
 	}
-	var kills []string
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) < 2 {
-			continue
-		}
-		if strings.TrimSpace(parts[1]) == "1" {
-			kills = append(kills, parts[0])
-		}
-	}
-	for _, p := range kills {
-		_ = s.T.Run("kill-pane", "-t", p)
+	for _, row := range slotLines(out, 2) {
+		_ = s.T.Run("kill-pane", "-t", row[0])
 	}
 	return nil
 }

--- a/internal/sticky/slots_test.go
+++ b/internal/sticky/slots_test.go
@@ -1,0 +1,145 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFindSlotInWindow_Found(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%2 1\n%3 \n"}
+	s := &Sticky{T: f}
+	got, err := s.FindSlotInWindow("$1:@7")
+	if err != nil {
+		t.Fatalf("FindSlotInWindow: %v", err)
+	}
+	if got != "%2" {
+		t.Errorf("want %%2, got %q", got)
+	}
+}
+
+func TestFindSlotInWindow_NotFound(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%2 \n"}
+	s := &Sticky{T: f}
+	got, err := s.FindSlotInWindow("$1:@7")
+	if err != nil {
+		t.Fatalf("FindSlotInWindow: %v", err)
+	}
+	if got != "" {
+		t.Errorf("want empty, got %q", got)
+	}
+}
+
+func TestAnySlotExists_Yes(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%2 1\n"}
+	s := &Sticky{T: f}
+	got, err := s.AnySlotExists()
+	if err != nil || !got {
+		t.Errorf("want true, got %v err=%v", got, err)
+	}
+}
+
+func TestAnySlotExists_No(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%2 \n"}
+	s := &Sticky{T: f}
+	got, err := s.AnySlotExists()
+	if err != nil || got {
+		t.Errorf("want false, got %v err=%v", got, err)
+	}
+}
+
+func TestEnsureSlotInWindow_Existing_Noop(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%2 1\n"}
+	s := &Sticky{T: f}
+	if err := s.EnsureSlotInWindow("$1:@7", 35); err != nil {
+		t.Fatalf("EnsureSlotInWindow: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "split-window") {
+			t.Errorf("expected no split-window (existing slot), got: %v", r)
+		}
+	}
+}
+
+func TestEnsureSlotInWindow_CreatesAndTags(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%9\n"}
+	s := &Sticky{T: f}
+	if err := s.EnsureSlotInWindow("$1:@7", 35); err != nil {
+		t.Fatalf("EnsureSlotInWindow: %v", err)
+	}
+	var sawTag, sawTitle bool
+	for _, r := range f.runs {
+		joined := strings.Join(r, " ")
+		if joined == "set-option -p -t %9 @demux_slot 1" {
+			sawTag = true
+		}
+		if joined == "select-pane -t %9 -T demux-slot" {
+			sawTitle = true
+		}
+	}
+	if !sawTag {
+		t.Errorf("expected set-option @demux_slot 1 on new pane, got: %v", f.runs)
+	}
+	if !sawTitle {
+		t.Errorf("expected select-pane -T demux-slot on new pane, got: %v", f.runs)
+	}
+}
+
+func TestInstallSlotsInAllWindows_PerWindow(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-windows -aF #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n$1:@8\n$2:@9\n"}
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n"}
+	f.outputs["list-panes -t $1:@8 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%3 1\n"} // already has slot
+	f.outputs["list-panes -t $2:@9 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%5 \n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%11\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $2:@9 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%12\n"}
+	s := &Sticky{T: f}
+	if err := s.InstallSlotsInAllWindows(35); err != nil {
+		t.Fatalf("InstallSlotsInAllWindows: %v", err)
+	}
+	var splits int
+	for _, r := range f.runs {
+		// Run records non-Output calls; split-window is Output, so it isn't in runs.
+		// set-option/select-pane for new panes are runs.
+		if strings.HasPrefix(strings.Join(r, " "), "set-option -p -t %11 @demux_slot") {
+			splits++
+		}
+		if strings.HasPrefix(strings.Join(r, " "), "set-option -p -t %12 @demux_slot") {
+			splits++
+		}
+	}
+	if splits != 2 {
+		t.Errorf("expected 2 new slots tagged (for @7 and @9), got %d; runs: %v", splits, f.runs)
+	}
+}
+
+func TestUninstallSlots_KillsTaggedPanesOnly(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%2 1\n%3 \n%4 1\n"}
+	s := &Sticky{T: f}
+	if err := s.UninstallSlots(); err != nil {
+		t.Fatalf("UninstallSlots: %v", err)
+	}
+	var kills []string
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane -t ") {
+			kills = append(kills, j)
+		}
+	}
+	want := map[string]bool{"kill-pane -t %2": true, "kill-pane -t %4": true}
+	if len(kills) != 2 {
+		t.Errorf("want 2 kill-pane calls, got %d: %v", len(kills), kills)
+	}
+	for _, k := range kills {
+		if !want[k] {
+			t.Errorf("unexpected kill: %q", k)
+		}
+	}
+}

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -145,8 +145,7 @@ func listStickyPaneEnv(t Tmux) ([]stickyPaneEnv, error) {
 		return nil, err
 	}
 	var envs []stickyPaneEnv
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
+	for _, line := range nonEmptyLines(out) {
 		if !strings.HasPrefix(line, envKeyPrefix) {
 			continue
 		}
@@ -208,8 +207,8 @@ func (s *Sticky) PaneAlive(paneID string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("tmux list-panes: %w", err)
 	}
-	for _, line := range strings.Split(out, "\n") {
-		if strings.TrimSpace(line) == paneID {
+	for _, line := range nonEmptyLines(out) {
+		if line == paneID {
 			return true, nil
 		}
 	}

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -104,6 +104,29 @@ func (s *Sticky) UnsetEnv(key string) error {
 	return nil
 }
 
+// PaneAlive returns true when paneID appears in `tmux list-panes -a`.
+func (s *Sticky) PaneAlive(paneID string) (bool, error) {
+	out, err := s.T.Output("list-panes", "-aF", "#{pane_id}")
+	if err != nil {
+		return false, fmt.Errorf("tmux list-panes: %w", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == paneID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// CurrentClientTTY returns the tmux #{client_tty} for the invoking client.
+func (s *Sticky) CurrentClientTTY() (string, error) {
+	out, err := s.T.Output("display-message", "-p", "#{client_tty}")
+	if err != nil {
+		return "", fmt.Errorf("tmux display-message #{client_tty}: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
 // isUnknownVariableErr inspects an error from exec.Command.Output() to detect
 // tmux's "unknown variable: X" stderr line.
 func isUnknownVariableErr(err error) bool {

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -5,6 +5,7 @@
 package sticky
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -64,5 +65,57 @@ func EnvKey(tty string) string {
 	return envKeyPrefix + SanitizeTTY(tty)
 }
 
-// keep imports used
-var _ = fmt.Sprintf
+// ReadEnv reads a tmux server-global env var.
+// Returns (value, true, nil) when set, ("", false, nil) when unset, error on
+// any other tmux failure. Unset is detected by an "unknown variable" line in
+// tmux's stderr (matches tmux 2.6+ output).
+func (s *Sticky) ReadEnv(key string) (string, bool, error) {
+	out, err := s.T.Output("show-environment", "-g", key)
+	if err != nil {
+		if isUnknownVariableErr(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("tmux show-environment %s: %w", key, err)
+	}
+	line := strings.TrimSpace(out)
+	eq := strings.IndexByte(line, '=')
+	if eq < 0 {
+		if strings.HasPrefix(line, "-") {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("tmux show-environment: unexpected output %q", line)
+	}
+	return line[eq+1:], true, nil
+}
+
+// WriteEnv sets a tmux server-global env var.
+func (s *Sticky) WriteEnv(key, value string) error {
+	if err := s.T.Run("set-environment", "-g", key, value); err != nil {
+		return fmt.Errorf("tmux set-environment -g %s: %w", key, err)
+	}
+	return nil
+}
+
+// UnsetEnv clears a tmux server-global env var.
+func (s *Sticky) UnsetEnv(key string) error {
+	if err := s.T.Run("set-environment", "-gu", key); err != nil {
+		return fmt.Errorf("tmux set-environment -gu %s: %w", key, err)
+	}
+	return nil
+}
+
+// isUnknownVariableErr inspects an error from exec.Command.Output() to detect
+// tmux's "unknown variable: X" stderr line.
+func isUnknownVariableErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "unknown variable") {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && strings.Contains(string(exitErr.Stderr), "unknown variable") {
+		return true
+	}
+	return false
+}

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -22,11 +22,30 @@ type Tmux interface {
 type realTmux struct{}
 
 func (realTmux) Run(args ...string) error {
-	return exec.Command("tmux", args...).Run()
+	cmd := exec.Command("tmux", args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
 }
 
 func (realTmux) Output(args ...string) (string, error) {
-	out, err := exec.Command("tmux", args...).Output()
+	cmd := exec.Command("tmux", args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return string(out), fmt.Errorf("%w: %s", err, msg)
+		}
+	}
 	return string(out), err
 }
 

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -129,6 +129,36 @@ func (s *Sticky) UnsetEnv(key string) error {
 	return nil
 }
 
+// stickyPaneEnv is one DEMUX_STICKY_PANE_* binding parsed from
+// `tmux show-environment -g`: the env var name and the pane id it points at.
+type stickyPaneEnv struct {
+	key  string
+	pane string
+}
+
+// listStickyPaneEnv runs `tmux show-environment -g` and returns every
+// DEMUX_STICKY_PANE_* binding found. Lines that lack a '=' (e.g. tmux's "-KEY"
+// unset marker) are skipped.
+func listStickyPaneEnv(t Tmux) ([]stickyPaneEnv, error) {
+	out, err := t.Output("show-environment", "-g")
+	if err != nil {
+		return nil, err
+	}
+	var envs []stickyPaneEnv
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, envKeyPrefix) {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		envs = append(envs, stickyPaneEnv{key: line[:eq], pane: line[eq+1:]})
+	}
+	return envs, nil
+}
+
 // VersionOK returns nil when the available tmux binary is >= 2.6, which is
 // required for the -f flag on split-window and join-pane.
 func (s *Sticky) VersionOK() error {

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -1,0 +1,68 @@
+// Package sticky implements the per-client tmux pane that runs `demux --sticky`
+// and physically follows the attached client between tmux sessions.
+//
+// See docs/superpowers/specs/2026-05-18-sticky-sidebar-design.md for the spec.
+package sticky
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Tmux abstracts the tmux invocations sticky needs. The production
+// implementation shells out; tests substitute a fake.
+type Tmux interface {
+	Run(args ...string) error
+	Output(args ...string) (string, error)
+}
+
+type realTmux struct{}
+
+func (realTmux) Run(args ...string) error {
+	return exec.Command("tmux", args...).Run()
+}
+
+func (realTmux) Output(args ...string) (string, error) {
+	out, err := exec.Command("tmux", args...).Output()
+	return string(out), err
+}
+
+// Sticky is the operations object. Construct via New() for production or
+// inject a fake Tmux for tests.
+type Sticky struct {
+	T Tmux
+}
+
+// New returns a Sticky wired to the real tmux binary.
+func New() *Sticky {
+	return &Sticky{T: realTmux{}}
+}
+
+// envKeyPrefix is the shared prefix for per-client sticky pane env vars.
+const envKeyPrefix = "DEMUX_STICKY_PANE_"
+
+// SanitizeTTY converts a tmux client_tty string into a token safe for use in
+// an environment variable name: lowercase, with any non-[a-z0-9] character
+// replaced by '_'.
+func SanitizeTTY(tty string) string {
+	var b strings.Builder
+	b.Grow(len(tty))
+	for _, r := range strings.ToLower(tty) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// EnvKey returns the tmux server-global env var name that stores the sticky
+// sidebar pane ID for the given client TTY.
+func EnvKey(tty string) string {
+	return envKeyPrefix + SanitizeTTY(tty)
+}
+
+// keep imports used
+var _ = fmt.Sprintf

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -34,6 +34,11 @@ func (realTmux) Output(args ...string) (string, error) {
 // inject a fake Tmux for tests.
 type Sticky struct {
 	T Tmux
+	// Slots toggles per-window slot mode: when true, Show installs a slot
+	// pane in every window and switches between them via swap-pane (instead
+	// of join-pane). The active sidebar pane lives in whichever window's
+	// slot is currently selected; the others run SlotPlaceholderCmd.
+	Slots bool
 }
 
 // New returns a Sticky wired to the real tmux binary.

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -224,6 +224,34 @@ func (s *Sticky) CurrentClientTTY() (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+// currentTarget returns the window the invoking tmux client is focused on.
+// target is the raw "session_id:window_id" string (usable directly as a tmux
+// -t argument); session and window are its two halves.
+func (s *Sticky) currentTarget() (target, session, window string, err error) {
+	out, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	if err != nil {
+		return "", "", "", fmt.Errorf("tmux display-message current target: %w", err)
+	}
+	target = strings.TrimSpace(out)
+	parts := strings.SplitN(target, ":", 2)
+	if len(parts) < 2 {
+		return "", "", "", fmt.Errorf("unexpected current target %q", target)
+	}
+	return target, parts[0], parts[1], nil
+}
+
+// nonEmptyLines splits raw tmux output on newlines and returns each line
+// trimmed of surrounding whitespace, dropping any that are empty.
+func nonEmptyLines(out string) []string {
+	var lines []string
+	for _, line := range strings.Split(out, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
 // isUnknownVariableErr inspects an error from exec.Command.Output() to detect
 // tmux's "unknown variable: X" stderr line.
 func isUnknownVariableErr(err error) bool {

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -102,6 +103,49 @@ func (s *Sticky) UnsetEnv(key string) error {
 		return fmt.Errorf("tmux set-environment -gu %s: %w", key, err)
 	}
 	return nil
+}
+
+// VersionOK returns nil when the available tmux binary is >= 2.6, which is
+// required for the -f flag on split-window and join-pane.
+func (s *Sticky) VersionOK() error {
+	out, err := s.T.Output("-V")
+	if err != nil {
+		return fmt.Errorf("tmux -V: %w", err)
+	}
+	return checkTmuxVersion(out)
+}
+
+// checkTmuxVersion parses output like "tmux 3.3a\n" and returns an error when
+// the version is older than 2.6. Unparseable inputs (next-* builds, empty
+// output) succeed.
+func checkTmuxVersion(out string) error {
+	s := strings.TrimSpace(out)
+	s = strings.TrimPrefix(s, "tmux ")
+	if s == "" || strings.HasPrefix(s, "next-") {
+		return nil
+	}
+	end := len(s)
+	for end > 0 {
+		r := s[end-1]
+		if (r >= '0' && r <= '9') || r == '.' {
+			break
+		}
+		end--
+	}
+	s = s[:end]
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) < 2 {
+		return nil
+	}
+	major, err1 := strconv.Atoi(parts[0])
+	minor, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return nil
+	}
+	if major > 2 || (major == 2 && minor >= 6) {
+		return nil
+	}
+	return fmt.Errorf("tmux %d.%d is too old; sticky sidebar requires tmux >= 2.6", major, minor)
 }
 
 // PaneAlive returns true when paneID appears in `tmux list-panes -a`.

--- a/internal/sticky/sticky_test.go
+++ b/internal/sticky/sticky_test.go
@@ -179,6 +179,33 @@ func TestCurrentClientTTY_NotInTmux(t *testing.T) {
 	}
 }
 
+func TestCheckTmuxVersion(t *testing.T) {
+	cases := map[string]bool{
+		"tmux 3.3a\n":     true,
+		"tmux 3.4\n":      true,
+		"tmux 2.6\n":      true,
+		"tmux 2.5\n":      false,
+		"tmux 1.8\n":      false,
+		"tmux next-3.5\n": true,
+		"":                true,
+	}
+	for in, expectOK := range cases {
+		err := checkTmuxVersion(in)
+		if (err == nil) != expectOK {
+			t.Errorf("checkTmuxVersion(%q): expectOK=%v, got err=%v", in, expectOK, err)
+		}
+	}
+}
+
+func TestVersionOK_UsesTmuxV(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3a\n"}
+	s := &Sticky{T: f}
+	if err := s.VersionOK(); err != nil {
+		t.Errorf("VersionOK: %v", err)
+	}
+}
+
 func TestUnsetEnv(t *testing.T) {
 	f := newFakeTmux()
 	s := &Sticky{T: f}

--- a/internal/sticky/sticky_test.go
+++ b/internal/sticky/sticky_test.go
@@ -128,6 +128,57 @@ func TestWriteEnv(t *testing.T) {
 	}
 }
 
+func TestPaneAlive_Found(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%1\n%42\n%3\n"}
+	s := &Sticky{T: f}
+	alive, err := s.PaneAlive("%42")
+	if err != nil || !alive {
+		t.Errorf("want alive=true, got alive=%v err=%v", alive, err)
+	}
+}
+
+func TestPaneAlive_NotFound(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%1\n%3\n"}
+	s := &Sticky{T: f}
+	alive, err := s.PaneAlive("%42")
+	if err != nil || alive {
+		t.Errorf("want alive=false, got alive=%v err=%v", alive, err)
+	}
+}
+
+func TestPaneAlive_TmuxFails(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{err: errors.New("server not running")}
+	s := &Sticky{T: f}
+	if _, err := s.PaneAlive("%42"); err == nil {
+		t.Error("expected error to surface")
+	}
+}
+
+func TestCurrentClientTTY(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	s := &Sticky{T: f}
+	tty, err := s.CurrentClientTTY()
+	if err != nil {
+		t.Fatalf("CurrentClientTTY: %v", err)
+	}
+	if tty != "/dev/ttys001" {
+		t.Errorf("tty: want /dev/ttys001, got %q", tty)
+	}
+}
+
+func TestCurrentClientTTY_NotInTmux(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{err: stderrExitError("no server running")}
+	s := &Sticky{T: f}
+	if _, err := s.CurrentClientTTY(); err == nil {
+		t.Error("expected error when tmux unavailable")
+	}
+}
+
 func TestUnsetEnv(t *testing.T) {
 	f := newFakeTmux()
 	s := &Sticky{T: f}

--- a/internal/sticky/sticky_test.go
+++ b/internal/sticky/sticky_test.go
@@ -1,6 +1,55 @@
 package sticky
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// fakeTmux records calls and returns scripted outputs/errors.
+type fakeTmux struct {
+	outputs map[string]fakeReply
+	runs    [][]string
+	runErrs map[string]error
+}
+
+type fakeReply struct {
+	out string
+	err error
+}
+
+func newFakeTmux() *fakeTmux {
+	return &fakeTmux{
+		outputs: map[string]fakeReply{},
+		runErrs: map[string]error{},
+	}
+}
+
+func (f *fakeTmux) key(args []string) string { return strings.Join(args, " ") }
+
+func (f *fakeTmux) Run(args ...string) error {
+	f.runs = append(f.runs, append([]string(nil), args...))
+	if err, ok := f.runErrs[f.key(args)]; ok {
+		return err
+	}
+	return nil
+}
+
+func (f *fakeTmux) Output(args ...string) (string, error) {
+	r, ok := f.outputs[f.key(args)]
+	if !ok {
+		return "", fmt.Errorf("fakeTmux: no scripted output for: %s", f.key(args))
+	}
+	return r.out, r.err
+}
+
+// stderrExitError mimics what exec.Command.Output() returns when tmux fails:
+// an *exec.ExitError whose Stderr contains the message.
+func stderrExitError(msg string) error {
+	return &exec.ExitError{Stderr: []byte(msg)}
+}
 
 func TestSanitizeTTY(t *testing.T) {
 	cases := map[string]string{
@@ -23,5 +72,70 @@ func TestEnvKey(t *testing.T) {
 	want := "DEMUX_STICKY_PANE__dev_ttys001"
 	if got != want {
 		t.Errorf("EnvKey: want %q, got %q", want, got)
+	}
+}
+
+func TestReadEnv_Set(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{
+		out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n",
+	}
+	s := &Sticky{T: f}
+	val, set, err := s.ReadEnv("DEMUX_STICKY_PANE__dev_ttys001")
+	if err != nil {
+		t.Fatalf("ReadEnv: %v", err)
+	}
+	if !set || val != "%42" {
+		t.Errorf("want (%q, true), got (%q, %v)", "%42", val, set)
+	}
+}
+
+func TestReadEnv_UnsetViaStderr(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g DEMUX_STICKY_PANE_x"] = fakeReply{
+		err: stderrExitError("unknown variable: DEMUX_STICKY_PANE_x\n"),
+	}
+	s := &Sticky{T: f}
+	val, set, err := s.ReadEnv("DEMUX_STICKY_PANE_x")
+	if err != nil {
+		t.Fatalf("ReadEnv: %v", err)
+	}
+	if set || val != "" {
+		t.Errorf("want unset, got (%q, %v)", val, set)
+	}
+}
+
+func TestReadEnv_OtherErrorSurfaces(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g DEMUX_STICKY_PANE_y"] = fakeReply{
+		err: errors.New("tmux: server not running"),
+	}
+	s := &Sticky{T: f}
+	if _, _, err := s.ReadEnv("DEMUX_STICKY_PANE_y"); err == nil {
+		t.Error("expected error to surface, got nil")
+	}
+}
+
+func TestWriteEnv(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f}
+	if err := s.WriteEnv("DEMUX_STICKY_PANE_x", "%5"); err != nil {
+		t.Fatalf("WriteEnv: %v", err)
+	}
+	want := []string{"set-environment", "-g", "DEMUX_STICKY_PANE_x", "%5"}
+	if len(f.runs) != 1 || strings.Join(f.runs[0], " ") != strings.Join(want, " ") {
+		t.Errorf("WriteEnv args: want %v, got %v", want, f.runs)
+	}
+}
+
+func TestUnsetEnv(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f}
+	if err := s.UnsetEnv("DEMUX_STICKY_PANE_x"); err != nil {
+		t.Fatalf("UnsetEnv: %v", err)
+	}
+	want := []string{"set-environment", "-gu", "DEMUX_STICKY_PANE_x"}
+	if len(f.runs) != 1 || strings.Join(f.runs[0], " ") != strings.Join(want, " ") {
+		t.Errorf("UnsetEnv args: want %v, got %v", want, f.runs)
 	}
 }

--- a/internal/sticky/sticky_test.go
+++ b/internal/sticky/sticky_test.go
@@ -1,0 +1,27 @@
+package sticky
+
+import "testing"
+
+func TestSanitizeTTY(t *testing.T) {
+	cases := map[string]string{
+		"/dev/ttys001":  "_dev_ttys001",
+		"/dev/pts/3":    "_dev_pts_3",
+		"":              "",
+		"ABC123":        "abc123",
+		"/dev/ttyS01-x": "_dev_ttys01_x",
+	}
+	for in, want := range cases {
+		got := SanitizeTTY(in)
+		if got != want {
+			t.Errorf("SanitizeTTY(%q): want %q, got %q", in, want, got)
+		}
+	}
+}
+
+func TestEnvKey(t *testing.T) {
+	got := EnvKey("/dev/ttys001")
+	want := "DEMUX_STICKY_PANE__dev_ttys001"
+	if got != want {
+		t.Errorf("EnvKey: want %q, got %q", want, got)
+	}
+}

--- a/internal/sticky/sweep.go
+++ b/internal/sticky/sweep.go
@@ -1,9 +1,5 @@
 package sticky
 
-import (
-	"strings"
-)
-
 // SweepStaleStickyEnv scans every DEMUX_STICKY_PANE_* env var on the server
 // and unsets any whose pane id no longer exists (or is empty). If after this
 // pass no live sidebar remains tracked, slot placeholder panes across all
@@ -54,11 +50,7 @@ func (s *Sticky) SweepOrphanWindows(width int) error {
 	if err != nil {
 		return nil
 	}
-	for _, line := range strings.Split(out, "\n") {
-		wid := strings.TrimSpace(line)
-		if wid == "" {
-			continue
-		}
+	for _, wid := range nonEmptyLines(out) {
 		_ = s.HandleWindowAfterKill(wid, width)
 	}
 	return nil

--- a/internal/sticky/sweep.go
+++ b/internal/sticky/sweep.go
@@ -1,0 +1,71 @@
+package sticky
+
+import (
+	"strings"
+)
+
+// SweepStaleStickyEnv scans every DEMUX_STICKY_PANE_* env var on the server
+// and unsets any whose pane id no longer exists (or is empty). If after this
+// pass no live sidebar remains tracked, slot placeholder panes across all
+// windows are uninstalled too. Intended as a fallback for tmux builds where
+// `#{hook_pane}` is not populated for `after-kill-pane`, leaving targeted
+// cleanup blind to which pane was actually killed.
+func (s *Sticky) SweepStaleStickyEnv() error {
+	out, err := s.T.Output("show-environment", "-g")
+	if err != nil {
+		return nil
+	}
+	var stale []string
+	anyLive := false
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, envKeyPrefix) {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		k, v := line[:eq], line[eq+1:]
+		if v == "" {
+			stale = append(stale, k)
+			continue
+		}
+		alive, _ := s.PaneAlive(v)
+		if alive {
+			anyLive = true
+			continue
+		}
+		stale = append(stale, k)
+	}
+	if len(stale) == 0 {
+		return nil
+	}
+	for _, k := range stale {
+		_ = s.T.Run("set-environment", "-gu", k)
+	}
+	if !anyLive {
+		_ = s.UninstallSlots()
+	}
+	return nil
+}
+
+// SweepOrphanWindows applies HandleWindowAfterKill to every window on the
+// server, so that any window currently left with only a sidebar slot pane is
+// either folded into a sibling window (if it holds the active sidebar) or
+// closed outright (if its slot is just a placeholder). Safe to call when no
+// orphan exists - HandleWindowAfterKill is a no-op for healthy windows.
+func (s *Sticky) SweepOrphanWindows() error {
+	out, err := s.T.Output("list-windows", "-aF", "#{window_id}")
+	if err != nil {
+		return nil
+	}
+	for _, line := range strings.Split(out, "\n") {
+		wid := strings.TrimSpace(line)
+		if wid == "" {
+			continue
+		}
+		_ = s.HandleWindowAfterKill(wid)
+	}
+	return nil
+}

--- a/internal/sticky/sweep.go
+++ b/internal/sticky/sweep.go
@@ -55,7 +55,10 @@ func (s *Sticky) SweepStaleStickyEnv() error {
 // either folded into a sibling window (if it holds the active sidebar) or
 // closed outright (if its slot is just a placeholder). Safe to call when no
 // orphan exists - HandleWindowAfterKill is a no-op for healthy windows.
-func (s *Sticky) SweepOrphanWindows() error {
+//
+// width is the configured sidebar width, forwarded to HandleWindowAfterKill
+// so a folded-in sidebar is sized correctly.
+func (s *Sticky) SweepOrphanWindows(width int) error {
 	out, err := s.T.Output("list-windows", "-aF", "#{window_id}")
 	if err != nil {
 		return nil
@@ -65,7 +68,7 @@ func (s *Sticky) SweepOrphanWindows() error {
 		if wid == "" {
 			continue
 		}
-		_ = s.HandleWindowAfterKill(wid)
+		_ = s.HandleWindowAfterKill(wid, width)
 	}
 	return nil
 }

--- a/internal/sticky/sweep.go
+++ b/internal/sticky/sweep.go
@@ -11,32 +11,23 @@ import (
 // `#{hook_pane}` is not populated for `after-kill-pane`, leaving targeted
 // cleanup blind to which pane was actually killed.
 func (s *Sticky) SweepStaleStickyEnv() error {
-	out, err := s.T.Output("show-environment", "-g")
+	envs, err := listStickyPaneEnv(s.T)
 	if err != nil {
 		return nil
 	}
 	var stale []string
 	anyLive := false
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, envKeyPrefix) {
+	for _, e := range envs {
+		if e.pane == "" {
+			stale = append(stale, e.key)
 			continue
 		}
-		eq := strings.IndexByte(line, '=')
-		if eq < 0 {
-			continue
-		}
-		k, v := line[:eq], line[eq+1:]
-		if v == "" {
-			stale = append(stale, k)
-			continue
-		}
-		alive, _ := s.PaneAlive(v)
+		alive, _ := s.PaneAlive(e.pane)
 		if alive {
 			anyLive = true
 			continue
 		}
-		stale = append(stale, k)
+		stale = append(stale, e.key)
 	}
 	if len(stale) == 0 {
 		return nil

--- a/internal/sticky/sweep_test.go
+++ b/internal/sticky/sweep_test.go
@@ -128,7 +128,7 @@ func TestSweepOrphanWindows_VisitsEveryWindow(t *testing.T) {
 	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%20 \n%21 \n"}
 	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 \n%31 \n"}
 	s := &Sticky{T: f}
-	if err := s.SweepOrphanWindows(); err != nil {
+	if err := s.SweepOrphanWindows(35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	var saw1, saw2, saw3 bool
@@ -160,7 +160,7 @@ func TestSweepOrphanWindows_KillsOrphanPlaceholder(t *testing.T) {
 	f.outputs["list-panes -t @7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%77 1\n"}
 	f.outputs["show-environment -g"] = fakeReply{out: ""}
 	s := &Sticky{T: f}
-	if err := s.SweepOrphanWindows(); err != nil {
+	if err := s.SweepOrphanWindows(35); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	saw := false
@@ -171,5 +171,33 @@ func TestSweepOrphanWindows_KillsOrphanPlaceholder(t *testing.T) {
 	}
 	if !saw {
 		t.Errorf("expected kill-pane for orphan placeholder %%77, got: %v", f.runs)
+	}
+}
+
+// SweepOrphanWindows must forward its width argument to HandleWindowAfterKill
+// so a folded-in sidebar is joined at the configured width.
+func TestSweepOrphanWindows_FoldsSidebarWithConfiguredWidth(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@7\n"}
+	// @7 holds the active sidebar as its lone pane.
+	f.outputs["list-panes -t @7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%77 1\n"}
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%77\n"}
+	f.outputs["display-message -t @7 -p #{session_id}"] = fakeReply{out: "$1\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@7 0\n@3 1\n"}
+	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 \n%31 \n"}
+	f.outputs["display-message -p -t %77 #{window_id}"] = fakeReply{out: "@7\n"}
+
+	s := &Sticky{T: f}
+	if err := s.SweepOrphanWindows(48); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "join-pane -f -h -b -d -l 48 -s %77 -t @3" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected join-pane sized to forwarded width 48, got: %v", f.runs)
 	}
 }

--- a/internal/sticky/sweep_test.go
+++ b/internal/sticky/sweep_test.go
@@ -1,0 +1,175 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSweepStaleStickyEnv_NoEnv_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: "OTHER=keep\n"}
+	s := &Sticky{T: f}
+	if err := s.SweepStaleStickyEnv(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "set-environment") || strings.HasPrefix(j, "kill-pane") {
+			t.Errorf("expected no changes, got: %v", r)
+		}
+	}
+}
+
+func TestSweepStaleStickyEnv_LiveSidebar_NoOp(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n%99\n"}
+	s := &Sticky{T: f}
+	if err := s.SweepStaleStickyEnv(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "set-environment") || strings.HasPrefix(j, "kill-pane") {
+			t.Errorf("expected no changes for live sidebar, got: %v", r)
+		}
+	}
+}
+
+func TestSweepStaleStickyEnv_DeadSidebar_UnsetsAndUninstalls(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\nOTHER=keep\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%99\n%100\n"}
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%70 1\n%80 1\n"}
+
+	s := &Sticky{T: f}
+	if err := s.SweepStaleStickyEnv(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var sawUnset, sawKill70, sawKill80 bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			sawUnset = true
+		}
+		if j == "kill-pane -t %70" {
+			sawKill70 = true
+		}
+		if j == "kill-pane -t %80" {
+			sawKill80 = true
+		}
+	}
+	if !sawUnset {
+		t.Errorf("expected env unset for dead sidebar, got: %v", f.runs)
+	}
+	if !sawKill70 || !sawKill80 {
+		t.Errorf("expected slot uninstall when no live sidebar remains, got: %v", f.runs)
+	}
+}
+
+func TestSweepStaleStickyEnv_OneDeadOneLive_KeepsSlotsAlive(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\nDEMUX_STICKY_PANE__dev_ttys002=%43\n"}
+	// Only %43 still exists.
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%43\n%99\n"}
+	s := &Sticky{T: f}
+	if err := s.SweepStaleStickyEnv(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var sawDeadUnset, sawLiveUnset, sawKillAny bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			sawDeadUnset = true
+		}
+		if j == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys002" {
+			sawLiveUnset = true
+		}
+		if strings.HasPrefix(j, "kill-pane") {
+			sawKillAny = true
+		}
+	}
+	if !sawDeadUnset {
+		t.Errorf("expected dead var to be unset, got: %v", f.runs)
+	}
+	if sawLiveUnset {
+		t.Errorf("did not expect live var to be unset, got: %v", f.runs)
+	}
+	if sawKillAny {
+		t.Errorf("did not expect UninstallSlots when a live sidebar remains, got: %v", f.runs)
+	}
+}
+
+func TestSweepStaleStickyEnv_EmptyValue_Unsets(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=\n"}
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: ""}
+	s := &Sticky{T: f}
+	if err := s.SweepStaleStickyEnv(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "set-environment -gu DEMUX_STICKY_PANE__dev_ttys001" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected unset of empty env var, got: %v", f.runs)
+	}
+}
+
+func TestSweepOrphanWindows_VisitsEveryWindow(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@2\n@3\n"}
+	// Each window has 2 panes => HandleWindowAfterKill no-ops; we only
+	// verify the iteration covers every window via list-panes calls.
+	f.outputs["list-panes -t @1 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n%11 \n"}
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%20 \n%21 \n"}
+	f.outputs["list-panes -t @3 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%30 \n%31 \n"}
+	s := &Sticky{T: f}
+	if err := s.SweepOrphanWindows(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var saw1, saw2, saw3 bool
+	for _, r := range f.runs {
+		// HandleWindowAfterKill on healthy windows produces no runs;
+		// verify by tracking Output calls instead.
+		_ = r
+	}
+	// Replay tracked outputs to detect coverage: any window that wasn't
+	// queried would still be in the fixture. Inspect fakeTmux internals
+	// via successful Output dispatches - here we just trust the absence
+	// of "no scripted output" errors as full coverage.
+	_, err := f.Output("list-panes", "-t", "@1", "-F", "#{pane_id} #{@demux_slot}")
+	saw1 = err == nil
+	_, err = f.Output("list-panes", "-t", "@2", "-F", "#{pane_id} #{@demux_slot}")
+	saw2 = err == nil
+	_, err = f.Output("list-panes", "-t", "@3", "-F", "#{pane_id} #{@demux_slot}")
+	saw3 = err == nil
+	if !saw1 || !saw2 || !saw3 {
+		t.Errorf("expected all windows to have been queried; saw=%v %v %v", saw1, saw2, saw3)
+	}
+}
+
+func TestSweepOrphanWindows_KillsOrphanPlaceholder(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@7\n"}
+	// Orphan slot-only window with no live sidebar in env: treated as
+	// placeholder, killed outright.
+	f.outputs["list-panes -t @7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%77 1\n"}
+	f.outputs["show-environment -g"] = fakeReply{out: ""}
+	s := &Sticky{T: f}
+	if err := s.SweepOrphanWindows(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	saw := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "kill-pane -t %77" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected kill-pane for orphan placeholder %%77, got: %v", f.runs)
+	}
+}

--- a/internal/sticky/toggle.go
+++ b/internal/sticky/toggle.go
@@ -1,0 +1,26 @@
+package sticky
+
+// Toggle hides the sticky sidebar if a live pane is tracked, otherwise shows
+// it. Stale env entries (env set but pane gone) are treated as "not shown"
+// and fall through to Show.
+func (s *Sticky) Toggle(opts ShowOpts) error {
+	tty, err := s.CurrentClientTTY()
+	if err != nil {
+		return err
+	}
+	key := EnvKey(tty)
+	val, set, err := s.ReadEnv(key)
+	if err != nil {
+		return err
+	}
+	if set && val != "" {
+		alive, err := s.PaneAlive(val)
+		if err != nil {
+			return err
+		}
+		if alive {
+			return s.Hide()
+		}
+	}
+	return s.Show(opts)
+}

--- a/internal/sticky/toggle_test.go
+++ b/internal/sticky/toggle_test.go
@@ -1,0 +1,62 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToggle_EnvSetAlive_CallsHide(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	s := &Sticky{T: f}
+	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Toggle: %v", err)
+	}
+	sawKill := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "kill-pane -t %42" {
+			sawKill = true
+		}
+	}
+	if !sawKill {
+		t.Errorf("expected Toggle to call kill-pane (Hide), got: %v", f.runs)
+	}
+}
+
+func TestToggle_EnvUnset_CallsShow(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["split-window -f -h -b -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+	s := &Sticky{T: f}
+	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Toggle: %v", err)
+	}
+	sawSplit := false
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "set-environment -g DEMUX_STICKY_PANE__dev_ttys001 %88") {
+			sawSplit = true
+		}
+	}
+	if !sawSplit {
+		t.Errorf("expected Toggle to call Show (recording new pane id), got: %v", f.runs)
+	}
+}
+
+func TestToggle_EnvSetButPaneDead_CallsShow(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%1\n%3\n"}
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["split-window -f -h -b -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+	s := &Sticky{T: f}
+	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Toggle: %v", err)
+	}
+}

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -149,6 +149,21 @@ func SelectNextPane() error {
 	return exec.Command("tmux", "select-pane", "-t", ":.+").Run()
 }
 
+// ResolveWindowID returns the @N window id of the destination tmux would
+// focus when target is given to switch-client / select-window. Accepts any
+// target tmux understands: session name, session_id, "session:winidx",
+// "session:winidx.paneidx", %paneid, @windowid.
+func ResolveWindowID(target string) (string, error) {
+	if target == "" {
+		return "", fmt.Errorf("empty target")
+	}
+	out, err := exec.Command("tmux", "display-message", "-t", target, "-p", "#{window_id}").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // PaneIDToTargetMap returns a map from pane_id (%N) to display label "session:windowIndex.paneIndex"
 // for all panes with a non-empty PaneID in the provided slice.
 func PaneIDToTargetMap(panes []Pane) map[string]string {

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -141,6 +141,14 @@ func SwitchClient(target string) error {
 	return exec.Command("tmux", "switch-client", "-t", target).Run()
 }
 
+// SelectNextPane runs tmux select-pane -t :.+ which is the same action as
+// tmux's default `prefix + o` binding: move focus to the next pane in the
+// current window. Used in sticky mode to jump out of the sidebar pane after
+// the user attaches to a session.
+func SelectNextPane() error {
+	return exec.Command("tmux", "select-pane", "-t", ":.+").Run()
+}
+
 // PaneIDToTargetMap returns a map from pane_id (%N) to display label "session:windowIndex.paneIndex"
 // for all panes with a non-empty PaneID in the provided slice.
 func PaneIDToTargetMap(panes []Pane) map[string]string {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -108,9 +108,9 @@ var keys = keyMap{
 }
 
 // allKeyDefs returns the ordered list of keyDefs for help menu rendering.
-// Bindings with empty section are omitted.
+// Bindings with empty section are omitted (used to hide entries in sticky mode).
 func allKeyDefs() []keyDef {
-	return []keyDef{
+	all := []keyDef{
 		// Global
 		keys.FocusSidebarList, keys.Yank, keys.FilterSearch, keys.ClearFilter,
 		keys.Refresh, keys.Help, keys.Quit,
@@ -124,4 +124,28 @@ func allKeyDefs() []keyDef {
 		keys.JumpUpDown, keys.ExpandCollapse, keys.ExpandCollapseAll,
 		keys.ProcEnter, keys.ProcOpen, keys.ActionMenu, keys.KillProc,
 	}
+	out := make([]keyDef, 0, len(all))
+	for _, d := range all {
+		if d.section == "" {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// ApplyStickyMode mutates the package-global `keys` so the quit binding is
+// disabled and the quit row is omitted from the help overlay. Idempotent.
+// Call once from tui.Run when cfg.StickyMode is true. Pair with ResetStickyMode
+// in tests that toggle sticky mode mid-process.
+func ApplyStickyMode() {
+	keys.Quit.Binding.SetEnabled(false)
+	keys.Quit.section = ""
+}
+
+// ResetStickyMode restores the quit binding to its default enabled state and
+// puts the Quit row back into the Global section. Test-only helper.
+func ResetStickyMode() {
+	keys.Quit.Binding.SetEnabled(true)
+	keys.Quit.section = "Global"
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -457,6 +457,9 @@ func (m Model) plainBreadcrumb() string {
 
 // Run launches the Bubbletea program.
 func Run(cfg config.Config, database *db.DB) error {
+	if cfg.StickyMode {
+		ApplyStickyMode()
+	}
 	m := New(cfg, database)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	_, err := p.Run()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -147,6 +147,11 @@ type Model struct {
 	currentSession   string
 	startupFocusDone bool
 
+	// pendingStickyRefocus is set by the sticky-mode follow poke (F12) and
+	// consumed on the next panesMsg to snap the sidebar cursor back to the
+	// active session. Avoids tying refocus to the periodic refresh tick.
+	pendingStickyRefocus bool
+
 	searchInput SearchInputModel
 	queryResult query.Result
 	searchGen   int

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -13,8 +13,26 @@ import (
 	"github.com/rtalexk/demux/internal/proc"
 	"github.com/rtalexk/demux/internal/query"
 	"github.com/rtalexk/demux/internal/session"
+	"github.com/rtalexk/demux/internal/sticky"
 	"github.com/rtalexk/demux/internal/tmux"
 )
+
+// stickyPrepareTarget pre-installs a slot pane in the window tmux would focus
+// when given target, so the after-select-window hook's follow can swap-pane
+// instead of split-window (avoiding a one-time flicker). No-op outside
+// sticky/slots mode or when the resolution fails. Best-effort.
+func (m Model) stickyPrepareTarget(target string) {
+	if target == "" || !m.cfg.StickyMode || !m.cfg.Sidebar.Sticky.Slots {
+		return
+	}
+	winID, err := tmux.ResolveWindowID(target)
+	if err != nil || winID == "" {
+		return
+	}
+	s := sticky.New()
+	s.Slots = true
+	_ = s.PrepareWindow(winID, m.cfg.Sidebar.Sticky.Width)
+}
 
 const (
 	dirDown = 1
@@ -278,6 +296,7 @@ func (m Model) switchLiveSession(sessionName string) (Model, tea.Cmd) {
 	if target == "" {
 		target = sessionName
 	}
+	m.stickyPrepareTarget(target)
 	err := tmux.SwitchClient(target)
 	if err == nil && m.popupMode {
 		return m, tea.Quit
@@ -471,6 +490,7 @@ func (m Model) handleProcListOpen() (Model, tea.Cmd) {
 		target = node.Session
 	}
 	if target != "" {
+		m.stickyPrepareTarget(target)
 		tmux.SwitchClient(target)
 		if m.popupMode {
 			return m, tea.Quit

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -121,6 +121,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, keys.Refresh.Binding):
 		m.procGen++
 		return m, tea.Batch(m.fetchPanes(), m.fetchStates(), m.fetchWatches(), m.fetchItemSessions(), m.scheduleProcFetch())
+	case msg.Type == tea.KeyF12:
+		// Sticky-mode follow poke: force-refresh and refocus the sidebar
+		// on the now-active session on the resulting panesMsg.
+		if m.cfg.StickyMode {
+			m.pendingStickyRefocus = true
+			m.procGen++
+			return m, tea.Batch(m.fetchPanes(), m.fetchStates(), m.fetchWatches(), m.fetchItemSessions(), m.scheduleProcFetch())
+		}
+		return m, nil
 	case msg.String() == "C":
 		// C toggles items mode globally regardless of focus.
 		// Not available in compact mode (no proclist panel to render into).

--- a/internal/tui/model_keys.go
+++ b/internal/tui/model_keys.go
@@ -282,6 +282,12 @@ func (m Model) switchLiveSession(sessionName string) (Model, tea.Cmd) {
 	if err == nil && m.popupMode {
 		return m, tea.Quit
 	}
+	if err == nil && m.cfg.StickyMode {
+		// In sticky mode the user wants 'o'/Enter to drop them out of the
+		// sidebar pane into the session content (otherwise focus stays in
+		// the sidebar). Equivalent to tmux's default `prefix + o`.
+		_ = tmux.SelectNextPane()
+	}
 	return m, nil
 }
 

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -240,10 +240,10 @@ func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 	m.sidebar.SetActiveSession(msg.currentSession)
 	m.updateDetailFromSelection()
 	var cmds []tea.Cmd
+	visibleRows := max(1, m.height-1-2-searchBoxH)
 	if !m.ready {
 		// First load: sidebar is visible — kick off tick and states; procs are fetched on-demand
 		m.currentSession = msg.currentSession
-		visibleRows := max(1, m.height-1-2-searchBoxH)
 		switch m.cfg.Sidebar.FocusOnOpen {
 		case "current_session", "first_session":
 			m.applyNonAlertFocusMode(m.cfg.Sidebar.FocusOnOpen, visibleRows)
@@ -265,6 +265,11 @@ func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 			m.procGen++
 			cmds = append(cmds, m.scheduleProcFetch())
 		}
+	} else if m.cfg.StickyMode && msg.currentSession != "" && msg.currentSession != m.currentSession {
+		// In sticky mode, refocus the sidebar on the active session every time
+		// the user jumps to a different tmux session.
+		m.currentSession = msg.currentSession
+		m.sidebar.FocusNode(m.currentSession, visibleRows)
 	}
 	if m.cfg.Git.Enabled {
 		for sessionName, windows := range grouped {

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -265,11 +265,14 @@ func (m Model) handlePanesMsg(msg panesMsg) (Model, tea.Cmd) {
 			m.procGen++
 			cmds = append(cmds, m.scheduleProcFetch())
 		}
-	} else if m.cfg.StickyMode && msg.currentSession != "" && msg.currentSession != m.currentSession {
-		// In sticky mode, refocus the sidebar on the active session every time
-		// the user jumps to a different tmux session.
+	} else if m.cfg.StickyMode && msg.currentSession != "" &&
+		(m.pendingStickyRefocus || msg.currentSession != m.currentSession) {
+		// In sticky mode, refocus the sidebar on the active session whenever
+		// the user jumps to a different session OR a follow poke (F12) asks
+		// us to re-snap (covers same-session window switches).
 		m.currentSession = msg.currentSession
 		m.sidebar.FocusNode(m.currentSession, visibleRows)
+		m.pendingStickyRefocus = false
 	}
 	if m.cfg.Git.Enabled {
 		for sessionName, windows := range grouped {

--- a/internal/tui/sticky_test.go
+++ b/internal/tui/sticky_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestApplyStickyMode_DisablesQuitBinding(t *testing.T) {
+	defer ResetStickyMode()
+	ApplyStickyMode()
+
+	qMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	if key.Matches(qMsg, keys.Quit.Binding) {
+		t.Error("expected Quit to NOT match 'q' in sticky mode")
+	}
+	ctrlC := tea.KeyMsg{Type: tea.KeyCtrlC}
+	if key.Matches(ctrlC, keys.Quit.Binding) {
+		t.Error("expected Quit to NOT match ctrl+c in sticky mode")
+	}
+}
+
+func TestApplyStickyMode_HidesQuitFromHelp(t *testing.T) {
+	defer ResetStickyMode()
+	ApplyStickyMode()
+
+	for _, d := range allKeyDefs() {
+		if strings.Contains(d.Binding.Help().Desc, "quit") {
+			t.Errorf("help overlay still contains quit row in sticky mode: %+v", d)
+		}
+	}
+}
+
+func TestAllKeyDefs_NormalIncludesQuit(t *testing.T) {
+	ResetStickyMode()
+
+	found := false
+	for _, d := range allKeyDefs() {
+		if strings.Contains(d.Binding.Help().Desc, "quit") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected default help overlay to include quit row")
+	}
+}
+
+func TestResetStickyMode_RestoresQuit(t *testing.T) {
+	ApplyStickyMode()
+	ResetStickyMode()
+
+	qMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	if !key.Matches(qMsg, keys.Quit.Binding) {
+		t.Error("expected Quit to match 'q' after ResetStickyMode")
+	}
+}


### PR DESCRIPTION
## Context

No ticket.

The demux sidebar was stateless: attaching to a new session or switching windows required manually recreating it. There was no way to keep a persistent sidebar pane that physically followed you across sessions and windows, or to avoid the one-frame layout flicker that `join-pane` causes on every window switch.

## What does this PR do

Adds a full sticky sidebar system to demux.

<img width="1800" height="610" alt="image" src="https://github.com/user-attachments/assets/7c3357b9-de5c-4f24-b21c-aad20f09bbf8" />

**New package `internal/sticky`**

- `Show` — idempotent: splits a sidebar pane running `demux --sticky`, or no-ops if one already exists. Writes `DEMUX_STICKY_PANE` env var to identify the pane.
- `Hide` — kills the sticky pane and any slot placeholders; idempotent.
- `Toggle` — show if hidden, hide if shown.
- `Follow` — moves the sidebar pane into the current session/window via `join-pane -f`. Preserves current width. Ejects focus back to the previously active pane with `-d`.
- `gc.go` / `sweep.go` / `orphan.go` — sweep stale env vars and kill orphan windows (windows left with only a slot placeholder after the sidebar is killed or a pane exits).

**Slots mode** (`sidebar.sticky.slots = true`, opt-in)

Default follow uses `join-pane`, which triggers a one-frame layout rebuild (flicker). Slots mode eliminates this:

- Maintains up to **8 slot panes** server-wide in the most recently visited windows; each slot runs `demux sidebar slot` as a quiet placeholder.
- On switch to a window that already has a slot, the active sidebar pane is **swapped** via `swap-pane -d` — no layout rebuild, no flicker.
- On switch to a window outside the MRU, one-time `split-window` creates a slot, then the swap follows; subsequent visits are flicker-free.
- MRU reservation priority (capped at 8): last window in current session → last session's active window → other current-session windows by MRU → cross-session MRU.

**New `demux sidebar` subcommands** (`cmd/sidebar.go`)

`toggle`, `show`, `hide`, `follow`, `slots {install,uninstall,ensure}`, and a hidden `slot` placeholder subcommand.

**Hook integration** (`cmd/hooks.go`)

`demux hooks init --tool tmux` now appends four extra lines:

- `client-session-changed` → `demux sidebar follow` (cross-session follow)
- `after-select-window` → `demux sidebar follow` (same-session window switch)
- `after-new-window` → `demux sidebar follow` (new-window doesn't fire `after-select-window`)
- `client-attached` → `demux sidebar show` (auto-create on client attach)

**`--sticky` flag on root command** (`cmd/root.go`)

Forces `compact` layout and `card` session view; disables the quit keybinding in the TUI (`cmd/tui/keys.go`). The TUI also jumps focus back out of the sticky pane after attaching to a session, and forces a refresh poke on every follow.

**Config** (`internal/config/`)

```toml
[sidebar.sticky]
width = 35   # initial pane width (columns); preserved across follows
slots = false
```

`width` is clamped to `[10, 220]`. `slots` is validated as bool.

### Out of scope (known gaps)

- `internal/sticky/follow.go` — `join-pane` requires tmux ≥ 2.6; a runtime version check gates this path, but there is no graceful degradation for older tmux versions beyond an error exit.
- No session-level config override for `slots`; it is global per config file.

> [!NOTE]
> There's still a small flicker while navigating between windows/sessions. It's likely either the time it takes to physically move the pane, or the forced redraw demux issues to pull the latest state. I'm OK with this — it's annoying, but not the end of the world. At some point I'll look into it and find a way to make it smoother.

## Manual QA

> Requires tmux ≥ 2.6 and a built `demux` binary on `$PATH`. All scenarios assume `$TMUX` is set (i.e., you are inside a tmux session).

### Prerequisites

<details>

<summary>1. demux binary is built and on PATH.</summary>

```bash
which demux && demux --version
```

Expect a version string. If missing, run `go build -o demux . && export PATH="$PWD:$PATH"`.

</details>

<details>

<summary>2. tmux version ≥ 2.6.</summary>

```bash
tmux -V
```

Expect `tmux 2.6` or higher. Older versions lack `-f` flag for `join-pane`.

</details>

<details>

<summary>3. No existing sticky pane from a prior run.</summary>

```bash
tmux show-environment -g DEMUX_STICKY_PANE 2>/dev/null || echo "clean"
```

If a stale pane id appears, run `demux sidebar hide` first.

</details>

### Scenario 1 — Show / Hide / Toggle

<details>

<summary>Scenario 1 — basic lifecycle</summary>

1. Inside a tmux session, run:
   ```bash
   demux sidebar show
   ```
   Expected: a new pane appears on the right running `demux --sticky` (compact card view, no quit binding visible).
2. Run `demux sidebar show` again.
   Expected: no second pane created; command exits 0 silently.
3. Run `demux sidebar hide`.
   Expected: pane is gone; window layout returns to single pane.
4. Run `demux sidebar hide` again.
   Expected: exits 0, no error.
5. Run `demux sidebar toggle`.
   Expected: pane appears.
6. Run `demux sidebar toggle` again.
   Expected: pane disappears.

</details>

### Scenario 2 — Follow across sessions

<details>

<summary>Scenario 2 — sidebar follows on session switch</summary>

1. Start with two sessions: `A` and `B`. Attach to `A`.
2. `demux sidebar show` in session `A`.
   Expected: sidebar pane visible in `A`.
3. Switch to session `B` (`tmux switch-client -t B`).
   Expected: sidebar pane now visible in `B`; it is gone from `A`.

> ⚠️ **Hooks required for automatic follow.** Without the hook lines from `demux hooks init --tool tmux` in `~/.tmux.conf`, you must call `demux sidebar follow` manually after switching. To test hook-driven follow: add the snippet to `~/.tmux.conf` and `tmux source ~/.tmux.conf` before step 3.

4. Verify focus landed on the non-sidebar pane:
   ```bash
   tmux display-message -p '#{pane_id}'
   ```
   Expected: id is the main pane, not the sidebar pane.

</details>

### Scenario 3 — Slots mode (no-flicker swap)

<details>

<summary>Scenario 3 — slots mode swap-pane follow</summary>

1. Add to `~/.config/demux/demux.toml`:
   ```toml
   [sidebar.sticky]
   slots = true
   ```
2. `demux sidebar show`. Sidebar appears.
3. Switch to a second window (`tmux new-window`).
   Expected: sidebar pane swaps into the new window with no visible layout flicker. A `demux-slot` placeholder pane is visible in the previous window (check `tmux list-panes -t :0` — expect a pane titled `demux-slot`).
4. Switch back to the first window.
   Expected: swap again, sidebar back in original window.
5. `demux sidebar hide`.
   Expected: sidebar gone; all slot placeholder panes killed; no windows left with only a slot pane.

</details>

### Scenario 4 — Width preservation

<details>

<summary>Scenario 4 — width preserved across follows</summary>

1. `demux sidebar show`. Note default width (35 columns or config value).
2. Resize the sidebar pane: `tmux resize-pane -t <pane-id> -x 50`.
3. Switch to another session or window (with hooks enabled).
4. Check sidebar pane width:
   ```bash
   tmux display-message -p '#{pane_width}'
   ```
   Expected: 50 (the resized width), not 35.

</details>

### Scenario 5 — SIGHUP/SIGTERM slot placeholder exit

<details>

<summary>Scenario 5 — slot placeholder exits cleanly on signal</summary>

1. With slots mode enabled and sidebar shown, note a slot placeholder window.
2. Kill tmux server or send SIGTERM to the slot pane's process:
   ```bash
   kill -TERM $(tmux display-message -t demux-slot -p '#{pane_pid}')
   ```
   Expected: the placeholder exits; tmux does not leave a zombie pane; the slot pane's window is cleaned up (closed if it was the last non-slot pane).

</details>
