### PR TITLE
fix(sidebar): background pane-kill hooks to unfreeze input on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,8 @@ set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_
 # Removes Demux state when a pane is closed (prevents stale state accumulation).
 # #{hook_pane} is the killed pane's ID; #{pane_id} is the new active pane after
 # the kill — using #{pane_id} here would clear the wrong pane's state.
-set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true'"
+# run-shell -b backgrounds the handler so closing many panes at once never blocks tmux input.
+set-hook -g after-kill-pane "run-shell -b 'demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true'"
 ```
 
 </details>

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"path/filepath"
+
 	"github.com/rtalexk/demux/internal/db"
 	demuxlog "github.com/rtalexk/demux/internal/log"
 	"github.com/rtalexk/demux/internal/sticky"
@@ -151,10 +153,12 @@ var eventPaneExitingCmd = &cobra.Command{
 	Use:   "pane_exiting",
 	Short: "Eject sidebar if it would be stranded by an exiting pane (called by pane-exited hook)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg := loadConfig()
-		t := stickyTmuxForEvents()
-		s := &sticky.Sticky{T: t}
-		return s.EjectSidebarIfAloneAfterExit(eventPaneExitingPaneID, eventPaneExitingWindowID, cfg.Sidebar.Sticky.Width)
+		return withEventLock(func() error {
+			cfg := loadConfig()
+			t := stickyTmuxForEvents()
+			s := &sticky.Sticky{T: t}
+			return s.EjectSidebarIfAloneAfterExit(eventPaneExitingPaneID, eventPaneExitingWindowID, cfg.Sidebar.Sticky.Width)
+		})
 	},
 }
 
@@ -165,13 +169,47 @@ var eventPaneClosedCmd = &cobra.Command{
 	Use:   "pane_closed",
 	Short: "Clear state for a closed tmux pane (called by after-kill-pane hook)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		d, err := openDB()
-		if err != nil {
-			return err
-		}
-		defer d.Close()
-		return applyPaneClosed(d, eventPaneClosedPaneID, eventPaneClosedWindowID)
+		return withEventLock(func() error {
+			d, err := openDB()
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			return applyPaneClosed(d, eventPaneClosedPaneID, eventPaneClosedWindowID)
+		})
 	},
+}
+
+// eventLockPath returns the path of the cross-process lock file that
+// serializes sticky-mutating tmux event handlers. It lives next to the state
+// database so it shares the demux data directory.
+func eventLockPath() (string, error) {
+	dbPath, err := db.DefaultPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(dbPath), "event.lock"), nil
+}
+
+// withEventLock runs fn while holding an exclusive cross-process lock shared by
+// the pane_closed and pane_exiting handlers.
+//
+// Their tmux hooks (after-kill-pane, pane-exited) run `run-shell -b`, so a
+// burst of pane kills - e.g. `demux sidebar hide` tearing down every sticky
+// sidebar slot pane - spawns many handler processes at once. Each runs a
+// server-wide sticky sweep, and those sweeps are only safe run sequentially -
+// the ordering tmux's synchronous command queue used to guarantee before the
+// hooks were backgrounded. This lock restores that guarantee. Because the
+// hooks run in the background, blocking on the lock never stalls tmux input.
+//
+// Best-effort: if the lock path cannot be resolved, fn runs unguarded rather
+// than dropping the cleanup entirely.
+func withEventLock(fn func() error) error {
+	path, err := eventLockPath()
+	if err != nil {
+		return fn()
+	}
+	return withFileLock(path, fn)
 }
 
 func applyPaneClosed(d *db.DB, paneID, windowID string) error {
@@ -192,12 +230,11 @@ func applyPaneClosed(d *db.DB, paneID, windowID string) error {
 	// after-kill-pane, so we cannot rely on the targeted paths above. Always
 	// run a server-wide sweep: stale env vars first, then orphan windows.
 	//
-	// This handler can re-enter itself: the sweep's kill-pane calls re-fire
-	// after-kill-pane, and the hook's run-shell is synchronous, so the nested
-	// handler runs to completion before kill-pane returns. The sweep is built
-	// to be idempotent under that re-entry (see HandleWindowAfterKill), so no
-	// lock is needed - and a lock would in fact deadlock against the nested,
-	// synchronous handler.
+	// The after-kill-pane hook runs `run-shell -b`, so a burst of kill-pane
+	// calls spawns these handlers concurrently, and the sweep's own kill-pane
+	// calls spawn still more. withEventLock (held by the pane_closed command)
+	// serializes every handler process, so each sweep still runs sequentially -
+	// the model HandleWindowAfterKill is built to be idempotent under.
 	s := &sticky.Sticky{T: tmuxClient}
 	if err := s.SweepStaleStickyEnv(); err != nil {
 		demuxlog.Warn("pane_closed: stale env sweep failed", "err", err)

--- a/cmd/event_lock_test.go
+++ b/cmd/event_lock_test.go
@@ -1,0 +1,70 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWithFileLock_SerializesConcurrentCallers verifies the file lock makes
+// concurrent callers run their critical sections one at a time. The
+// after-kill-pane / pane-exited hooks run `run-shell -b`, which spawns handler
+// processes concurrently; this lock is what keeps their sticky sweeps
+// sequential. Without it, maxInside would climb toward the goroutine count.
+func TestWithFileLock_SerializesConcurrentCallers(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "event.lock")
+
+	var mu sync.Mutex
+	inside, maxInside := 0, 0
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = withFileLock(lockPath, func() error {
+				mu.Lock()
+				inside++
+				if inside > maxInside {
+					maxInside = inside
+				}
+				mu.Unlock()
+
+				time.Sleep(5 * time.Millisecond)
+
+				mu.Lock()
+				inside--
+				mu.Unlock()
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+
+	if maxInside != 1 {
+		t.Errorf("withFileLock allowed %d concurrent callers, want 1", maxInside)
+	}
+}
+
+// TestWithFileLock_RunsFnAndReturnsItsError verifies the lock wrapper is
+// transparent: it runs fn exactly once and propagates its return value.
+func TestWithFileLock_RunsFnAndReturnsItsError(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "event.lock")
+
+	calls := 0
+	sentinel := errors.New("sentinel")
+	err := withFileLock(lockPath, func() error {
+		calls++
+		return sentinel
+	})
+	if calls != 1 {
+		t.Errorf("fn ran %d times, want 1", calls)
+	}
+	if err != sentinel {
+		t.Errorf("withFileLock returned %v, want %v", err, sentinel)
+	}
+}

--- a/cmd/event_lock_unix.go
+++ b/cmd/event_lock_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// withFileLock runs fn while holding an exclusive advisory lock (flock) on the
+// file at path, creating the file and its parent directory if needed. The lock
+// is released when fn returns.
+//
+// Best-effort: if the directory or lock file cannot be created, or the lock
+// cannot be taken, fn still runs (unguarded) rather than dropping the work.
+func withFileLock(path string, fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fn()
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fn()
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return fn()
+	}
+	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
+	return fn()
+}

--- a/cmd/event_lock_windows.go
+++ b/cmd/event_lock_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package cmd
+
+// withFileLock runs fn directly on Windows. The tmux event hooks that need
+// cross-process serialization (after-kill-pane, pane-exited) only run under
+// tmux, which is unix-only, so no lock is taken here.
+func withFileLock(_ string, fn func() error) error {
+	return fn()
+}

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -151,7 +151,10 @@ set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_
 # the kill - using #{pane_id} here would clear the wrong pane's state.
 # #{hook_window} lets demux detect a window left with only a sidebar slot pane
 # (e.g. the user closed the last non-slot pane) and clean it up.
-set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
+# run-shell -b backgrounds the handler so closing many panes at once (e.g.
+# 'demux sidebar hide' tearing down every sticky slot pane) never blocks tmux
+# input; concurrent handlers serialize on a file lock instead.
+set-hook -g after-kill-pane "run-shell -b 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
 
 # Sticky sidebar - proactively ejects the sidebar when the process running in a
 # pane exits and the sidebar would be the only pane left in that window. Fires
@@ -159,7 +162,9 @@ set-hook -g after-kill-pane "run-shell 'demux event pane_closed --pane=#{hook_pa
 # the sidebar return to the previous window without any stranded-sidebar flicker.
 # Complements after-kill-pane for cases where that hook is unreliable (e.g.
 # natural process exits in some tmux versions).
-set-hook -ga pane-exited "run-shell 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
+# run-shell -b backgrounds the handler (see after-kill-pane above) so it never
+# blocks tmux input; it shares the pane_closed handler's file lock.
+set-hook -ga pane-exited "run-shell -b 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
 
 # Sticky sidebar - moves the demux sidebar pane to the newly active session.
 set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null; true'"

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -47,6 +47,22 @@ func TestTmuxHooksSnippet_ContainsAfterKillPane(t *testing.T) {
 	}
 }
 
+func TestTmuxHooksSnippet_KillHooksBackgrounded(t *testing.T) {
+	// after-kill-pane and pane-exited can fire in a burst when many panes close
+	// at once (e.g. `demux sidebar hide` tearing down every sticky slot pane).
+	// They must run with `run-shell -b` so the cleanup never blocks tmux input.
+	for _, line := range strings.Split(tmuxHooksSnippet, "\n") {
+		if !strings.HasPrefix(line, "set-hook") {
+			continue
+		}
+		if strings.Contains(line, "after-kill-pane") || strings.Contains(line, "pane-exited") {
+			if !strings.Contains(line, "run-shell -b") {
+				t.Errorf("kill-related hook must use 'run-shell -b':\n  %s", line)
+			}
+		}
+	}
+}
+
 func TestTmuxHooksSnippet_ContainsPaneExitedHook(t *testing.T) {
 	if !strings.Contains(tmuxHooksSnippet, "pane-exited") {
 		t.Error("snippet should include pane-exited hook for proactive sidebar eject")


### PR DESCRIPTION
## Context

No tracking ticket — user-reported.

With `sidebar.sticky.slots = true`, closing the sticky sidebar produced a
perceptible input freeze: the terminal stopped accepting keystrokes for a
few milliseconds up to about a second after the sidebar disappeared.

Root cause: closing the sidebar in slots mode kills up to nine panes (the
active sidebar plus one placeholder slot per window, capped at `MRUMaxLen`).
Every `kill-pane` fires the `after-kill-pane` tmux hook, which ran
`run-shell` **without `-b`** — synchronous. So each kill blocked on a full
`demux event pane_closed` process (config load, SQLite, server-wide sticky
sweeps) while the tmux command queue stalled and could not service input.
The freeze scaled linearly with slot count.

Scope is the **input-freeze on sidebar close**. The redundant sweep work
itself (each backgrounded handler still runs a server-wide sweep) is left
as-is — it now happens off the input path, so it is no longer user-visible.

## What does this PR do

- `after-kill-pane` and `pane-exited` hooks now run `run-shell -b`, so pane
  cleanup happens in the background and never blocks the tmux command queue.
- Adds a shared cross-process file lock (`flock` on
  `~/.local/share/demux/event.lock`) around the `pane_closed` and
  `pane_exiting` handlers. Backgrounding removed the implicit serialization
  tmux's synchronous queue used to provide; the lock restores it so the
  sticky sweeps still run sequentially (the model `HandleWindowAfterKill`
  is built for).
- The lock is a build-tagged no-op on Windows (`syscall.Flock` is unix-only;
  tmux does not run on Windows anyway). goreleaser still cross-builds Windows.
- Updates the generated tmux hook snippet (`demux hooks init`) and the
  README copy to match.

Best-effort: if the lock file cannot be created, the handler runs unguarded
rather than dropping the cleanup. No schema change, no migration.

### Out of scope

- `pane-exited` backgrounding means its "eject sidebar before flicker"
  timing is no longer guaranteed to land before `after-kill-pane`. Harmless:
  `applyPaneClosed`'s orphan sweep (`cmd/event.go`) catches any stranded
  sidebar anyway — the two hooks were already documented as complementary.

## Manual QA

> tmux-runtime behavior. The freeze cannot be exercised by `go test`;
> verify interactively inside tmux. Automated coverage is below under
> Setup.

### Prerequisites

<details>

<summary>1. tmux is running and demux hooks are installed.</summary>

```bash
tmux display-message -p '#{version}' && tmux show-hooks -g | grep after-kill-pane
```

Expect a tmux version and an `after-kill-pane` hook line. If the hook is
missing, run `demux hooks init --tool tmux` and apply the snippet, then
`tmux source ~/.tmux.conf`.

</details>

<details>

<summary>2. Slots mode is enabled.</summary>

```bash
grep -A3 '\[sidebar.sticky\]' ~/.config/demux/demux.toml | grep slots
```

Expect `slots = true`. If absent, set it and reload.

</details>

> ⚠️ **The fix only takes effect after the tmux hooks are regenerated.**
> An already-running tmux server holds the old blocking hooks in memory.
> Run `demux hooks init --tool tmux`, re-apply the `after-kill-pane` and
> `pane-exited` lines to `~/.tmux.conf`, then `tmux source ~/.tmux.conf`
> (or restart the server) before testing.

### Setup

Build the branch and run the automated checks:

```bash
go build ./... && CGO_ENABLED=0 GOOS=windows go build ./cmd/ && go test ./...
```

Expected: both builds succeed; full suite passes (763 tests). The new
`TestWithFileLock_SerializesConcurrentCallers` proves the lock allows at
most one caller in the critical section; `TestTmuxHooksSnippet_KillHooksBackgrounded`
asserts both kill hooks use `run-shell -b`.

Then open ~8 tmux windows so the slot budget is fully populated:

```bash
for i in $(seq 1 8); do tmux new-window; done
demux sidebar show
tmux list-panes -aF '#{@demux_slot}' | grep -c 1
```

Expected: the last command prints the slot-pane count (up to 8 + active).

<details>

<summary>Scenario 1 — Closing the sidebar no longer freezes input</summary>

1. With the sidebar shown and ~8 windows open, focus a normal pane.
2. Start typing a command and immediately run `demux sidebar toggle`
   (or its bound key) mid-keystroke.
3. Keep typing through the close.

   Expected: keystrokes register without a stall; the sidebar (and every
   slot pane) disappears, and the terminal stays responsive throughout.
   Before this change, input was dropped/delayed for up to ~1s.
4. Confirm full teardown:
   ```bash
   tmux list-panes -aF '#{@demux_slot}' | grep -c 1 || echo 0
   ```
   Expected: `0` — no slot panes remain.

</details>

<details>

<summary>Scenario 2 — State cleanup still runs after backgrounded close</summary>

1. With the sidebar open, set a state on a pane, then close the sidebar.
2. Wait ~1s for the backgrounded handlers to drain, then check the log:
   ```bash
   tail -n 20 "$(demux --version >/dev/null; echo ~/.local/state/demux/demux.log)" 2>/dev/null \
     || tail -n 20 ~/.local/share/demux/demux.log
   ```
   Expected: `pane_closed` debug lines, no sweep errors.
3. Confirm the lock file exists and is not held after teardown:
   ```bash
   ls -l ~/.local/share/demux/event.lock
   ```
   Expected: the file exists; nothing should be blocked on it.

</details>
