### PR TITLE
fix(tui): exclude sticky sidebar slot panes from the process list

### DIFF
--- a/internal/tmux/pane_cwd.go
+++ b/internal/tmux/pane_cwd.go
@@ -1,15 +1,22 @@
 package tmux
 
-// PrimaryPaneCWD returns the CWD of pane index 0, falling back to the first pane.
-// Returns "" if panes is empty.
+// PrimaryPaneCWD returns the CWD of the primary pane: pane index 0, falling
+// back to the first pane. Sticky sidebar slot panes are skipped so an open
+// sidebar does not hijack a session's primary path. Returns "" if panes is
+// empty or contains only slot panes.
 func PrimaryPaneCWD(panes []Pane) string {
 	for _, p := range panes {
+		if p.IsSlot {
+			continue
+		}
 		if p.PaneIndex == 0 {
 			return p.CWD
 		}
 	}
-	if len(panes) > 0 {
-		return panes[0].CWD
+	for _, p := range panes {
+		if !p.IsSlot {
+			return p.CWD
+		}
 	}
 	return ""
 }

--- a/internal/tmux/pane_cwd.go
+++ b/internal/tmux/pane_cwd.go
@@ -5,6 +5,7 @@ package tmux
 // open sidebar does not hijack the primary path. Returns nil if panes is empty
 // or contains only slot panes.
 func PrimaryPane(panes []Pane) *Pane {
+	var fallback *Pane
 	for i := range panes {
 		if panes[i].IsSlot {
 			continue
@@ -12,13 +13,11 @@ func PrimaryPane(panes []Pane) *Pane {
 		if panes[i].PaneIndex == 0 {
 			return &panes[i]
 		}
-	}
-	for i := range panes {
-		if !panes[i].IsSlot {
-			return &panes[i]
+		if fallback == nil {
+			fallback = &panes[i]
 		}
 	}
-	return nil
+	return fallback
 }
 
 // PrimaryPaneCWD returns the CWD of the primary pane (see PrimaryPane).

--- a/internal/tmux/pane_cwd.go
+++ b/internal/tmux/pane_cwd.go
@@ -1,22 +1,31 @@
 package tmux
 
-// PrimaryPaneCWD returns the CWD of the primary pane: pane index 0, falling
-// back to the first pane. Sticky sidebar slot panes are skipped so an open
-// sidebar does not hijack a session's primary path. Returns "" if panes is
-// empty or contains only slot panes.
-func PrimaryPaneCWD(panes []Pane) string {
-	for _, p := range panes {
-		if p.IsSlot {
+// PrimaryPane returns the primary pane of a session or window: pane index 0,
+// falling back to the first pane. Sticky sidebar slot panes are skipped so an
+// open sidebar does not hijack the primary path. Returns nil if panes is empty
+// or contains only slot panes.
+func PrimaryPane(panes []Pane) *Pane {
+	for i := range panes {
+		if panes[i].IsSlot {
 			continue
 		}
-		if p.PaneIndex == 0 {
-			return p.CWD
+		if panes[i].PaneIndex == 0 {
+			return &panes[i]
 		}
 	}
-	for _, p := range panes {
-		if !p.IsSlot {
-			return p.CWD
+	for i := range panes {
+		if !panes[i].IsSlot {
+			return &panes[i]
 		}
+	}
+	return nil
+}
+
+// PrimaryPaneCWD returns the CWD of the primary pane (see PrimaryPane).
+// Returns "" if panes is empty or contains only slot panes.
+func PrimaryPaneCWD(panes []Pane) string {
+	if p := PrimaryPane(panes); p != nil {
+		return p.CWD
 	}
 	return ""
 }

--- a/internal/tmux/pane_cwd_test.go
+++ b/internal/tmux/pane_cwd_test.go
@@ -15,6 +15,10 @@ func TestPrimaryPaneCWD(t *testing.T) {
 		{"empty", nil, ""},
 		{"pane 0 first", []tmux.Pane{{PaneIndex: 0, CWD: "/a"}, {PaneIndex: 1, CWD: "/b"}}, "/a"},
 		{"no pane 0 fallback", []tmux.Pane{{PaneIndex: 1, CWD: "/b"}}, "/b"},
+		{"slot at index 0 skipped", []tmux.Pane{{PaneIndex: 0, CWD: "/sidebar", IsSlot: true}, {PaneIndex: 1, CWD: "/real"}}, "/real"},
+		{"slot not at index 0 ignored", []tmux.Pane{{PaneIndex: 0, CWD: "/real"}, {PaneIndex: 1, CWD: "/sidebar", IsSlot: true}}, "/real"},
+		{"only slot pane", []tmux.Pane{{PaneIndex: 0, CWD: "/sidebar", IsSlot: true}}, ""},
+		{"slot at index 0, fallback skips it", []tmux.Pane{{PaneIndex: 0, CWD: "/sidebar", IsSlot: true}, {PaneIndex: 2, CWD: "/real"}}, "/real"},
 	}
 	for _, c := range cases {
 		got := tmux.PrimaryPaneCWD(c.panes)

--- a/internal/tmux/pane_cwd_test.go
+++ b/internal/tmux/pane_cwd_test.go
@@ -27,3 +27,32 @@ func TestPrimaryPaneCWD(t *testing.T) {
 		}
 	}
 }
+
+func TestPrimaryPane(t *testing.T) {
+	cases := []struct {
+		name  string
+		panes []tmux.Pane
+		want  string // CWD of the expected pane, or "<nil>" when none
+	}{
+		{"empty", nil, "<nil>"},
+		{"pane 0", []tmux.Pane{{PaneIndex: 0, CWD: "/a"}, {PaneIndex: 1, CWD: "/b"}}, "/a"},
+		{"slot at index 0 skipped", []tmux.Pane{{PaneIndex: 0, CWD: "/sidebar", IsSlot: true}, {PaneIndex: 1, CWD: "/real"}}, "/real"},
+		{"only slot pane", []tmux.Pane{{PaneIndex: 0, CWD: "/sidebar", IsSlot: true}}, "<nil>"},
+	}
+	for _, c := range cases {
+		got := tmux.PrimaryPane(c.panes)
+		if c.want == "<nil>" {
+			if got != nil {
+				t.Errorf("%s: expected nil, got %+v", c.name, *got)
+			}
+			continue
+		}
+		if got == nil {
+			t.Errorf("%s: expected pane with CWD %q, got nil", c.name, c.want)
+			continue
+		}
+		if got.CWD != c.want {
+			t.Errorf("%s: PrimaryPane CWD = %q, want %q", c.name, got.CWD, c.want)
+		}
+	}
+}

--- a/internal/tmux/query.go
+++ b/internal/tmux/query.go
@@ -19,6 +19,7 @@ type Pane struct {
 	WindowName      string
 	PanePID         int32 // PID of the shell process running in this pane
 	SessionActivity int64 // Unix timestamp from #{session_activity}
+	IsSlot          bool  // true when the pane is a sticky sidebar slot (@demux_slot=1)
 }
 
 // DisplayLabel returns the "session:windowIndex.paneIndex" string used as a human-readable display label.
@@ -28,8 +29,10 @@ func (p Pane) DisplayLabel() string {
 
 // ListPanes runs tmux list-panes and returns all panes across all sessions.
 func ListPanes() ([]Pane, error) {
+	// The trailing #{@demux_slot} is the sticky sidebar slot marker
+	// (sticky.SlotMarker); it is empty on every non-slot pane.
 	out, err := exec.Command("tmux", "list-panes", "-a",
-		"-F", "#{session_name}\t#{session_id}\t#{window_index}\t#{window_id}\t#{pane_index}\t#{pane_current_path}\t#{pane_id}\t#{window_name}\t#{pane_pid}\t#{session_activity}",
+		"-F", "#{session_name}\t#{session_id}\t#{window_index}\t#{window_id}\t#{pane_index}\t#{pane_current_path}\t#{pane_id}\t#{window_name}\t#{pane_pid}\t#{session_activity}\t#{@demux_slot}",
 	).Output()
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes: %w", err)
@@ -73,6 +76,9 @@ func ParsePanes(raw string) ([]Pane, error) {
 			if ts, err := strconv.ParseInt(strings.TrimSpace(parts[9]), 10, 64); err == nil {
 				p.SessionActivity = ts
 			}
+		}
+		if len(parts) >= 11 {
+			p.IsSlot = strings.TrimSpace(parts[10]) == "1"
 		}
 		panes = append(panes, p)
 	}

--- a/internal/tmux/query_test.go
+++ b/internal/tmux/query_test.go
@@ -105,6 +105,41 @@ func TestParsePanes_WithoutSessionActivity_BackwardCompat(t *testing.T) {
 	}
 }
 
+func TestParsePanes_WithSlotMarker(t *testing.T) {
+	// 11-field format: ...session_activity, demux_slot. Slot panes carry "1",
+	// every other pane carries an empty trailing field.
+	raw := "s\t$1\t0\t@5\t0\t/home/dev\t%1\tdemux-slot\t1234\t1711652000\t1\n" +
+		"s\t$1\t0\t@5\t1\t/home/dev/app\t%2\teditor\t1235\t1711652000\t\n"
+	panes, err := tmux.ParsePanes(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(panes) != 2 {
+		t.Fatalf("expected 2 panes, got %d", len(panes))
+	}
+	if !panes[0].IsSlot {
+		t.Error("expected pane 0 (demux_slot=1) to have IsSlot=true")
+	}
+	if panes[1].IsSlot {
+		t.Error("expected pane 1 (demux_slot empty) to have IsSlot=false")
+	}
+}
+
+func TestParsePanes_WithoutSlotMarker_BackwardCompat(t *testing.T) {
+	// 10-field format (no demux_slot) should still parse with IsSlot=false
+	raw := "mysession\t$1\t0\t@5\t0\t/home/dev\t%1\teditor\t1234\t1711652000\n"
+	panes, err := tmux.ParsePanes(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(panes) != 1 {
+		t.Fatalf("expected 1 pane, got %d", len(panes))
+	}
+	if panes[0].IsSlot {
+		t.Error("expected IsSlot=false for old format")
+	}
+}
+
 func TestSessionActivityMap_MaxPerSession(t *testing.T) {
 	panes := []tmux.Pane{
 		{Session: "s1", SessionActivity: 1000},

--- a/internal/tui/proclist.go
+++ b/internal/tui/proclist.go
@@ -219,12 +219,13 @@ func (p *ProcListModel) SetSessionData(panes []tmux.Pane, session string, procs 
 	}
 	sort.Ints(winIdxs)
 
-	// Compute session-level primary CWD from the first window's first pane.
+	// Compute the session-level primary CWD from the first window's primary
+	// pane. Sticky sidebar slot panes are skipped so an open sidebar does not
+	// hijack the session's primary path.
 	p.primaryCWD = ""
 	for _, wi := range winIdxs {
-		ps := sortPanes(windows[wi])
-		if len(ps) > 0 {
-			p.primaryCWD = ps[0].CWD
+		if cwd := tmux.PrimaryPaneCWD(windows[wi]); cwd != "" {
+			p.primaryCWD = cwd
 			break
 		}
 	}
@@ -237,17 +238,23 @@ func (p *ProcListModel) SetSessionData(panes []tmux.Pane, session string, procs 
 }
 
 // appendWindowNodes appends a window header and all of its panes' nodes to p.nodes.
-// It is a no-op when the window has no panes.
+// It is a no-op when the window has no panes. The window's primary pane (and
+// thus its CWD) skips any sticky sidebar slot so the window path reflects real
+// work rather than the sidebar's stale path.
 func (p *ProcListModel) appendWindowNodes(wPanes []tmux.Pane, session string, wi int, procs []proc.Process, cwdMap map[int32]string, tree map[int32][]proc.Process, gitInfo map[string]git.Info) {
 	wPanes = sortPanes(wPanes)
 	if len(wPanes) == 0 {
 		return
 	}
-	winCWD := wPanes[0].CWD
+	headerPane := wPanes[0]
+	if pp := tmux.PrimaryPane(wPanes); pp != nil {
+		headerPane = *pp
+	}
+	winCWD := headerPane.CWD
 
 	p.nodes = append(p.nodes, ProcListNode{
 		IsWindowHeader: true,
-		Pane:           wPanes[0],
+		Pane:           headerPane,
 	})
 
 	for _, pane := range wPanes {

--- a/internal/tui/proclist.go
+++ b/internal/tui/proclist.go
@@ -182,7 +182,8 @@ func (p *ProcListModel) appendPaneNodes(pane tmux.Pane, displayPane tmux.Pane, w
 	procNodes := buildProcNodesForPane(pane, procs, cwdMap, tree, p.collapsedPIDs, winCWD)
 	p.nodes = append(p.nodes, procNodes...)
 
-	if len(p.nodes) == headerIdx+1 {
+	// A sticky sidebar slot pane never shows an idle marker.
+	if len(p.nodes) == headerIdx+1 && !pane.IsSlot {
 		p.nodes = append(p.nodes, ProcListNode{IsIdle: true, Depth: 1})
 	}
 }

--- a/internal/tui/proclist_render.go
+++ b/internal/tui/proclist_render.go
@@ -277,28 +277,30 @@ func (p ProcListModel) renderProcLine(node ProcListNode, selected bool, innerW i
 	return dimStyle.Render(stripANSI(rendered))
 }
 
-// renderSlotPaneHeader renders the header row for a sticky sidebar slot pane.
-// A slot pane shows only "pane N" plus the [sidebar] tag (styled like the idle
-// indicator); it never displays a path, git divergence, or an idle marker.
-func renderSlotPaneHeader(paneIndex int, selected bool, innerW int) string {
-	label := fmt.Sprintf("pane %d", paneIndex)
+// renderPaneHeaderTag renders a pane-header row made up of a label and a short
+// trailing tag styled like the idle indicator — used both for the "idle" marker
+// and the "[sidebar]" slot tag. When selected, the whole row carries the
+// selected background and is padded to innerW.
+func renderPaneHeaderTag(label, tag string, selected bool, innerW int) string {
 	if !selected {
-		return paneHeaderStyle.Render(label) + colSep + paneIdleStyle.Render(slotPaneTag)
+		return paneHeaderStyle.Render(label) + colSep + paneIdleStyle.Render(tag)
 	}
-	tagVisualW := len(colSep) + len([]rune(slotPaneTag))
-	padCount := innerW - len([]rune(label)) - tagVisualW
+	padCount := innerW - len([]rune(label)) - len(colSep) - len([]rune(tag))
 	if padCount < 0 {
 		padCount = 0
 	}
 	return selectedBG.Render(label) +
 		selectedBG.Render(colSep) +
-		paneIdleStyle.Background(activeTheme.ColorSelected).Render(slotPaneTag) +
+		paneIdleStyle.Background(activeTheme.ColorSelected).Render(tag) +
 		selectedBG.Render(strings.Repeat(" ", padCount))
 }
 
 func (p ProcListModel) renderPaneHeader(node ProcListNode, selected bool, innerW int, hasIdle bool) string {
 	if node.Pane.IsSlot {
-		return renderSlotPaneHeader(node.Pane.PaneIndex, selected, innerW)
+		// A sticky sidebar slot pane shows only its label plus the [sidebar]
+		// tag — never a path, git divergence, or idle marker.
+		label := fmt.Sprintf("pane %d", node.Pane.PaneIndex)
+		return renderPaneHeaderTag(label, slotPaneTag, selected, innerW)
 	}
 	label := fmt.Sprintf("pane %d", node.Pane.PaneIndex)
 
@@ -380,18 +382,7 @@ func (p ProcListModel) renderPaneHeaderSelected(label, pathStr, gitSuffix string
 		return selectedBG.Render(content + strings.Repeat(" ", padCount))
 	}
 	if hasIdle {
-		// Render "label  idle" inline, then fill the remaining width with
-		// the selected background so the row doesn't wrap.
-		const idleVisualW = len(colSep) + len(idleLabel)
-		padCount := innerW - len([]rune(left)) - idleVisualW
-		if padCount < 0 {
-			padCount = 0
-		}
-		idleRendered := paneIdleStyle.Background(activeTheme.ColorSelected).Render("idle")
-		return selectedBG.Render(left) +
-			selectedBG.Render(colSep) +
-			idleRendered +
-			selectedBG.Render(strings.Repeat(" ", padCount))
+		return renderPaneHeaderTag(left, idleLabel, true, innerW)
 	}
 	padCount := innerW - len([]rune(left))
 	if padCount < 0 {

--- a/internal/tui/proclist_render.go
+++ b/internal/tui/proclist_render.go
@@ -33,6 +33,10 @@ const (
 
 	// idleLabel is the text shown next to a pane with no active process.
 	idleLabel = "idle"
+
+	// slotPaneTag marks a pane that is the sticky sidebar slot, so it is
+	// recognizable in the process list and not mistaken for real work.
+	slotPaneTag = "[sidebar]"
 )
 
 // renderedLine pairs a node index with its rendered text, used to build the
@@ -275,6 +279,9 @@ func (p ProcListModel) renderProcLine(node ProcListNode, selected bool, innerW i
 
 func (p ProcListModel) renderPaneHeader(node ProcListNode, selected bool, innerW int, hasIdle bool) string {
 	label := fmt.Sprintf("pane %d", node.Pane.PaneIndex)
+	if node.Pane.IsSlot {
+		label += colSep + slotPaneTag
+	}
 
 	pathStr := ""
 	if node.Pane.CWD != "" && node.Pane.CWD != p.primaryCWD {

--- a/internal/tui/proclist_render.go
+++ b/internal/tui/proclist_render.go
@@ -277,11 +277,30 @@ func (p ProcListModel) renderProcLine(node ProcListNode, selected bool, innerW i
 	return dimStyle.Render(stripANSI(rendered))
 }
 
-func (p ProcListModel) renderPaneHeader(node ProcListNode, selected bool, innerW int, hasIdle bool) string {
-	label := fmt.Sprintf("pane %d", node.Pane.PaneIndex)
-	if node.Pane.IsSlot {
-		label += colSep + slotPaneTag
+// renderSlotPaneHeader renders the header row for a sticky sidebar slot pane.
+// A slot pane shows only "pane N" plus the [sidebar] tag (styled like the idle
+// indicator); it never displays a path, git divergence, or an idle marker.
+func renderSlotPaneHeader(paneIndex int, selected bool, innerW int) string {
+	label := fmt.Sprintf("pane %d", paneIndex)
+	if !selected {
+		return paneHeaderStyle.Render(label) + colSep + paneIdleStyle.Render(slotPaneTag)
 	}
+	tagVisualW := len(colSep) + len([]rune(slotPaneTag))
+	padCount := innerW - len([]rune(label)) - tagVisualW
+	if padCount < 0 {
+		padCount = 0
+	}
+	return selectedBG.Render(label) +
+		selectedBG.Render(colSep) +
+		paneIdleStyle.Background(activeTheme.ColorSelected).Render(slotPaneTag) +
+		selectedBG.Render(strings.Repeat(" ", padCount))
+}
+
+func (p ProcListModel) renderPaneHeader(node ProcListNode, selected bool, innerW int, hasIdle bool) string {
+	if node.Pane.IsSlot {
+		return renderSlotPaneHeader(node.Pane.PaneIndex, selected, innerW)
+	}
+	label := fmt.Sprintf("pane %d", node.Pane.PaneIndex)
 
 	pathStr := ""
 	if node.Pane.CWD != "" && node.Pane.CWD != p.primaryCWD {

--- a/internal/tui/proclist_test.go
+++ b/internal/tui/proclist_test.go
@@ -1333,3 +1333,96 @@ func TestRender_SessionMode_PaneHeaderIndented(t *testing.T) {
 		t.Errorf("expected '    pane 0' (4-space indent) in output, got:\n%s", plain)
 	}
 }
+
+// ---------- sidebar slot handling ----------
+
+// slotSessionPanes returns a window whose pane index 0 is a sticky sidebar
+// slot pointing at a stale directory, with the real work in pane index 1.
+func slotSessionPanes() []tmux.Pane {
+	return []tmux.Pane{
+		{Session: "s", WindowIndex: 0, PaneIndex: 0, CWD: "/sidebar", IsSlot: true, PanePID: 9},
+		{Session: "s", WindowIndex: 0, PaneIndex: 1, CWD: "/real", PanePID: 10},
+	}
+}
+
+func TestSetSessionData_PrimaryCWDIgnoresSlotPane(t *testing.T) {
+	var m ProcListModel
+	m.SetSessionData(slotSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, config.Config{},
+	)
+	if m.primaryCWD != "/real" {
+		t.Errorf("expected primaryCWD '/real' (sidebar slot ignored), got %q", m.primaryCWD)
+	}
+}
+
+func TestSetSessionData_WindowHeaderIgnoresSlotPane(t *testing.T) {
+	var m ProcListModel
+	m.SetSessionData(slotSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, config.Config{},
+	)
+	found := false
+	for _, n := range m.nodes {
+		if n.IsWindowHeader {
+			found = true
+			if n.Pane.IsSlot {
+				t.Error("window header pane should not be the sidebar slot pane")
+			}
+			if n.Pane.CWD != "/real" {
+				t.Errorf("expected window header CWD '/real' (slot ignored), got %q", n.Pane.CWD)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no window header node emitted")
+	}
+}
+
+func TestSetSessionData_WindowCWDFromSlotPaneSkipped(t *testing.T) {
+	var m ProcListModel
+	m.SetSessionData(slotSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, config.Config{},
+	)
+	for _, n := range m.nodes {
+		if !n.IsPaneHeader {
+			continue
+		}
+		if n.Pane.IsSlot {
+			// Slot pane diverges from the real window CWD — keeps its own path.
+			if n.Pane.CWD != "/sidebar" {
+				t.Errorf("expected slot pane to keep CWD '/sidebar', got %q", n.Pane.CWD)
+			}
+		} else {
+			// Real pane matches the window CWD — path suppressed.
+			if n.Pane.CWD != "" {
+				t.Errorf("expected real pane CWD suppressed (matches window CWD), got %q", n.Pane.CWD)
+			}
+		}
+	}
+}
+
+func TestRenderPaneHeader_SlotPane_ShowsSidebarTag(t *testing.T) {
+	var p ProcListModel
+	node := ProcListNode{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0, IsSlot: true}}
+	plain := stripANSI(p.renderPaneHeader(node, false, 40, false))
+	if !strings.Contains(plain, slotPaneTag) {
+		t.Errorf("expected sidebar slot tag %q in pane header, got: %q", slotPaneTag, plain)
+	}
+}
+
+func TestRenderPaneHeader_NonSlotPane_NoSidebarTag(t *testing.T) {
+	var p ProcListModel
+	node := ProcListNode{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0}}
+	plain := stripANSI(p.renderPaneHeader(node, false, 40, false))
+	if strings.Contains(plain, slotPaneTag) {
+		t.Errorf("expected no slot tag for a non-slot pane, got: %q", plain)
+	}
+}
+
+func TestRenderPaneHeader_SlotPane_Selected_ShowsSidebarTag(t *testing.T) {
+	var p ProcListModel
+	node := ProcListNode{IsPaneHeader: true, Pane: tmux.Pane{PaneIndex: 0, IsSlot: true}}
+	plain := stripANSI(p.renderPaneHeader(node, true, 40, false))
+	if !strings.Contains(plain, slotPaneTag) {
+		t.Errorf("expected sidebar slot tag in selected slot pane header, got: %q", plain)
+	}
+}

--- a/internal/tui/proclist_test.go
+++ b/internal/tui/proclist_test.go
@@ -1426,3 +1426,80 @@ func TestRenderPaneHeader_SlotPane_Selected_ShowsSidebarTag(t *testing.T) {
 		t.Errorf("expected sidebar slot tag in selected slot pane header, got: %q", plain)
 	}
 }
+
+func TestRenderPaneHeader_SlotPane_HidesPathAndGit(t *testing.T) {
+	p := ProcListModel{
+		cfg: config.Config{ProcessList: config.ProcessListConfig{PathRightAlign: true}},
+	}
+	node := ProcListNode{
+		IsPaneHeader: true,
+		Pane:         tmux.Pane{PaneIndex: 0, IsSlot: true, CWD: "/divergent-marker"},
+		GitDeviant:   true,
+	}
+	plain := stripANSI(p.renderPaneHeader(node, false, 60, false))
+	if strings.Contains(plain, "divergent-marker") {
+		t.Errorf("expected slot pane to hide its path, got: %q", plain)
+	}
+	if strings.Contains(plain, pathRedirectGlyph) {
+		t.Errorf("expected slot pane to hide the git divergence glyph, got: %q", plain)
+	}
+}
+
+func TestSetSessionData_SlotPaneHasNoIdleNode(t *testing.T) {
+	var m ProcListModel
+	m.SetSessionData(slotSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, config.Config{},
+	)
+	for i, n := range m.nodes {
+		if n.IsPaneHeader && n.Pane.IsSlot {
+			if i+1 < len(m.nodes) && m.nodes[i+1].IsIdle {
+				t.Error("slot pane header should not be followed by an idle node")
+			}
+		}
+	}
+}
+
+func TestSetSessionData_RealEmptyPaneKeepsIdleNode(t *testing.T) {
+	var m ProcListModel
+	m.SetSessionData(slotSessionPanes(), "s",
+		nil, map[int32]string{}, map[string]git.Info{}, config.Config{},
+	)
+	found := false
+	for i, n := range m.nodes {
+		if n.IsPaneHeader && !n.Pane.IsSlot && n.Pane.PaneIndex == 1 {
+			if i+1 < len(m.nodes) && m.nodes[i+1].IsIdle {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected real empty pane to keep its idle node")
+	}
+}
+
+func TestRender_SlotPaneRow_NoPathNoIdle(t *testing.T) {
+	panes := []tmux.Pane{
+		{Session: "s", WindowIndex: 0, PaneIndex: 0, CWD: "/real", PanePID: 10},
+		{Session: "s", WindowIndex: 0, PaneIndex: 1, CWD: "/sidebar-divergent", IsSlot: true, PanePID: 9},
+	}
+	var m ProcListModel
+	m.SetSessionData(panes, "s",
+		nil, map[int32]string{}, map[string]git.Info{}, config.Config{},
+	)
+	out := stripANSI(m.Render(120, 20, false, "procs"))
+	slotLine := ""
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, slotPaneTag) {
+			slotLine = ln
+		}
+	}
+	if slotLine == "" {
+		t.Fatal("slot pane row not found in render output")
+	}
+	if strings.Contains(slotLine, "sidebar-divergent") {
+		t.Errorf("slot row should not show a path, got: %q", slotLine)
+	}
+	if strings.Contains(slotLine, idleLabel) {
+		t.Errorf("slot row should not show the idle label, got: %q", slotLine)
+	}
+}


### PR DESCRIPTION
## Context

No linked ticket — surfaced while running the sticky sidebar in **slots mode**.

When `[sidebar.sticky]` has `slots = true`, demux pre-creates a reserved sidebar
pane in every tmux window (tagged with the `@demux_slot` option, titled
`demux-slot`). The process list enumerates every pane in a session's windows, so
that slot pane was treated as real work:

- Its CWD — wherever the sidebar pane happened to start — could be chosen as the
  window/session **primary path** shown in the border title, hiding the path of
  the pane the user is actually working in.
- It rendered a full pane-header row with a path, git divergence glyph, and an
  `idle` marker. That row describes the sidebar itself, not the user's work.

Desired behavior: the sticky sidebar slot is infrastructure and should never
influence or clutter the process list.

Scope is **the process list's treatment of slot panes**. The sticky sidebar
lifecycle (`internal/sticky`) is unchanged.

## What does this PR do

<img width="1629" height="518" alt="image" src="https://github.com/user-attachments/assets/386e8a44-2d8d-4b18-828f-e959c218d66b" />

- Adds an `IsSlot` field to `tmux.Pane`, parsed from a new `#{@demux_slot}` field
  appended to the `list-panes` format string. Old 10-field output still parses
  cleanly — `IsSlot` defaults to `false`.
- Introduces `tmux.PrimaryPane` / `tmux.PrimaryPaneCWD`: resolve a session or
  window's primary pane (index 0, else first pane) while skipping slot panes.
  Return `nil` / `""` when only slot panes exist.
- The process list uses `PrimaryPane` for both the session-level primary CWD and
  each window header's CWD, so an open sidebar no longer hijacks the displayed
  path.
- Slot panes render a dedicated header — `pane N  [sidebar]` — with no path, no
  git divergence, and no `idle` marker.
- Final commit (`refactor(tui)`) is behavior-preserving cleanup: deduplicates
  the label+tag render path and collapses `PrimaryPane` to a single loop.

## Manual QA

> TUI change — verified visually in the demux process list, plus deterministic
> unit coverage. The visual path needs a real tmux session with slots mode on;
> the unit tests are the no-setup fallback.

### Prerequisites

<details>

<summary>1. tmux is installed and a server is running.</summary>

```bash
tmux -V && tmux list-sessions
```

Expect a version string and at least one session. If no server is running,
start one with `tmux new -d -s qa`.

</details>

<details>

<summary>2. Slots mode is enabled in the demux config.</summary>

```bash
grep -A1 'sidebar.sticky' ~/.config/demux/demux.toml | grep slots
```

Expect `slots = true`. If absent or `false`, set it under `[sidebar.sticky]`.
Without slots mode no `@demux_slot` panes are ever created and the bug cannot
be reproduced.

</details>

### Setup

```bash
go build -o /tmp/demux . && /tmp/demux sidebar toggle
```

This spawns the sticky sidebar and, in slots mode, a `@demux_slot` pane in the
current window. Confirm the slot pane exists and carries the marker:

```bash
tmux list-panes -aF '#{pane_id} #{pane_title} #{@demux_slot}'
# expect one line ending in "demux-slot 1"
```

### Scenario 1 — Slot pane does not hijack the primary path

<details>

<summary>Scenario 1 — primary path reflects real work, not the sidebar</summary>

1. In the working (non-slot) pane, `cd` to a recognizable directory, e.g.
   `cd ~/com.github/demux/main`.
2. Open the demux TUI in that pane: `/tmp/demux`.
3. Select the session and focus the process list (`l`).
4. Read the right-side border title and the window header path.
   Expected: both show the working directory (`~/com.github/demux/main`), **not**
   the directory the sticky sidebar pane started in.

</details>

### Scenario 2 — Slot pane row is tagged, not pathed

<details>

<summary>Scenario 2 — slot pane renders "pane N  [sidebar]"</summary>

1. With the process list open (Scenario 1), find the row for the slot pane.
2. Expected: it renders `pane N  [sidebar]` — no directory path, no `↪` git
   divergence glyph, no `idle` marker.
3. Move the cursor onto the slot row.
   Expected: the `[sidebar]` tag stays visible with the selected background;
   still no path / git / idle.
4. Compare with a real pane row: it still shows its path and (if applicable)
   git divergence — the change is scoped to slot panes only.

</details>

### Fallback — unit coverage (no tmux setup)

<details>

<summary>Run the unit tests added by this PR</summary>

```bash
go test ./internal/tmux/ ./internal/tui/
```

Expected: all pass. Covers `IsSlot` parsing (incl. 10-field backward compat),
`PrimaryPane` slot-skipping, primary-CWD resolution, and the `[sidebar]` header
render for selected and unselected slot panes.

</details>
