### PR TITLE
fix(hooks): stop tmux hook snippet from stacking duplicate copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,22 +656,28 @@ demux hooks init --tool tmux >> ~/.tmux.conf
 tmux source ~/.tmux.conf
 ```
 
-The snippet now includes four extra lines:
+The snippet adds these sticky-sidebar hooks:
 
 - `set-hook -ga client-session-changed "run-shell 'demux sidebar follow ...'"`
   moves the sidebar pane to whichever session you switch into.
 - `set-hook -ga after-select-window "run-shell 'demux sidebar follow ...'"`
   moves the sidebar pane to whichever window you switch into (same session).
-- `set-hook -ga after-new-window "run-shell 'demux sidebar follow ...'"`
-  moves the sidebar pane into a window you just created. tmux does not fire
-  `after-select-window` for `new-window`, so this hook is needed separately.
-- `set-hook -ga client-attached "run-shell 'demux sidebar show ...'"`
+- `set-hook -g after-new-window "run-shell -b 'demux sidebar follow ...; demux sidebar slots ensure ...'"`
+  moves the sidebar into a window you just created and reconciles slot panes.
+  tmux does not fire `after-select-window` for `new-window`, so this hook is
+  needed separately.
+- `set-hook -g client-attached "run-shell -b 'demux sidebar show ...'"`
   creates the sidebar pane automatically when you attach a tmux client.
 
+The `after-new-window` and `client-attached` hooks use `-g` (replace), not
+`-ga` (append), so re-sourcing `~/.tmux.conf` replaces them in place instead
+of stacking duplicate copies; `run-shell -b` keeps window creation and client
+attach from blocking while the handler runs.
+
 If you prefer to manage the sidebar manually with `demux sidebar toggle`,
-remove the `client-attached` line. The three `follow` lines are required for
-the "follow" behavior; without them the sidebar stays in whichever session
-and window it was created in.
+remove the `client-attached` line. The two `follow` lines plus
+`after-new-window` are required for the "follow" behavior; without them the
+sidebar stays in whichever session and window it was created in.
 
 ### Configuration
 

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -132,6 +132,13 @@ const tmuxHooksSnippet = `# demux tmux hooks
 # positional parameter, which is empty. With --flag value, an empty expansion
 # leaves the flag with no argument and the command fails. With --flag=value, an
 # empty expansion produces --flag= (empty string), which is valid.
+#
+# Idempotency note: the hooks below use -g (replace), not -ga (append), so
+# re-sourcing this file (e.g. via a stray after-new-session re-source hook)
+# replaces each hook in place instead of stacking duplicate copies. The two
+# follow hooks on shared events (client-session-changed, after-select-window)
+# keep -ga only because a -g line for the same event resets the array just
+# above them.
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Clears Demux done states when switching between panes within the same window.
@@ -164,7 +171,7 @@ set-hook -g after-kill-pane "run-shell -b 'demux event pane_closed --pane=#{hook
 # natural process exits in some tmux versions).
 # run-shell -b backgrounds the handler (see after-kill-pane above) so it never
 # blocks tmux input; it shares the pane_closed handler's file lock.
-set-hook -ga pane-exited "run-shell -b 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
+set-hook -g pane-exited "run-shell -b 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
 
 # Sticky sidebar - moves the demux sidebar pane to the newly active session.
 set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null; true'"
@@ -173,19 +180,18 @@ set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null
 # (within the same session). join-pane uses -d so user focus is preserved.
 set-hook -ga after-select-window "run-shell 'demux sidebar follow 2>/dev/null; true'"
 
-# Sticky sidebar - moves the demux sidebar pane into a newly created window.
-# tmux does NOT fire after-select-window for new-window, so this separate hook
-# is required for the sidebar to follow when you create a window.
-set-hook -ga after-new-window "run-shell 'demux sidebar follow 2>/dev/null; true'"
-
-# Sticky sidebar (slots mode) - ensures every newly created window gets a
-# sidebar slot pane. No-op when [sidebar.sticky] slots = false or when no
-# slots have been installed yet.
-set-hook -ga after-new-window "run-shell 'demux sidebar slots ensure 2>/dev/null; true'"
+# Sticky sidebar - moves the demux sidebar pane into a newly created window and
+# ensures that window gets a slot pane (slots mode; no-op when slots = false or
+# no slots are installed). tmux does NOT fire after-select-window for
+# new-window, so this separate hook is required.
+# run-shell -b backgrounds the handler so creating a window never blocks input
+# while the sidebar relocates. follow + slots ensure run sequentially in one
+# job so they never race each other.
+set-hook -g after-new-window "run-shell -b 'demux sidebar follow 2>/dev/null; demux sidebar slots ensure 2>/dev/null; true'"
 
 # Sticky sidebar auto-show on client attach. Remove this line if you prefer
 # to toggle the sticky sidebar manually with 'demux sidebar toggle'.
