### PR TITLE
feat(sticky): add focus_on_open and focus_before_toggle_close config

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,12 @@ and window it was created in.
 width = 35
 # Opt in to slots mode (see below).
 slots = false
+# Focus the sidebar pane when it opens (split and slots mode alike).
+focus_on_open = true
+# When `demux sidebar toggle` runs while the sidebar is open but not focused,
+# move focus into it instead of closing it. Toggle again from inside the
+# sidebar to close it.
+focus_before_toggle_close = false
 ```
 
 ### Slots mode (opt-in, no follow flicker)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -109,6 +109,11 @@ width = 35
 # sticky sidebar swaps between slots on window/session switch, avoiding the
 # brief layout flicker of join-pane. Cost: one extra pane per window.
 # slots = false
+# Focus the sidebar pane when it opens (split and slots mode alike).
+focus_on_open = true
+# When 'demux sidebar toggle' runs while the sidebar is open but not focused,
+# move focus into it instead of closing it; toggle again from inside to close.
+# focus_before_toggle_close = false
 
 # Sidebar process labels — render a single highest-count label per session.
 # Globs match either the process name or any whitespace-separated token of the

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -66,7 +66,7 @@ active_session_icon = "►"
 focus_on_open = "current_session"
 
 # Start with cursor in the search input (also available as --search flag)
-# focus_search_on_open = false
+focus_search_on_open = false
 
 # Initial sidebar filter on startup: t (tmux) | a (all) | g (config) | w (worktree) | ! (priority)
 default_filter = "t"
@@ -101,19 +101,23 @@ card_separator = "blank"
 # See README "Sticky sidebar" section for the tmux hook snippet that auto-shows
 # the sidebar on attach.
 [sidebar.sticky]
+
 # Initial width (columns) the first time the pane is created. After that, the
 # user resizes the pane normally; the width is preserved on every session move.
 width = 35
+
 # Opt in to slots mode: pre-create a reserved sidebar pane in every window
 # (tagged with the @demux_slot tmux option and titled "demux-slot"). The
 # sticky sidebar swaps between slots on window/session switch, avoiding the
 # brief layout flicker of join-pane. Cost: one extra pane per window.
-# slots = false
+ slots = false
+
 # Focus the sidebar pane when it opens (split and slots mode alike).
 focus_on_open = true
+
 # When 'demux sidebar toggle' runs while the sidebar is open but not focused,
 # move focus into it instead of closing it; toggle again from inside to close.
-# focus_before_toggle_close = false
+focus_before_toggle_close = false
 
 # Sidebar process labels — render a single highest-count label per session.
 # Globs match either the process name or any whitespace-separated token of the

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -110,7 +110,7 @@ width = 35
 # (tagged with the @demux_slot tmux option and titled "demux-slot"). The
 # sticky sidebar swaps between slots on window/session switch, avoiding the
 # brief layout flicker of join-pane. Cost: one extra pane per window.
- slots = false
+slots = false
 
 # Focus the sidebar pane when it opens (split and slots mode alike).
 focus_on_open = true

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -17,6 +17,8 @@ var stickyClient = func() *sticky.Sticky {
 	cfg := loadConfig()
 	s := sticky.New()
 	s.Slots = cfg.Sidebar.Sticky.Slots
+	s.FocusOnOpen = cfg.Sidebar.Sticky.FocusOnOpen
+	s.FocusBeforeToggleClose = cfg.Sidebar.Sticky.FocusBeforeToggleClose
 	return s
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -240,8 +240,10 @@ func normalizeSessionView(value, key, emptyDefault string) string {
 }
 
 type SidebarStickyConfig struct {
-	Width int  `toml:"width"`
-	Slots bool `toml:"slots"`
+	Width                  int  `toml:"width"`
+	Slots                  bool `toml:"slots"`
+	FocusOnOpen            bool `toml:"focus_on_open"`
+	FocusBeforeToggleClose bool `toml:"focus_before_toggle_close"`
 }
 
 type SidebarConfig struct {
@@ -319,7 +321,7 @@ func Default() Config {
 			ActiveSessionIcon: DefaultActiveSessionIcon,
 			SessionView:       SidebarViewRow,
 			CardSeparator:     CardSeparatorBlank,
-			Sticky:            SidebarStickyConfig{Width: DefaultStickySidebarWidth},
+			Sticky:            SidebarStickyConfig{Width: DefaultStickySidebarWidth, FocusOnOpen: true},
 		},
 		StatusBar: StatusBarConfig{Show: true},
 		Log:       LogConfig{Level: "warn"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -939,3 +939,32 @@ func TestResolvedSessionView(t *testing.T) {
 		})
 	}
 }
+
+func TestSidebarSticky_DefaultFocusFlags(t *testing.T) {
+	cfg := config.Default()
+	if !cfg.Sidebar.Sticky.FocusOnOpen {
+		t.Errorf("default sticky focus_on_open: want true, got false")
+	}
+	if cfg.Sidebar.Sticky.FocusBeforeToggleClose {
+		t.Errorf("default sticky focus_before_toggle_close: want false, got true")
+	}
+}
+
+func TestSidebarSticky_LoadOverridesFocusFlags(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demux.toml")
+	body := "[sidebar.sticky]\nfocus_on_open = false\nfocus_before_toggle_close = true\n"
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Sidebar.Sticky.FocusOnOpen {
+		t.Errorf("focus_on_open override: want false, got true")
+	}
+	if !cfg.Sidebar.Sticky.FocusBeforeToggleClose {
+		t.Errorf("focus_before_toggle_close override: want true, got false")
+	}
+}

--- a/internal/sticky/focus.go
+++ b/internal/sticky/focus.go
@@ -21,3 +21,11 @@ func (s *Sticky) focusPane(paneID string) {
 	}
 	_ = s.T.Run("select-pane", "-t", paneID)
 }
+
+// maybeFocusOnOpen focuses the just-created sidebar pane when the FocusOnOpen
+// config flag is set. Shared tail of both Show modes.
+func (s *Sticky) maybeFocusOnOpen(paneID string) {
+	if s.FocusOnOpen {
+		s.focusPane(paneID)
+	}
+}

--- a/internal/sticky/focus.go
+++ b/internal/sticky/focus.go
@@ -1,0 +1,23 @@
+package sticky
+
+import "strings"
+
+// activePane returns the pane id the invoking tmux client currently has
+// focused.
+func (s *Sticky) activePane() (string, error) {
+	out, err := s.T.Output("display-message", "-p", "#{pane_id}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// focusPane moves the invoking client's focus to paneID. Best-effort: a
+// select-pane failure is swallowed so callers never crash on a focus nicety.
+// An empty paneID is a no-op.
+func (s *Sticky) focusPane(paneID string) {
+	if paneID == "" {
+		return
+	}
+	_ = s.T.Run("select-pane", "-t", paneID)
+}

--- a/internal/sticky/focus_test.go
+++ b/internal/sticky/focus_test.go
@@ -1,0 +1,47 @@
+package sticky
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestActivePane(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{pane_id}"] = fakeReply{out: "%7\n"}
+	s := &Sticky{T: f}
+	got, err := s.activePane()
+	if err != nil {
+		t.Fatalf("activePane: %v", err)
+	}
+	if got != "%7" {
+		t.Errorf("activePane: want %%7, got %q", got)
+	}
+}
+
+func TestActivePane_TmuxFails(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{pane_id}"] = fakeReply{err: errors.New("no server")}
+	s := &Sticky{T: f}
+	if _, err := s.activePane(); err == nil {
+		t.Error("expected error to surface")
+	}
+}
+
+func TestFocusPane(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f}
+	s.focusPane("%42")
+	if len(f.runs) != 1 || strings.Join(f.runs[0], " ") != "select-pane -t %42" {
+		t.Errorf("focusPane: want one \"select-pane -t %%42\" call, got %v", f.runs)
+	}
+}
+
+func TestFocusPane_EmptyNoop(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f}
+	s.focusPane("")
+	if len(f.runs) != 0 {
+		t.Errorf("focusPane(\"\"): want no tmux calls, got %v", f.runs)
+	}
+}

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -104,11 +104,11 @@ func (s *Sticky) ejectFocusIfOnSidebar(sidebarPane string) {
 	if sidebarPane == "" {
 		return
 	}
-	out, err := s.T.Output("display-message", "-p", "#{pane_id}")
+	active, err := s.activePane()
 	if err != nil {
 		return
 	}
-	if strings.TrimSpace(out) == sidebarPane {
+	if active == sidebarPane {
 		_ = s.T.Run("select-pane", "-t", ":.+")
 	}
 }

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -73,9 +73,7 @@ func (s *Sticky) showSplitMode(key string, opts ShowOpts) error {
 	if err := s.WriteEnv(key, newPane); err != nil {
 		return err
 	}
-	if s.FocusOnOpen {
-		s.focusPane(newPane)
-	}
+	s.maybeFocusOnOpen(newPane)
 	return nil
 }
 
@@ -103,9 +101,7 @@ func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
 	if err := s.WriteEnv(key, slot); err != nil {
 		return err
 	}
-	if s.FocusOnOpen {
-		s.focusPane(slot)
-	}
+	s.maybeFocusOnOpen(slot)
 	// Install slots only in the MRU-reserved set (capped at MRUMaxLen).
 	// Current window already has its own slot (the sidebar), so we pass it
 	// in explicitly so reconcile won't touch it.

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -57,7 +57,7 @@ func (s *Sticky) showSplitMode(key string, opts ShowOpts) error {
 		return err
 	}
 	out, err := s.T.Output(
-		"split-window", "-f", "-h", "-b",
+		"split-window", "-f", "-h", "-b", "-d",
 		"-l", strconv.Itoa(opts.Width),
 		"-t", target,
 		"-P", "-F", "#{pane_id}",
@@ -70,7 +70,13 @@ func (s *Sticky) showSplitMode(key string, opts ShowOpts) error {
 	if newPane == "" {
 		return fmt.Errorf("tmux split-window returned empty pane id")
 	}
-	return s.WriteEnv(key, newPane)
+	if err := s.WriteEnv(key, newPane); err != nil {
+		return err
+	}
+	if s.FocusOnOpen {
+		s.focusPane(newPane)
+	}
+	return nil
 }
 
 func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
@@ -96,6 +102,9 @@ func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
 	}
 	if err := s.WriteEnv(key, slot); err != nil {
 		return err
+	}
+	if s.FocusOnOpen {
+		s.focusPane(slot)
 	}
 	// Install slots only in the MRU-reserved set (capped at MRUMaxLen).
 	// Current window already has its own slot (the sidebar), so we pass it

--- a/internal/sticky/show_test.go
+++ b/internal/sticky/show_test.go
@@ -12,7 +12,7 @@ func TestShow_EnvUnset_CreatesPane(t *testing.T) {
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable: DEMUX_STICKY_PANE__dev_ttys001\n")}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
-	f.outputs["split-window -f -h -b -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
 	s := &Sticky{T: f}
 	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
 		t.Fatalf("Show: %v", err)
@@ -55,7 +55,7 @@ func TestShow_EnvSetButPaneDead_Recreates(t *testing.T) {
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
 	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%1\n%2\n"}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$2:@9\n"}
-	f.outputs["split-window -f -h -b -l 35 -t $2:@9 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%99\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $2:@9 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%99\n"}
 	s := &Sticky{T: f}
 	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
 		t.Fatalf("Show: %v", err)
@@ -134,13 +134,83 @@ func TestShow_SlotsMode_ActivatesCurrentSlotBeforeOtherWindows(t *testing.T) {
 	}
 }
 
+func TestShow_FocusOnOpen_SplitMode_SelectsPane(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+	s := &Sticky{T: f, FocusOnOpen: true}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	sawFocus := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "select-pane -t %88" {
+			sawFocus = true
+		}
+	}
+	if !sawFocus {
+		t.Errorf("expected select-pane -t %%88 (focus new pane), got runs: %v", f.runs)
+	}
+}
+
+func TestShow_NoFocusOnOpen_SplitMode_NoSelectPane(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+	s := &Sticky{T: f, FocusOnOpen: false}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "select-pane") {
+			t.Errorf("expected no select-pane when FocusOnOpen=false, got: %v", r)
+		}
+	}
+}
+
+func TestShow_FocusOnOpen_SlotsMode_SelectsSlot(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%1 \n%10 1\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%10\n"}
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@7\n@8\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@7 0\n@8 1\n"}
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@7 %10 1\n"}
+	f.outputs["list-panes -t @8 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%2 \n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t @8 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%11\n"}
+	s := &Sticky{T: f, Slots: true, FocusOnOpen: true}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	sawFocus := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "select-pane -t %10" {
+			sawFocus = true
+		}
+	}
+	if !sawFocus {
+		t.Errorf("expected select-pane -t %%10 (focus the slot), got runs: %v", f.runs)
+	}
+}
+
 func TestShow_SplitFailure_Surfaces(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
 	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
-	f.outputs["split-window -f -h -b -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{err: errors.New("can't split")}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{err: errors.New("can't split")}
 	s := &Sticky{T: f}
 	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err == nil {
 		t.Error("expected split-window failure to surface")

--- a/internal/sticky/sticky.go
+++ b/internal/sticky/sticky.go
@@ -58,6 +58,13 @@ type Sticky struct {
 	// of join-pane). The active sidebar pane lives in whichever window's
 	// slot is currently selected; the others run SlotPlaceholderCmd.
 	Slots bool
+	// FocusOnOpen, when true, moves focus into the sidebar pane right after
+	// Show creates (split mode) or activates (slots mode) it.
+	FocusOnOpen bool
+	// FocusBeforeToggleClose, when true, makes Toggle focus an already-open
+	// but unfocused sidebar instead of hiding it; a second Toggle from
+	// inside the sidebar then hides it.
+	FocusBeforeToggleClose bool
 }
 
 // New returns a Sticky wired to the real tmux binary.

--- a/internal/sticky/toggle.go
+++ b/internal/sticky/toggle.go
@@ -3,6 +3,11 @@ package sticky
 // Toggle hides the sticky sidebar if a live pane is tracked, otherwise shows
 // it. Stale env entries (env set but pane gone) are treated as "not shown"
 // and fall through to Show.
+//
+// When FocusBeforeToggleClose is set and the tracked pane is live but is not
+// the client's active pane, Toggle moves focus into the sidebar instead of
+// hiding it; a subsequent Toggle from inside the sidebar then hides it. If the
+// active pane cannot be determined, Toggle falls through to Hide.
 func (s *Sticky) Toggle(opts ShowOpts) error {
 	tty, err := s.CurrentClientTTY()
 	if err != nil {
@@ -19,6 +24,12 @@ func (s *Sticky) Toggle(opts ShowOpts) error {
 			return err
 		}
 		if alive {
+			if s.FocusBeforeToggleClose {
+				if active, err := s.activePane(); err == nil && active != val {
+					s.focusPane(val)
+					return nil
+				}
+			}
 			return s.Hide()
 		}
 	}

--- a/internal/sticky/toggle_test.go
+++ b/internal/sticky/toggle_test.go
@@ -31,7 +31,7 @@ func TestToggle_EnvUnset_CallsShow(t *testing.T) {
 	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
 	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
-	f.outputs["split-window -f -h -b -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
 	s := &Sticky{T: f}
 	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
 		t.Fatalf("Toggle: %v", err)
@@ -54,7 +54,7 @@ func TestToggle_EnvSetButPaneDead_CallsShow(t *testing.T) {
 	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%1\n%3\n"}
 	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
 	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
-	f.outputs["split-window -f -h -b -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
 	s := &Sticky{T: f}
 	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
 		t.Fatalf("Toggle: %v", err)

--- a/internal/sticky/toggle_test.go
+++ b/internal/sticky/toggle_test.go
@@ -1,6 +1,7 @@
 package sticky
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -58,5 +59,75 @@ func TestToggle_EnvSetButPaneDead_CallsShow(t *testing.T) {
 	s := &Sticky{T: f}
 	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
 		t.Fatalf("Toggle: %v", err)
+	}
+}
+
+func TestToggle_FocusBeforeClose_Unfocused_Focuses(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{pane_id}"] = fakeReply{out: "%7\n"}
+	s := &Sticky{T: f, FocusBeforeToggleClose: true}
+	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Toggle: %v", err)
+	}
+	var sawFocus, sawKill bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "select-pane -t %42" {
+			sawFocus = true
+		}
+		if strings.HasPrefix(j, "kill-pane") {
+			sawKill = true
+		}
+	}
+	if !sawFocus {
+		t.Errorf("expected select-pane -t %%42 (focus sidebar), got: %v", f.runs)
+	}
+	if sawKill {
+		t.Errorf("expected no kill-pane when focusing instead of closing, got: %v", f.runs)
+	}
+}
+
+func TestToggle_FocusBeforeClose_Focused_Closes(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{pane_id}"] = fakeReply{out: "%42\n"}
+	s := &Sticky{T: f, FocusBeforeToggleClose: true}
+	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Toggle: %v", err)
+	}
+	sawKill := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "kill-pane -t %42" {
+			sawKill = true
+		}
+	}
+	if !sawKill {
+		t.Errorf("expected kill-pane (close) when sidebar is focused, got: %v", f.runs)
+	}
+}
+
+func TestToggle_FocusBeforeClose_ActivePaneError_Closes(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	f.outputs["display-message -p #{pane_id}"] = fakeReply{err: errors.New("no server")}
+	s := &Sticky{T: f, FocusBeforeToggleClose: true}
+	if err := s.Toggle(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Toggle: %v", err)
+	}
+	sawKill := false
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "kill-pane -t %42" {
+			sawKill = true
+		}
+	}
+	if !sawKill {
+		t.Errorf("expected fall-through to kill-pane on activePane error, got: %v", f.runs)
 	}
 }


### PR DESCRIPTION
## Context

The sticky sidebar's open-focus behavior was mode-dependent and not configurable. Split mode (`split-window`) focused the newly created sidebar pane; slots mode (`respawn-pane`) left focus on the work pane. There was also no way to make `demux sidebar toggle` focus an already-open sidebar — toggle always closed it, so a user with the sidebar open but their cursor in a work pane could not jump into the sidebar with the same key.

Scope is the two new config keys and their wiring. `show` / `hide` / `follow` semantics are unchanged apart from the added focus step.

## What does this PR do

Adds two `[sidebar.sticky]` config keys:

- `focus_on_open` (default `true`) — when the sidebar opens, focus moves into the sidebar pane. Applies uniformly to split and slots mode. `split-window` now passes `-d` so open-focus is controlled solely by this key instead of tmux's split default.
- `focus_before_toggle_close` (default `false`) — when `demux sidebar toggle` runs while the sidebar is open but is not the active pane, focus moves into the sidebar instead of closing it. A second toggle from inside the sidebar closes it. If the active pane cannot be determined, toggle falls through to close (unchanged behavior).

Both keys decode into `SidebarStickyConfig` and are copied onto `sticky.Sticky` by `stickyClient()` — the same pattern already used for `slots`. New `focusPane` / `activePane` helpers (`internal/sticky/focus.go`) centralize the tmux focus calls; `ejectFocusIfOnSidebar` reuses `activePane`. No schema change, no migration. `README.md` and the `demux config init` template document both keys.

### Out of scope

- Cross-window focus handling — not needed. The `after-select-window` and `client-session-changed` hooks (`cmd/hooks.go:165-169`) keep the sidebar in the active window via `Follow`, so the tracked pane is always in the current window while the sidebar is open.

## Manual QA

> tmux/TUI feature — verify in a real tmux session with the demux sidebar hooks installed. No automated test can exercise tmux focus; `go test ./...` (760 tests) covers the command-construction logic.

### Prerequisites

<details>
<summary>1. Running inside tmux.</summary>

```bash
tmux display-message -p '#{client_tty}'
```
Expect a tty path (e.g. `/dev/ttys001`). If it errors, attach a tmux session first.
</details>

<details>
<summary>2. demux built from this branch and on PATH.</summary>

```bash
go build -o "$(go env GOPATH)/bin/demux" . && demux --version
```
Expect the version string. If `demux` is not found, ensure `$(go env GOPATH)/bin` is on `PATH`.
</details>

<details>
<summary>3. Sidebar follow hooks installed.</summary>

```bash
tmux show-hooks -g | grep 'sidebar follow'
```
Expect `after-select-window` and `client-session-changed` entries. If missing, install them from the README "Sticky sidebar" snippet (`demux hooks` prints it).
</details>

### Setup

Default config (no `[sidebar.sticky]` overrides) = split mode, `focus_on_open = true`, `focus_before_toggle_close = false`. Confirm no sidebar is open:

```bash
tmux show-environment -g | grep DEMUX_STICKY_PANE || echo "no sidebar tracked"
```

### Scenario 1 — focus_on_open opens with cursor in the sidebar

<details>
<summary>Scenario 1</summary>

1. With `focus_on_open = true` (default), from a work pane run `demux sidebar toggle`.
2. The sidebar opens. Capture the active pane and the tracked sidebar pane:
   ```bash
   tmux display-message -p '#{pane_id}'
   tmux show-environment -g | grep DEMUX_STICKY_PANE
   ```
   Expected: the active pane id equals the `DEMUX_STICKY_PANE_*` value — cursor is in the sidebar.
3. Repeat with `[sidebar.sticky] slots = true` in the config — same result.
</details>

### Scenario 2 — focus_on_open = false keeps focus on the work pane

<details>
<summary>Scenario 2</summary>

1. Set `[sidebar.sticky] focus_on_open = false`. Run `demux sidebar toggle` from a work pane.
2. The sidebar opens. Check:
   ```bash
   tmux display-message -p '#{pane_id}'
   tmux show-environment -g | grep DEMUX_STICKY_PANE
   ```
   Expected: the active pane id does NOT equal the sidebar pane id — cursor stayed in the work pane.
</details>

### Scenario 3 — focus_before_toggle_close focuses instead of closing

<details>
<summary>Scenario 3</summary>

1. Set `[sidebar.sticky] focus_before_toggle_close = true`. Open the sidebar, then move the cursor to a work pane (`prefix + o` or click).
2. Run `demux sidebar toggle`.
   Expected: focus jumps into the sidebar; the sidebar is still open (`tmux show-environment -g | grep DEMUX_STICKY_PANE` still set, `tmux display-message -p '#{pane_id}'` equals the sidebar pane).
3. Run `demux sidebar toggle` again from inside the sidebar.
   Expected: the sidebar closes — `tmux show-environment -g | grep DEMUX_STICKY_PANE` returns nothing.
</details>

### Scenario 4 — focus_before_toggle_close = false closes as before

<details>
<summary>Scenario 4</summary>

1. Set `[sidebar.sticky] focus_before_toggle_close = false`. Open the sidebar, move the cursor to a work pane.
2. Run `demux sidebar toggle`.
   Expected: the sidebar closes immediately (unchanged behavior) — `tmux show-environment -g | grep DEMUX_STICKY_PANE` returns nothing.
3. Switch tmux windows/sessions while the sidebar is open in a separate run — confirm the sidebar still follows and focus behavior is unaffected.
</details>