### PR TITLE
fix: sidebar highlight gap and sticky slot cleanup on natural exit

### DIFF
--- a/internal/sticky/orphan.go
+++ b/internal/sticky/orphan.go
@@ -91,9 +91,17 @@ func (s *Sticky) HandleWindowAfterKill(windowID string, width int) error {
 // while waiting for after-kill-pane to fire (which may be unreliable for
 // natural process exits in some tmux versions).
 //
+// When the remaining pane is a placeholder slot rather than the active
+// sidebar (e.g. an ephemeral lazygit window that got a slot from the
+// after-new-window hook), the placeholder is killed so the window closes
+// cleanly instead of lingering as a useless slot-only window. This mirrors
+// HandleWindowAfterKill's placeholder branch - but after-kill-pane does not
+// fire for natural process exits, so this proactive path is the only cleanup
+// that runs for them.
+//
 // No-op when the window has more than two panes, when the remaining pane after
-// excluding exitingPaneID is not the tracked sidebar, or when there is no
-// sibling window to receive the sidebar.
+// excluding exitingPaneID is a regular (non-sticky) pane, or when there is no
+// sibling window to receive a relocated sidebar.
 func (s *Sticky) EjectSidebarIfAloneAfterExit(exitingPaneID, windowID string, width int) error {
 	if exitingPaneID == "" || windowID == "" {
 		return nil
@@ -102,7 +110,7 @@ func (s *Sticky) EjectSidebarIfAloneAfterExit(exitingPaneID, windowID string, wi
 	if err != nil {
 		return nil
 	}
-	var orphan string
+	var orphan, orphanSlot string
 	remaining := 0
 	for _, line := range nonEmptyLines(panesOut) {
 		parts := strings.SplitN(line, " ", 2)
@@ -112,6 +120,10 @@ func (s *Sticky) EjectSidebarIfAloneAfterExit(exitingPaneID, windowID string, wi
 		}
 		remaining++
 		orphan = paneID
+		orphanSlot = ""
+		if len(parts) >= 2 {
+			orphanSlot = strings.TrimSpace(parts[1])
+		}
 	}
 	if remaining != 1 {
 		return nil
@@ -126,6 +138,13 @@ func (s *Sticky) EjectSidebarIfAloneAfterExit(exitingPaneID, windowID string, wi
 		}
 	}
 	if !isSidebar {
+		// The window would be left with a single pane that is not the active
+		// sidebar. If it is a placeholder slot, kill it now so the window
+		// closes once the exiting pane dies; a regular pane is left alone.
+		if orphanSlot == "1" {
+			demuxlog.Info("pre-exit: lone placeholder slot, killing", "window_id", windowID, "pane_id", orphan)
+			_ = s.T.Run("kill-pane", "-t", orphan)
+		}
 		return nil
 	}
 	demuxlog.Info("pre-exit: sidebar will be alone, relocating", "window_id", windowID, "pane_id", orphan)

--- a/internal/sticky/orphan_test.go
+++ b/internal/sticky/orphan_test.go
@@ -363,6 +363,33 @@ func TestEjectSidebarIfAloneAfterExit_RemainingIsNotSidebar_NoOp(t *testing.T) {
 	}
 }
 
+// Regression: an ephemeral window (e.g. a lazygit `new-window`) holds a
+// content pane plus a placeholder slot pane. When the content pane's process
+// exits naturally, pane-exited fires but after-kill-pane does not, so this is
+// the only cleanup that runs. The lone placeholder must be killed so the
+// window closes instead of lingering as a useless slot-only window.
+func TestEjectSidebarIfAloneAfterExit_RemainingIsPlaceholderSlot_KillsIt(t *testing.T) {
+	f := newFakeTmux()
+	// Window @2: content pane %10 is exiting; the only other pane %42 is a
+	// placeholder slot (tagged) that is NOT the tracked sidebar.
+	f.outputs["list-panes -t @2 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 \n%42 1\n"}
+	// Active sidebar is alive elsewhere (%99); env does not point at %42.
+	f.outputs["show-environment -g"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%99\n"}
+	s := &Sticky{T: f}
+	if err := s.EjectSidebarIfAloneAfterExit("%10", "@2", 35); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ranCmd(f, "kill-pane -t %42") {
+		t.Errorf("expected kill-pane for lone placeholder slot, got: %v", f.runs)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "join-pane") || strings.HasPrefix(j, "swap-pane") {
+			t.Errorf("did not expect a sidebar move for a placeholder, got: %v", f.runs)
+		}
+	}
+}
+
 func TestEjectSidebarIfAloneAfterExit_SidebarAlone_MovesToLastActive(t *testing.T) {
 	f := newFakeTmux()
 	// Ephemeral window @2: lazygit pane %10 is exiting, sidebar %42 would be left alone.

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -733,6 +733,17 @@ func sessionIcon(sess session.Session) string {
 	return activeTheme.IconCfgSession
 }
 
+// sessionIconPrefix returns the raw "<icon> " prefix for a sidebar session
+// row, or "" when the session cannot be resolved. The trailing space separates
+// the icon from the name; styledIconPrefix applies the colour.
+func (s SidebarModel) sessionIconPrefix(node SidebarNode) string {
+	sess := s.FindSession(node.Session)
+	if sess == nil {
+		return ""
+	}
+	return sessionIcon(*sess) + " "
+}
+
 // styledIconPrefix styles a raw "<icon> " prefix for a sidebar session row.
 // When highlighted, the muted icon colour and the selection background are
 // applied as a single lipgloss style: rendering a pre-styled string (which
@@ -949,11 +960,7 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 	}
 	indicators := s.sessionIndicators(node, selected, focused)
 
-	// Icon prefix: look up the session and render its icon.
-	iconPrefix := ""
-	if sess := s.FindSession(node.Session); sess != nil {
-		iconPrefix = sessionIcon(*sess) + " "
-	}
+	iconPrefix := s.sessionIconPrefix(node)
 	iconW := visualWidth(iconPrefix)
 
 	// Row format: [focus(1)] [gap(1)] [active-slot(1)] [icon(iconW)] [name+indicators(availW)]
@@ -1056,11 +1063,7 @@ func (s SidebarModel) activeIndicator(node SidebarNode, highlighted bool) string
 func (s SidebarModel) renderCardHeader(node SidebarNode, selected, focused bool, innerW int) string {
 	active := s.activeIndicator(node, focused)
 
-	// Session icon.
-	iconPrefix := ""
-	if sess := s.FindSession(node.Session); sess != nil {
-		iconPrefix = sessionIcon(*sess) + " "
-	}
+	iconPrefix := s.sessionIconPrefix(node)
 	iconW := visualWidth(iconPrefix)
 
 	// Watch slot (fixed width even when unwatched).

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -719,17 +719,33 @@ func (s *SidebarModel) SetLaunchErr(msg string) { s.launchErr = msg }
 // ClearLaunchErr clears any stored launch error.
 func (s *SidebarModel) ClearLaunchErr() { s.launchErr = "" }
 
-// sessionIcon returns the rendered icon for a sidebar session row.
+// sessionIcon returns the raw (unstyled) icon glyph for a sidebar session
+// row. Styling is applied by the caller via styledIconPrefix so the glyph can
+// be composed into a highlighted row without an embedded SGR reset breaking
+// the selection background.
 func sessionIcon(sess session.Session) string {
-	var icon string
 	if sess.IsConfig && sess.Config != nil && sess.Config.Icon != "" {
-		icon = sess.Config.Icon
-	} else if sess.IsLive {
-		icon = activeTheme.IconTmuxSession
-	} else {
-		icon = activeTheme.IconCfgSession
+		return sess.Config.Icon
 	}
-	return sessionIconStyle.Render(icon)
+	if sess.IsLive {
+		return activeTheme.IconTmuxSession
+	}
+	return activeTheme.IconCfgSession
+}
+
+// styledIconPrefix styles a raw "<icon> " prefix for a sidebar session row.
+// When highlighted, the muted icon colour and the selection background are
+// applied as a single lipgloss style: rendering a pre-styled string (which
+// ends in an SGR reset) inside a background style would reset that background
+// mid-row and leave the space after the icon un-highlighted.
+func styledIconPrefix(iconPrefix string, highlighted bool) string {
+	if iconPrefix == "" {
+		return ""
+	}
+	if highlighted {
+		return selectedBG.Foreground(activeTheme.ColorFgMuted).Render(iconPrefix)
+	}
+	return sessionIconStyle.Render(iconPrefix)
 }
 
 // resolveProcLabelColors picks the effective fg/bg for a sidebar proc label.
@@ -919,12 +935,12 @@ func renderSelectedRow(iconPrefix, nameStr, indicators, gap string, availW, indW
 		trail := lipgloss.NewStyle().Background(activeTheme.ColorSelected).Render(selectedTrail)
 		name := selectedBG.Bold(true).Render(nameStr + strings.Repeat(" ", pad))
 		spacer := selectedBG.Render(" ")
-		styledIcon := selectedBG.Render(iconPrefix)
+		styledIcon := styledIconPrefix(iconPrefix, true)
 		return indicatorGlyph + gap + spacer + styledIcon + name + indicators + trail
 	}
 	indicatorGlyph := lipgloss.NewStyle().Foreground(activeTheme.ColorSession).Render(focusGlyph)
 	name := selectedInactive.Bold(true).Render(nameStr + strings.Repeat(" ", pad))
-	return indicatorGlyph + gap + " " + iconPrefix + name + indicators
+	return indicatorGlyph + gap + " " + styledIconPrefix(iconPrefix, false) + name + indicators
 }
 
 func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, width int) string {
@@ -967,7 +983,7 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 		return renderSelectedRow(iconPrefix, nameStr, indicators, gap, availW, indW, focused)
 	}
 	text := alignedRow(nameStr, indicators, availW)
-	return " " + gap + " " + iconPrefix + sessionStyle.Render(text)
+	return " " + gap + " " + styledIconPrefix(iconPrefix, false) + sessionStyle.Render(text)
 }
 
 // renderSessionCard renders a session as a two-row card.
@@ -1074,7 +1090,7 @@ func (s SidebarModel) renderCardHeader(node SidebarNode, selected, focused bool,
 
 	focusGl := cardLeadingGlyph(selected, focused)
 	if focused {
-		iconStyled := selectedBG.Render(iconPrefix)
+		iconStyled := styledIconPrefix(iconPrefix, true)
 		nameStyled := selectedBG.Bold(true).Render(nameStr)
 		sep := selectedBG.Render(" ")
 		trail := selectedBG.Render(strings.Repeat(" ", pad+1)) // +1 for the trailing slot in overhead
@@ -1082,7 +1098,7 @@ func (s SidebarModel) renderCardHeader(node SidebarNode, selected, focused bool,
 	}
 
 	nameStyled := sessionStyle.Render(nameStr)
-	return focusGl + active + " " + iconPrefix + nameStyled + " " + watch
+	return focusGl + active + " " + styledIconPrefix(iconPrefix, false) + nameStyled + " " + watch
 }
 
 // renderCardStatus builds the bottom row of a session card: focus +

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1625,6 +1625,22 @@ func TestRenderSessionCard_Focused_HighlightsBothRows(t *testing.T) {
 	}
 }
 
+// extColorArgs returns how many extra SGR parameters an extended-colour
+// introducer (38/48) consumes: 2 for "5;<n>" (256-colour), 4 for
+// "2;<r>;<g>;<b>" (truecolour), 0 otherwise.
+func extColorArgs(rest []string) int {
+	if len(rest) == 0 {
+		return 0
+	}
+	switch rest[0] {
+	case "5":
+		return 2
+	case "2":
+		return 4
+	}
+	return 0
+}
+
 // sgrBackgroundActive interprets one SGR parameter list and returns whether a
 // background colour is active afterwards, given the prior state. It consumes
 // 38/48 extended-colour arguments so a foreground colour is never mistaken for
@@ -1636,29 +1652,13 @@ func sgrBackgroundActive(params string, bg bool) bool {
 	parts := strings.Split(params, ";")
 	for k := 0; k < len(parts); k++ {
 		switch parts[k] {
-		case "0":
-			bg = false
-		case "49":
+		case "0", "49":
 			bg = false
 		case "48":
 			bg = true
-			if k+1 < len(parts) {
-				switch parts[k+1] {
-				case "5":
-					k += 2
-				case "2":
-					k += 4
-				}
-			}
+			k += extColorArgs(parts[k+1:])
 		case "38":
-			if k+1 < len(parts) {
-				switch parts[k+1] {
-				case "5":
-					k += 2
-				case "2":
-					k += 4
-				}
-			}
+			k += extColorArgs(parts[k+1:])
 		}
 	}
 	return bg

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"time"
 
@@ -1620,6 +1621,96 @@ func TestRenderSessionCard_Focused_HighlightsBothRows(t *testing.T) {
 	for i, l := range uLines {
 		if strings.Contains(l, bgPrefix) {
 			t.Errorf("unfocused row %d unexpectedly contains background ANSI %q: %q", i+1, bgPrefix, l)
+		}
+	}
+}
+
+// sgrBackgroundActive interprets one SGR parameter list and returns whether a
+// background colour is active afterwards, given the prior state. It consumes
+// 38/48 extended-colour arguments so a foreground colour is never mistaken for
+// a background reset.
+func sgrBackgroundActive(params string, bg bool) bool {
+	if params == "" {
+		return false // ESC[m is a full reset
+	}
+	parts := strings.Split(params, ";")
+	for k := 0; k < len(parts); k++ {
+		switch parts[k] {
+		case "0":
+			bg = false
+		case "49":
+			bg = false
+		case "48":
+			bg = true
+			if k+1 < len(parts) {
+				switch parts[k+1] {
+				case "5":
+					k += 2
+				case "2":
+					k += 4
+				}
+			}
+		case "38":
+			if k+1 < len(parts) {
+				switch parts[k+1] {
+				case "5":
+					k += 2
+				case "2":
+					k += 4
+				}
+			}
+		}
+	}
+	return bg
+}
+
+// bgColumns returns one bool per display column of an ANSI-styled line,
+// reporting whether a background colour is active at that column.
+func bgColumns(line string) []bool {
+	var cols []bool
+	bg := false
+	for i := 0; i < len(line); {
+		if line[i] == '\x1b' && i+1 < len(line) && line[i+1] == '[' {
+			j := i + 2
+			for j < len(line) && line[j] != 'm' {
+				j++
+			}
+			bg = sgrBackgroundActive(line[i+2:j], bg)
+			i = j + 1
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(line[i:])
+		for w := runewidth.RuneWidth(r); w > 0; w-- {
+			cols = append(cols, bg)
+		}
+		i += size
+	}
+	return cols
+}
+
+// Regression: sessionIcon returns a pre-styled glyph that ends in an SGR reset.
+// When the focused card header re-wraps "icon + space" in the selection
+// background, that embedded reset punches a hole in the highlight, leaving the
+// space after the icon un-highlighted. Every column of a focused header must
+// carry the background.
+func TestRenderSessionCard_Focused_IconHighlightIsContiguous(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+	initStyles(Theme{
+		IconTmuxSession: "⊞", IconCfgSession: "⚙︎",
+		ColorSelected:  lipgloss.Color("#2a2a4a"),
+		ColorFgPrimary: lipgloss.Color("#ffffff"),
+		ColorFgMuted:   lipgloss.Color("#888888"), // makes sessionIcon emit ANSI
+	}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg:      config.Config{Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40}},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+	}
+	header := strings.Split(s.renderSessionCard(SidebarNode{Session: "alpha"}, true, true, 40), "\n")[0]
+	cols := bgColumns(header)
+	for i, hasBg := range cols {
+		if !hasBg {
+			t.Errorf("focused card header column %d lacks the highlight background; gap in selection bar\n  line: %q\n  bg:   %v", i, header, cols)
 		}
 	}
 }


### PR DESCRIPTION
## Context

No ticket.

Two independent regressions discovered during manual testing of the sidebar:

1. **Highlight gap after session icon (card view):** `sessionIcon` returned a fully-styled string (with an embedded SGR reset at the end). When `renderSessionCard` wrapped the `"<icon> "` prefix inside the selection-background style, that embedded reset terminated the background mid-row, leaving the space after the icon un-highlighted. Visually this punched a thin gap in the selection bar.

2. **Phantom slot window after natural process exit:** `after-kill-pane` does not fire when a process exits naturally (e.g. `lazygit` quit). Only `pane-exited` fires. `EjectSidebarIfAloneAfterExit` was missing the placeholder-slot cleanup that `HandleWindowAfterKill` already had — so an ephemeral window that received a slot from `after-new-window` was left open with just the placeholder pane instead of closing.

Both fixes are self-contained and have regression tests.

## What does this PR do

**Highlight fix (`internal/tui/sidebar.go`)**

- Extracts `styledIconPrefix(iconPrefix string, highlighted bool) string`. When `highlighted`, it composes the muted-foreground colour and the selection background into a single lipgloss render call instead of rendering the icon separately and then re-wrapping it. A single render call never emits an interior SGR reset, so the background is unbroken across the full `"<icon> "` prefix.
- `sessionIcon` is split into a raw-glyph getter (no styling) and the new `styledIconPrefix` compositor.
- All four call sites in `renderSessionHeader` and `renderSessionCard` updated.

**Sticky slot fix (`internal/sticky/orphan.go`)**

- `EjectSidebarIfAloneAfterExit` now reads the `@demux_slot` tag for the surviving pane alongside its pane ID.
- When the surviving pane is not the active sidebar but *is* a placeholder slot (`@demux_slot == 1`), it kills the slot pane immediately — matching the behaviour `HandleWindowAfterKill` already had for this case.
- The window then has no panes and closes on its own once the exiting pane dies.

### Out of scope

- `after-kill-pane` reliability across tmux versions is not addressed here; the pane-exited path is the correct primary cleanup for natural exits regardless.

## Manual QA

> TUI + tmux integration. Verify in a live tmux session.

### Prerequisites

<details>

<summary>1. Build and install the dev binary.</summary>

```bash
go build -o /tmp/demux . && /tmp/demux --version
```

Expected: binary prints version without error.

</details>

<details>

<summary>2. demux is running and a session is active in the sidebar.</summary>

```bash
demux ls
```

Expected: at least one session listed.

</details>

### Scenario 1 — Focused card header has no highlight gap

<details>

<summary>Scenario 1 — Focused card header has no highlight gap</summary>

1. Open demux with `SessionView: card` in `~/.config/demux/demux.toml`.
2. Navigate focus to any session row in the sidebar.
3. Inspect the icon column of the highlighted row (the first glyph + the space after it).
   Expected: the background colour covers the icon glyph **and** the space immediately after it — no uncoloured gap between the icon and the session name.
4. Run the regression unit test as a quick sanity check:
   ```bash
   go test ./internal/tui/ -run TestRenderSessionCard_Focused_IconHighlightIsContiguous -v
   ```
   Expected: `PASS`.

</details>

### Scenario 2 — Ephemeral lazygit window closes on quit

<details>

<summary>Scenario 2 — Ephemeral lazygit window closes on quit</summary>

> ⚠️ **Requires tmux + demux sticky sidebar enabled.** Run in a real tmux session, not inside the Go test runner.

1. Capture the current tmux window list:
   ```bash
   tmux list-windows
   ```
2. Open lazygit in a new tmux window (the `after-new-window` hook assigns it a sidebar slot):
   ```bash
   tmux new-window lazygit
   ```
   Expected: lazygit opens; sidebar appears in the new window.
3. Quit lazygit normally (press `q` inside lazygit).
   Expected: the window closes completely — `tmux list-windows` returns to the baseline from step 1 with no extra window.
4. Verify no orphan slot survives:
   ```bash
   tmux list-panes -a -F "#{window_id} #{pane_id} #{@demux_slot}"
   ```
   Expected: no pane with `@demux_slot=1` appears in a window that has only one pane.
5. Run the regression unit test:
   ```bash
   go test ./internal/sticky/ -run TestEjectSidebarIfAloneAfterExit_RemainingIsPlaceholderSlot_KillsIt -v
   ```
   Expected: `PASS`.

</details>