-set-hook -ga client-attached "run-shell 'demux sidebar show 2>/dev/null; true'"
+set-hook -g client-attached "run-shell -b 'demux sidebar show 2>/dev/null; true'"
 # ──────────────────────────────────────────────────────────────────────────────
 `
 

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -106,8 +106,8 @@ func TestTmuxHooksSnippet_ContainsStickyWindowFollowHook(t *testing.T) {
 }
 
 func TestTmuxHooksSnippet_ContainsStickySlotsEnsureHook(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga after-new-window") {
-		t.Error("snippet should include after-new-window -ga hook for slots ensure")
+	if !strings.Contains(tmuxHooksSnippet, "set-hook -g after-new-window") {
+		t.Error("snippet should include after-new-window hook for slots ensure")
 	}
 	if !strings.Contains(tmuxHooksSnippet, "demux sidebar slots ensure") {
 		t.Error("after-new-window hook should call 'demux sidebar slots ensure'")
@@ -116,27 +116,47 @@ func TestTmuxHooksSnippet_ContainsStickySlotsEnsureHook(t *testing.T) {
 
 func TestTmuxHooksSnippet_ContainsStickyNewWindowFollowHook(t *testing.T) {
 	// after-select-window does NOT fire when a window is created via new-window
-	// (tmux fires after-new-window instead), so a separate after-new-window
-	// follow hook is required for the sidebar to follow into a fresh window.
+	// (tmux fires after-new-window instead), so the after-new-window hook must
+	// move the sidebar into the fresh window. It uses -g (replace), not -ga, so
+	// re-sourcing ~/.tmux.conf cannot stack duplicate copies, and run-shell -b
+	// so window creation never blocks on the handler.
 	found := false
 	for _, line := range strings.Split(tmuxHooksSnippet, "\n") {
-		if strings.Contains(line, "set-hook -ga after-new-window") &&
-			strings.Contains(line, "demux sidebar follow") {
+		if strings.HasPrefix(line, "set-hook -g after-new-window") &&
+			strings.Contains(line, "demux sidebar follow") &&
+			strings.Contains(line, "run-shell -b") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("snippet should bind 'demux sidebar follow' to after-new-window so the sidebar follows into newly created windows")
+		t.Error("snippet should bind 'demux sidebar follow' to after-new-window via 'set-hook -g' with 'run-shell -b'")
 	}
 }
 
 func TestTmuxHooksSnippet_ContainsStickyAutoShowHook(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga client-attached") {
+	if !strings.Contains(tmuxHooksSnippet, "set-hook -g client-attached") {
 		t.Error("snippet should include client-attached hook for sticky auto-show")
 	}
 	if !strings.Contains(tmuxHooksSnippet, "demux sidebar show") {
 		t.Error("snippet should call 'demux sidebar show' on client-attached")
+	}
+}
+
+func TestTmuxHooksSnippet_NonSharedHooksAreIdempotent(t *testing.T) {
+	// after-new-window, client-attached and pane-exited have no -g reset line
+	// for their event elsewhere in the snippet, so they must use -g (replace),
+	// not -ga (append). With -ga, re-sourcing ~/.tmux.conf stacks a duplicate
+	// copy every time, eventually spawning dozens of demux processes per event.
+	for _, line := range strings.Split(tmuxHooksSnippet, "\n") {
+		if !strings.HasPrefix(line, "set-hook") {
+			continue
+		}
+		for _, ev := range []string{"after-new-window", "client-attached", "pane-exited"} {
+			if strings.Contains(line, ev) && strings.Contains(line, "-ga") {
+				t.Errorf("%s hook must use -g (not -ga) to stay idempotent on re-source:\n  %s", ev, line)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Context

No tracked issue (this repo has no issue tracker; related follow-up branch: `feat/tmux-hook-self-registration`).

demux's tmux integration ships as a snippet that users paste into `~/.tmux.conf` via `demux hooks init --tool tmux`. Several of those hooks use `set-hook -ga` (append) with no `-g` reset line for the same event. Re-sourcing `~/.tmux.conf` — common, e.g. via an `after-new-session` hook that re-sources the config on every new session — appends another copy of each `-ga` hook every time. The hooks accumulate without bound.

Observed in a real session: `after-new-window` had reached **37 registered entries**. Creating any tmux window then ran all 37 — ~19 `demux sidebar follow` plus ~18 `demux sidebar slots ensure` — each a separate `demux` process, freezing input for **over a second**. Opening tools in a new window (e.g. LazyGit via a tmux shortcut) hit the same lag, and it grew worse with every new tmux session.

Scope is **the pasted snippet's idempotency only**. A larger redesign — demux self-registering its hooks and removing the pasted snippet entirely — is out of scope here and lives on a separate branch.

## What does this PR do

Changes `cmd/hooks.go` (the `tmuxHooksSnippet` constant) and `README.md`. No application logic changes — only the generated snippet text and docs.

- `after-new-window` — the two separate `-ga` hooks (`demux sidebar follow` and `demux sidebar slots ensure`) are merged into **one** `set-hook -g` line that runs both sequentially. `-g` (replace) means re-sourcing replaces the hook instead of stacking copies; `run-shell -b` keeps window creation from blocking on the handler; one job means follow and ensure can never race each other.
- `client-attached` — `-ga` → `-g`, plus `run-shell -b`.
- `pane-exited` — `-ga` → `-g`.
- `after-select-window` and `client-session-changed` — **unchanged**: they keep `-ga` because the snippet sets a `-g` `pane_focus` hook on those same events first, which resets the array before the append, so they stay stable at 2 entries across re-sources.
- The snippet header gains an idempotency note; the README hook-setup section is updated to match.

Stat: 2 files, +31 −19.

### Out of scope

- The full redesign (demux self-registering hooks, eliminating the pasted snippet) — separate branch `feat/tmux-hook-self-registration`. This PR is the immediate band-aid for users on the current model.
- This PR does not clean up hooks that have **already** duplicated in a running tmux server. A user who has hit the bug must unset the stale hooks (`tmux set-hook -gu after-new-window`) or restart the tmux server once. Documenting that is a reasonable follow-up but is not included here.
- Users must re-run `demux hooks init` and replace their pasted snippet (or hand-edit the affected `set-hook` lines) to benefit; an already-pasted old snippet keeps duplicating until replaced.

## Manual QA

> tmux-only change — no application code paths are touched. Verify by confirming that re-sourcing the config no longer stacks duplicate hooks, and that creating a window stays responsive.

### Prerequisites

<details>

<summary>1. tmux is installed and reasonably recent.</summary>

```bash
tmux -V
```

Expect `tmux 3.x` (any 3.x is fine). On tmux older than ~3.2 the `pane-exited` hook does not exist; that hook line is simply ignored by tmux, which is expected — the rest of the snippet still applies.

</details>

<details>

<summary>2. demux is built from this branch.</summary>

```bash
git switch fix/tmux-hook-snippet-dedup
go build -o /tmp/demux .
/tmp/demux --version
```

Expect a version string and exit 0.

</details>

### Setup

Generate the new snippet and apply it to an isolated scratch tmux server (socket `prtest`, so your real session is untouched):

```bash
/tmp/demux hooks init --tool tmux > /tmp/demux-hooks.tmux
tmux -L prtest new-session -d
tmux -L prtest source-file /tmp/demux-hooks.tmux
tmux -L prtest show-hooks -g | grep -c after-new-window
# baseline expected: 1
```

### Scenario 1 — re-sourcing never stacks duplicate hooks

<details>

<summary>Scenario 1 — re-sourcing never stacks duplicate hooks</summary>

1. Re-source the snippet 10 more times (simulating an `after-new-session` re-source hook firing across 10 sessions):
   ```bash
   for i in $(seq 10); do tmux -L prtest source-file /tmp/demux-hooks.tmux; done
   ```
2. Count the registered hooks:
   ```bash
   tmux -L prtest show-hooks -g | grep -c after-new-window
   tmux -L prtest show-hooks -g | grep -c client-attached
   ```
   Expected: `1` and `1`. With the snippet on `main`, `after-new-window` would now read `11`.
3. Confirm `after-select-window` is still stable at its intended 2 entries (one `pane_focus`, one `sidebar follow`):
   ```bash
   tmux -L prtest show-hooks -g | grep -c after-select-window
   ```
   Expected: `2`.
4. Inspect the `after-new-window` hook — it should be a single backgrounded job running both commands:
   ```bash
   tmux -L prtest show-hooks -g | grep after-new-window
   ```
   Expected: one line containing `run-shell -b` and both `demux sidebar follow` and `demux sidebar slots ensure`.
5. Tear down the scratch server:
   ```bash
   tmux -L prtest kill-server
   ```

</details>

### Scenario 2 — creating a window stays responsive with the sticky sidebar open

<details>

<summary>Scenario 2 — creating a window stays responsive with the sticky sidebar open</summary>

1. In a real tmux session, apply the new snippet (replace any old demux hook lines in `~/.tmux.conf`, then `tmux source ~/.tmux.conf`).
2. Open the sticky sidebar:
   ```bash
   demux sidebar toggle
   ```
   Expected: the sidebar pane appears.
3. Create a new window (`prefix` then `c`) and immediately type into it.
   Expected: keyboard control of the new window is immediate — no multi-hundred-millisecond freeze. The `after-new-window` handler runs backgrounded (`run-shell -b`), so input is never blocked.
4. Confirm the hook count is still 1 after the new window:
   ```bash
   tmux show-hooks -g | grep -c after-new-window
   ```
   Expected: `1`.

</details>
