### PR TITLE
fix(tui): show idle icon for aged-done sessions in card view

### DIFF
--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -1112,20 +1112,21 @@ func (s SidebarModel) renderCardStatus(node SidebarNode, selected, focused bool,
 	// Left group: state icon + label.
 	var leftIcon, leftLabel string
 	st := s.stateForSession(node.Session)
-	if st != nil {
+	// Gate on the raw state, not the age-driven value: a "done" state that has
+	// aged into StateIdle (via ageDrivenValue) must still render its idle icon,
+	// matching the full dashboard. Only a genuine StateIdle row blanks the group.
+	if st != nil && st.Value.IsDisplayable() {
 		value := ageDrivenValue(*st, s.cfg.Tui.DoneIdleAfterSecs)
-		if value.IsDisplayable() {
-			if focused {
-				leftIcon = stateIconOnBG(value, activeTheme.ColorSelected)
-			} else {
-				leftIcon = stateIcon(value)
-			}
-			labelStyle := lipgloss.NewStyle().Foreground(activeTheme.ColorFgSubtext)
-			if focused {
-				labelStyle = labelStyle.Background(activeTheme.ColorSelected)
-			}
-			leftLabel = labelStyle.Render(value.String())
+		if focused {
+			leftIcon = stateIconOnBG(value, activeTheme.ColorSelected)
+		} else {
+			leftIcon = stateIcon(value)
 		}
+		labelStyle := lipgloss.NewStyle().Foreground(activeTheme.ColorFgSubtext)
+		if focused {
+			labelStyle = labelStyle.Background(activeTheme.ColorSelected)
+		}
+		leftLabel = labelStyle.Render(value.String())
 	}
 
 	// Right group: proc, git, todo, last-seen. Joined by a single space, styled

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1732,6 +1732,34 @@ func TestRenderSessionCard_IdleStateBlanksLeftGroup(t *testing.T) {
 	}
 }
 
+// Regression: a "done" state that has aged past done_idle_after_secs collapses
+// to StateIdle via ageDrivenValue. The card must still show the idle icon (as
+// the full dashboard does), not blank the left group — only a genuine StateIdle
+// row blanks it.
+func TestRenderSessionCard_AgedDoneShowsIdleIcon(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", IconStateIdle: "○"}, config.ProcessesConfig{}, nil)
+	s := SidebarModel{
+		cfg: config.Config{
+			Sidebar: config.SidebarConfig{SessionView: config.SidebarViewCard, Width: 40},
+			Tui:     config.TuiConfig{DoneIdleAfterSecs: 60},
+		},
+		sessions: []session.Session{{DisplayName: "alpha", IsLive: true}},
+		states: []db.ToolState{{
+			Target:    db.Target{Type: db.TargetTypeSession, ID: "alpha"},
+			Value:     db.StateDone,
+			UpdatedAt: time.Now().Add(-2 * time.Minute),
+		}},
+	}
+	out := s.renderSessionCard(SidebarNode{Session: "alpha"}, false, false, 40)
+	row2 := strings.Split(out, "\n")[1]
+	if !strings.Contains(stripANSI(row2), activeTheme.IconStateIdle) {
+		t.Errorf("aged done should show idle icon: %q", row2)
+	}
+	if !strings.Contains(stripANSI(row2), "idle") {
+		t.Errorf("aged done should show \"idle\" label: %q", row2)
+	}
+}
+
 func TestRenderSessionCard_WorkingStateShowsLabel(t *testing.T) {
 	initStyles(Theme{IconTmuxSession: "⊞", IconCfgSession: "⚙︎", IconStateWorking: "⟳"}, config.ProcessesConfig{}, nil)
 	s := SidebarModel{


### PR DESCRIPTION
## Context

A `done` state that has aged past `done_idle_after_secs` renders inconsistently across views. The full dashboard shows it as `<idle icon> task complete`, but the card view (used in compact mode and the sidebar) shows no state at all. The session still sorts first by state precedence, so it appears as a stateless card ahead of newer sessions, which is confusing.

## What does this PR do

`renderCardStatus` gated the state group on the **age-driven** value's `IsDisplayable()`. `ageDrivenValue` collapses an aged `done` into `StateIdle`, which `IsDisplayable()` rejects, so the card blanked the entire left group. The full dashboard (`paneStateIndicator`) applies no such gate and still renders the idle icon.

The fix gates on the **raw** `st.Value` instead:

- Aged-done row stays `StateDone` (raw), so it remains displayable and the card renders the idle icon, matching the dashboard.
- A genuine `StateIdle` row is still blanked, preserving the card's resting-state design.

The icon and label still use the age-driven value, so an aged-done card reads `<idle icon> idle` (the card has no message slot and uses the state name by convention).

## Manual QA

1. Open demux in compact mode (or any mode with the sidebar card view).
2. Set a session target to `done`: `demux state set <target> done -m "task complete"`.
3. Confirm the card shows the done icon and `done` label.
4. Wait past `done_idle_after_secs` (default 60s).
5. Confirm the card now shows the idle icon and `idle` label, matching the full dashboard.
6. Clear the state (`demux state clear <target>`) and confirm the card's left state group is blank.

## Automated tests

- `go test ./internal/tui/... ./internal/db/...` (405 pass)
- New: `TestRenderSessionCard_AgedDoneShowsIdleIcon`
- Existing `TestRenderSessionCard_IdleStateBlanksLeftGroup` still passes (genuine idle stays blank)