### PR TITLE
feat(tmux): self-registering tmux hooks via managed block

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,9 +642,10 @@ demux sidebar hide     # idempotent: kill if present
 All three require the invoking shell to be inside tmux (`$TMUX` set). Running
 them outside tmux exits with status 1.
 
-Internally, `demux sidebar follow` is invoked by a tmux hook on
-`client-session-changed`; it physically moves the existing pane (preserving
-its current width) into the newly attached session.
+Internally, the tmux hooks call `demux event window_focus` and
+`demux event session_changed` when you switch windows or sessions; each
+physically moves the existing sidebar pane (preserving its current width) into
+the newly focused window or session.
 
 ### Enable the tmux hooks
 

--- a/README.md
+++ b/README.md
@@ -695,6 +695,8 @@ focus_on_open = true
 # move focus into it instead of closing it. Toggle again from inside the
 # sidebar to close it.
 focus_before_toggle_close = false
+# Automatically show the sticky sidebar when a tmux client attaches.
+auto_show = false
 ```
 
 ### Slots mode (opt-in, no follow flicker)

--- a/README.md
+++ b/README.md
@@ -646,38 +646,33 @@ Internally, `demux sidebar follow` is invoked by a tmux hook on
 `client-session-changed`; it physically moves the existing pane (preserving
 its current width) into the newly attached session.
 
-### Enable the auto-show + follow hooks
+### Enable the tmux hooks
 
-Run `demux hooks init --tool tmux` and paste the snippet into your
-`~/.tmux.conf`, then reload tmux:
+Run `demux hooks install` once:
 
 ```bash
-demux hooks init --tool tmux >> ~/.tmux.conf
-tmux source ~/.tmux.conf
+demux hooks install --tool tmux
 ```
 
-The snippet adds these sticky-sidebar hooks:
+This writes a one-line managed block to `~/.tmux.conf`:
 
-- `set-hook -ga client-session-changed "run-shell 'demux sidebar follow ...'"`
-  moves the sidebar pane to whichever session you switch into.
-- `set-hook -ga after-select-window "run-shell 'demux sidebar follow ...'"`
-  moves the sidebar pane to whichever window you switch into (same session).
-- `set-hook -g after-new-window "run-shell -b 'demux sidebar follow ...; demux sidebar slots ensure ...'"`
-  moves the sidebar into a window you just created and reconciles slot panes.
-  tmux does not fire `after-select-window` for `new-window`, so this hook is
-  needed separately.
-- `set-hook -g client-attached "run-shell -b 'demux sidebar show ...'"`
-  creates the sidebar pane automatically when you attach a tmux client.
+```
+# >>> demux managed block >>>
+set-hook -g client-attached "run-shell -b 'demux event client_attached 2>/dev/null; true'"
+# <<< demux managed block <<<
+```
 
-The `after-new-window` and `client-attached` hooks use `-g` (replace), not
-`-ga` (append), so re-sourcing `~/.tmux.conf` replaces them in place instead
-of stacking duplicate copies; `run-shell -b` keeps window creation and client
-attach from blocking while the handler runs.
+On every tmux client attach, demux reconciles its full hook set into the
+running server — de-duplicating and self-healing automatically, with no
+snippet to re-paste when demux updates. Re-running `demux hooks install` is
+safe and idempotent. If an older multi-line demux snippet is found, you are
+prompted to remove it.
 
-If you prefer to manage the sidebar manually with `demux sidebar toggle`,
-remove the `client-attached` line. The two `follow` lines plus
-`after-new-window` are required for the "follow" behavior; without them the
-sidebar stays in whichever session and window it was created in.
+`demux hooks install --print-only` prints the bootstrap line without touching
+any files.
+
+Set `[sidebar.sticky] auto_show = true` to have the sticky sidebar appear
+automatically on attach.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -746,9 +746,8 @@ demux sidebar slots install     # idempotent: ensure every reserved window has a
 demux sidebar slots uninstall   # remove every slot pane
 ```
 
-The tmux snippet from `demux hooks init --tool tmux` already includes an
-`after-new-window` hook that reconciles the slot set when a new window
-appears (no-op when `slots = false`).
+demux's tmux hooks already include an `after-new-window` hook that
+reconciles the slot set when a new window appears (no-op when `slots = false`).
 
 Trade-offs:
 
@@ -918,56 +917,11 @@ If the named session is configured in `sessions.toml` or `private.toml` but not 
 
 ### Tmux
 
-demux can automatically clear `done` states when you navigate between panes, windows, or sessions, so you always know if a tool finished while you were away. Generate the hook configuration with:
-
-```bash
-demux hooks init --tool tmux
-```
-
-Paste the output into `~/.tmux.conf` and reload:
-
-```bash
-tmux source ~/.tmux.conf
-```
-
-> [!CAUTION]
-> Use `--flag=value` syntax (not `--flag value`) in tmux hooks. tmux expands
-> `#{session_id}` to a raw ID like `$8`; the shell then treats `$8` as a
-> positional parameter, which is empty. With `--flag value` the empty expansion
-> leaves the flag without an argument and the command silently fails. With
-> `--flag=value` the empty expansion produces `--flag=` (empty string), which
-> is valid and handled correctly.
-
-<details>
-
-<summary>Tmux hook snippet</summary>
-
-```tmux
-# Note: flags use --flag=value (not --flag value). tmux expands #{session_id} to a
-# raw ID like $8; the shell then treats $8 as a positional parameter (empty). With
-# --flag value an empty expansion leaves the flag with no argument. With --flag=value
-# an empty expansion produces --flag= (empty string), which is valid.
-
-# Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
-
-# Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
-
-# Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
-
-# Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
-
-# Removes Demux state when a pane is closed (prevents stale state accumulation).
-# #{hook_pane} is the killed pane's ID; #{pane_id} is the new active pane after
-# the kill — using #{pane_id} here would clear the wrong pane's state.
-# run-shell -b backgrounds the handler so closing many panes at once never blocks tmux input.
-set-hook -g after-kill-pane "run-shell -b 'demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true'"
-```
-
-</details>
+demux uses tmux hooks to clear `done` states when you navigate between panes,
+windows, or sessions, so you always know if a tool finished while you were
+away, plus the hooks that drive the sticky sidebar. These hooks are registered
+and kept up to date automatically by `demux hooks install` — see
+[Enable the tmux hooks](#enable-the-tmux-hooks) for the one-time setup.
 
 ### Tmux Status Bar
 
@@ -1171,7 +1125,7 @@ demux event pane_focus [--pane-id <%N>] [--window-id <@N>] [--session-id <$N>]
 
 # Config
 demux config init                  # print default config to stdout
-demux hooks init --tool tmux       # print tmux hook snippet to paste into .tmux.conf
+demux hooks install --tool tmux    # install demux's tmux hooks (writes a managed block to .tmux.conf)
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -669,6 +669,16 @@ snippet to re-paste when demux updates. Re-running `demux hooks install` is
 safe and idempotent. If an older multi-line demux snippet is found, you are
 prompted to remove it.
 
+> [!WARNING]
+> **Upgrading from an older demux?** Earlier versions had you paste a multi-line
+> hook snippet from `demux hooks init` into `~/.tmux.conf` and re-source it on
+> every update. That snippet is obsolete. Run `demux hooks install` once: it
+> detects the old pasted lines and prompts you to remove them in favor of the
+> managed block. Until they are removed the old lines still fire (demux
+> de-duplicates them into its canonical set at each client attach), but they no
+> longer track demux's hook set, so clear them when prompted. `demux hooks init`
+> is kept only as a deprecated alias and now prints just the one-line bootstrap.
+
 `demux hooks install --print-only` prints the bootstrap line without touching
 any files.
 

--- a/README.md
+++ b/README.md
@@ -1185,17 +1185,22 @@ tail -f ~/.local/share/demux/demux.log
 First, confirm the hooks are registered in the running tmux session (not just in `.tmux.conf`):
 
 ```bash
-# List all global hooks — demux registers four of them
+# List all global hooks
 tmux show-hooks -g
 
 # Filter to just the demux lines
 tmux show-hooks -g | grep demux
 ```
 
-Expected output includes entries for `after-select-pane`, `after-select-window`, `client-session-changed`, and `client-focus-in`. If any are missing, reload the config:
+Expected output includes entries for `after-select-pane`, `after-select-window`,
+`client-session-changed`, `client-focus-in`, `after-kill-pane`, and
+`after-new-window`. demux registers these automatically each time a tmux client
+attaches, via the `client-attached` bootstrap hook installed by `demux hooks
+install`. If they are missing, the managed block may not be installed — run
+`demux hooks install` and re-attach, or trigger a reconcile directly:
 
 ```bash
-tmux source ~/.tmux.conf
+demux event client_attached
 tmux show-hooks -g | grep demux   # verify again
 ```
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -119,6 +119,10 @@ focus_on_open = true
 # move focus into it instead of closing it; toggle again from inside to close.
 focus_before_toggle_close = false
 
+# Automatically show the sticky sidebar when a tmux client attaches.
+# Requires the demux managed block in ~/.tmux.conf (see "demux hooks install").
+auto_show = false
+
 # Sidebar process labels — render a single highest-count label per session.
 # Globs match either the process name or any whitespace-separated token of the
 # full cmdline (case-insensitive). Only the pane root and its direct children

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -181,6 +181,67 @@ var eventPaneClosedCmd = &cobra.Command{
 	},
 }
 
+// runWindowFocus is the shared handler for the window_focus and session_changed
+// events. It clears resting done-states for the focused pane (like pane_focus)
+// and moves the sticky sidebar to the focused window/session.
+func runWindowFocus(cmd *cobra.Command, args []string) error {
+	paneID, _ := cmd.Flags().GetString("pane-id")
+	windowID, _ := cmd.Flags().GetString("window-id")
+	sessionID, _ := cmd.Flags().GetString("session-id")
+	if paneID == "" {
+		var err error
+		paneID, windowID, sessionID, err = tmuxCurrentIDs()
+		if err != nil {
+			return err
+		}
+	}
+
+	d, err := openDB()
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	if err := applyPaneFocus(d, paneID, windowID, sessionID); err != nil {
+		return err
+	}
+	if err := stickyClient().Follow(); err != nil {
+		demuxlog.Warn("window_focus: sidebar follow failed", "err", err)
+	}
+	return nil
+}
+
+// eventWindowFocusCmd is fired by the after-select-window hook.
+var eventWindowFocusCmd = &cobra.Command{
+	Use:   "window_focus",
+	Short: "Clear done states and move the sticky sidebar to the focused window",
+	RunE:  runWindowFocus,
+}
+
+// eventSessionChangedCmd is fired by the client-session-changed hook.
+var eventSessionChangedCmd = &cobra.Command{
+	Use:   "session_changed",
+	Short: "Clear done states and move the sticky sidebar to the focused session",
+	RunE:  runWindowFocus,
+}
+
+// eventNewWindowCmd is fired by the after-new-window hook. It moves the sticky
+// sidebar into the new window and reconciles slot panes. Both steps are
+// best-effort: failures are logged, not returned.
+var eventNewWindowCmd = &cobra.Command{
+	Use:   "new_window",
+	Short: "Move the sticky sidebar into a new window and reconcile slot panes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := stickyClient().Follow(); err != nil {
+			demuxlog.Warn("new_window: sidebar follow failed", "err", err)
+		}
+		if err := ensureSlots(); err != nil {
+			demuxlog.Warn("new_window: slots ensure failed", "err", err)
+		}
+		return nil
+	},
+}
+
 // eventClientAttachedCmd is fired by the demux managed-block bootstrap hook on
 // client-attached. It reconciles demux's tmux hook set (version-gated fast
 // path), auto-shows the sticky sidebar when configured, and warns when legacy
@@ -311,6 +372,12 @@ func init() {
 	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedWindowID, "window", "", "Stable window ID (@N format) of the killed pane's window (optional)")
 	eventPaneClosedCmd.MarkFlagRequired("pane")
 
-	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd, eventClientAttachedCmd)
+	for _, c := range []*cobra.Command{eventWindowFocusCmd, eventSessionChangedCmd} {
+		c.Flags().String("pane-id", "", "Stable pane ID (%N format)")
+		c.Flags().String("window-id", "", "Stable window ID (@N format)")
+		c.Flags().String("session-id", "", "Stable session ID ($N format)")
+	}
+
+	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd, eventClientAttachedCmd, eventWindowFocusCmd, eventSessionChangedCmd, eventNewWindowCmd)
 	rootCmd.AddCommand(eventCmd)
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -242,6 +242,26 @@ var eventNewWindowCmd = &cobra.Command{
 	},
 }
 
+// warnLegacyTmuxHooks logs a warning when old-style pasted demux hook lines
+// still linger outside the managed block in ~/.tmux.conf. Best-effort: any
+// failure to locate or read the config is silently skipped.
+func warnLegacyTmuxHooks() {
+	path, err := tmuxhooks.ConfPath()
+	if err != nil {
+		return
+	}
+	content, _, _, err := tmuxhooks.LoadConf(path)
+	if err != nil {
+		return
+	}
+	legacy := tmuxhooks.DetectLegacyHooks(content)
+	if len(legacy) == 0 {
+		return
+	}
+	demuxlog.Warn("client_attached: legacy demux hook lines in tmux.conf; run `demux hooks install` to remove them",
+		"count", len(legacy), "path", path)
+}
+
 // eventClientAttachedCmd is fired by the demux managed-block bootstrap hook on
 // client-attached. It reconciles demux's tmux hook set (version-gated fast
 // path), auto-shows the sticky sidebar when configured, and warns when legacy
@@ -264,14 +284,7 @@ var eventClientAttachedCmd = &cobra.Command{
 			}
 		}
 
-		if path, err := tmuxhooks.ConfPath(); err == nil {
-			if content, _, _, err := tmuxhooks.LoadConf(path); err == nil {
-				if legacy := tmuxhooks.DetectLegacyHooks(content); len(legacy) > 0 {
-					demuxlog.Warn("client_attached: legacy demux hook lines in tmux.conf; run `demux hooks install` to remove them",
-						"count", len(legacy), "path", path)
-				}
-			}
-		}
+		warnLegacyTmuxHooks()
 		return nil
 	},
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -378,6 +378,7 @@ func init() {
 		c.Flags().String("session-id", "", "Stable session ID ($N format); auto-detected if omitted")
 	}
 
+	rejectUnknownSubcommand(eventCmd)
 	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd, eventClientAttachedCmd, eventWindowFocusCmd, eventSessionChangedCmd, eventNewWindowCmd)
 	rootCmd.AddCommand(eventCmd)
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rtalexk/demux/internal/db"
 	demuxlog "github.com/rtalexk/demux/internal/log"
 	"github.com/rtalexk/demux/internal/sticky"
+	"github.com/rtalexk/demux/internal/tmuxhooks"
 	"github.com/spf13/cobra"
 )
 
@@ -180,6 +181,40 @@ var eventPaneClosedCmd = &cobra.Command{
 	},
 }
 
+// eventClientAttachedCmd is fired by the demux managed-block bootstrap hook on
+// client-attached. It reconciles demux's tmux hook set (version-gated fast
+// path), auto-shows the sticky sidebar when configured, and warns when legacy
+// pasted hook lines still linger in tmux.conf.
+var eventClientAttachedCmd = &cobra.Command{
+	Use:   "client_attached",
+	Short: "Reconcile demux tmux hooks and auto-show the sidebar (called by the client-attached hook)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_ = withEventLock(func() error {
+			if err := tmuxhooks.Sync(tmuxhooks.Real()); err != nil {
+				demuxlog.Warn("client_attached: hook sync failed", "err", err)
+			}
+			return nil
+		})
+
+		cfg := loadConfig()
+		if cfg.Sidebar.Sticky.AutoShow {
+			if err := stickyClient().Show(sidebarShowOpts()); err != nil {
+				demuxlog.Warn("client_attached: sidebar show failed", "err", err)
+			}
+		}
+
+		if path, err := tmuxhooks.ConfPath(); err == nil {
+			if content, _, _, err := tmuxhooks.LoadConf(path); err == nil {
+				if legacy := tmuxhooks.DetectLegacyHooks(content); len(legacy) > 0 {
+					demuxlog.Warn("client_attached: legacy demux hook lines in tmux.conf; run `demux hooks install` to remove them",
+						"count", len(legacy), "path", path)
+				}
+			}
+		}
+		return nil
+	},
+}
+
 // eventLockPath returns the path of the cross-process lock file that
 // serializes sticky-mutating tmux event handlers. It lives next to the state
 // database so it shares the demux data directory.
@@ -276,6 +311,6 @@ func init() {
 	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedWindowID, "window", "", "Stable window ID (@N format) of the killed pane's window (optional)")
 	eventPaneClosedCmd.MarkFlagRequired("pane")
 
-	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd)
+	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd, eventClientAttachedCmd)
 	rootCmd.AddCommand(eventCmd)
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -206,7 +206,7 @@ func runWindowFocus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if err := stickyClient().Follow(); err != nil {
-		demuxlog.Warn("window_focus: sidebar follow failed", "err", err)
+		demuxlog.Warn(cmd.Use+": sidebar follow failed", "err", err)
 	}
 	return nil
 }
@@ -373,9 +373,9 @@ func init() {
 	eventPaneClosedCmd.MarkFlagRequired("pane")
 
 	for _, c := range []*cobra.Command{eventWindowFocusCmd, eventSessionChangedCmd} {
-		c.Flags().String("pane-id", "", "Stable pane ID (%N format)")
-		c.Flags().String("window-id", "", "Stable window ID (@N format)")
-		c.Flags().String("session-id", "", "Stable session ID ($N format)")
+		c.Flags().String("pane-id", "", "Stable pane ID (%N format); auto-detected if omitted")
+		c.Flags().String("window-id", "", "Stable window ID (@N format); auto-detected if omitted")
+		c.Flags().String("session-id", "", "Stable session ID ($N format); auto-detected if omitted")
 	}
 
 	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd, eventClientAttachedCmd, eventWindowFocusCmd, eventSessionChangedCmd, eventNewWindowCmd)

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/sticky"
+	"github.com/spf13/cobra"
 )
 
 func paneTarget(paneID, windowID, sessionID string) db.Target {
@@ -231,5 +232,20 @@ func TestApplyPaneClosed_ClearsStickyEnvVar(t *testing.T) {
 	}
 	if !sawUnset {
 		t.Errorf("expected sticky env unset for %%42, got runs: %v", fake.runs)
+	}
+}
+
+func TestEventClientAttachedCommandRegistered(t *testing.T) {
+	var found *cobra.Command
+	for _, c := range eventCmd.Commands() {
+		if c.Use == "client_attached" {
+			found = c
+		}
+	}
+	if found == nil {
+		t.Fatal("event client_attached subcommand not registered")
+	}
+	if found.RunE == nil {
+		t.Error("client_attached command has no RunE")
 	}
 }

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -249,3 +249,20 @@ func TestEventClientAttachedCommandRegistered(t *testing.T) {
 		t.Error("client_attached command has no RunE")
 	}
 }
+
+func TestEventWindowEventsRegistered(t *testing.T) {
+	want := map[string]bool{"window_focus": false, "session_changed": false, "new_window": false}
+	for _, c := range eventCmd.Commands() {
+		if _, ok := want[c.Use]; ok {
+			want[c.Use] = true
+			if c.RunE == nil {
+				t.Errorf("%s command has no RunE", c.Use)
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("event %s subcommand not registered", name)
+		}
+	}
+}

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -36,6 +36,52 @@ func promptYesNo(r io.Reader, w io.Writer, question string) bool {
 	}
 }
 
+// reviewLegacyHooks reports any legacy (pre-managed-block) demux hook lines in
+// content, prompts the user to remove them, and returns content with the
+// confirmed removals applied. realPath is used only in the report. content is
+// returned unchanged when there are no legacy lines or the user declines.
+func reviewLegacyHooks(in io.Reader, out io.Writer, content, realPath string) string {
+	legacy := tmuxhooks.DetectLegacyHooks(content)
+	if len(legacy) == 0 {
+		return content
+	}
+	fmt.Fprintf(out, "Found %d legacy demux hook line(s) in %s:\n", len(legacy), realPath)
+	for _, l := range legacy {
+		fmt.Fprintf(out, "  L%d: %s\n", l.Number, strings.TrimSpace(l.Text))
+	}
+	if !promptYesNo(in, out, "Remove them and replace with the managed block?") {
+		fmt.Fprintln(out, "Kept legacy lines; they will be de-duplicated at runtime but should be removed.")
+		return content
+	}
+	nums := make([]int, len(legacy))
+	for i, l := range legacy {
+		nums[i] = l.Number
+	}
+	fmt.Fprintf(out, "Removed %d legacy line(s).\n", len(legacy))
+	return tmuxhooks.RemoveLines(content, nums)
+}
+
+// registerLiveHooks registers the bootstrap hook and demux's full hook set into
+// the running tmux server, then records the hook-set version. Failures are
+// reported as warnings on stderr, not returned: the managed block is already
+// written, so the next client attach reconciles even if no server is reachable.
+func registerLiveHooks(cmd *cobra.Command) {
+	out, errOut := cmd.OutOrStdout(), cmd.ErrOrStderr()
+	t := tmuxhooks.Real()
+	if err := t.Run("set-hook", "-g", tmuxhooks.BootstrapEvent, tmuxhooks.BootstrapCommand); err != nil {
+		fmt.Fprintf(errOut, "warning: live bootstrap registration failed (not in tmux?): %v\n", err)
+		return
+	}
+	if err := tmuxhooks.Reconcile(t); err != nil {
+		fmt.Fprintf(errOut, "warning: live hook reconcile failed: %v\n", err)
+		return
+	}
+	if err := tmuxhooks.MarkVersion(t); err != nil {
+		fmt.Fprintf(errOut, "warning: recording hook version failed: %v\n", err)
+	}
+	fmt.Fprintln(out, "Registered demux hooks in the live tmux server.")
+}
+
 var hooksInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install demux's tmux hooks into ~/.tmux.conf and the live server",
@@ -66,24 +112,7 @@ With --print-only, prints the bootstrap line and makes no changes.`,
 			return err
 		}
 
-		legacy := tmuxhooks.DetectLegacyHooks(content)
-		if len(legacy) > 0 {
-			fmt.Fprintf(out, "Found %d legacy demux hook line(s) in %s:\n", len(legacy), realPath)
-			for _, l := range legacy {
-				fmt.Fprintf(out, "  L%d: %s\n", l.Number, strings.TrimSpace(l.Text))
-			}
-			if promptYesNo(cmd.InOrStdin(), out, "Remove them and replace with the managed block?") {
-				nums := make([]int, len(legacy))
-				for i, l := range legacy {
-					nums[i] = l.Number
-				}
-				content = tmuxhooks.RemoveLines(content, nums)
-				fmt.Fprintf(out, "Removed %d legacy line(s).\n", len(legacy))
-			} else {
-				fmt.Fprintln(out, "Kept legacy lines; they will be de-duplicated at runtime but should be removed.")
-			}
-		}
-
+		content = reviewLegacyHooks(cmd.InOrStdin(), out, content, realPath)
 		content = tmuxhooks.WithManagedBlock(content)
 		if err := tmuxhooks.SaveConf(realPath, content); err != nil {
 			return err
@@ -94,19 +123,7 @@ With --print-only, prints the bootstrap line and makes no changes.`,
 			fmt.Fprintf(out, "Created %s\n", realPath)
 		}
 
-		t := tmuxhooks.Real()
-		if err := t.Run("set-hook", "-g", tmuxhooks.BootstrapEvent, tmuxhooks.BootstrapCommand()); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: live bootstrap registration failed (not in tmux?): %v\n", err)
-			return nil
-		}
-		if err := tmuxhooks.Reconcile(t); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: live hook reconcile failed: %v\n", err)
-			return nil
-		}
-		if err := tmuxhooks.MarkVersion(t); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: recording hook version failed: %v\n", err)
-		}
-		fmt.Fprintln(out, "Registered demux hooks in the live tmux server.")
+		registerLiveHooks(cmd)
 		return nil
 	},
 }

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -1,70 +1,143 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
-	"sort"
 	"strings"
 
 	"github.com/rtalexk/demux/internal/db"
+	"github.com/rtalexk/demux/internal/tmuxhooks"
 	"github.com/spf13/cobra"
 )
 
-var hooksInitTool string
+var (
+	hooksInstallTool      string
+	hooksInstallPrintOnly bool
+)
 
 var hooksCmd = &cobra.Command{
 	Use:   "hooks",
-	Short: "AI agent hook utilities",
+	Short: "Manage demux's tmux hooks",
 }
 
-var hooksInitCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Print hook configuration for an AI agent",
-	Long: `Prints a configuration snippet for the specified tool.
+// promptYesNo reads a line from r and returns true only for an affirmative
+// answer (y/yes, case-insensitive). Anything else, including EOF, is false.
+func promptYesNo(r io.Reader, w io.Writer, question string) bool {
+	fmt.Fprintf(w, "%s [y/N] ", question)
+	line, _ := bufio.NewReader(r).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
 
-Supported tools: tmux
+var hooksInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install demux's tmux hooks into ~/.tmux.conf and the live server",
+	Long: `Installs demux's tmux integration.
 
-For --tool tmux, prints hook lines to add to ~/.tmux.conf.`,
+Writes a one-line managed block to ~/.tmux.conf that bootstraps demux's
+self-registering hooks, and registers them in the running tmux server
+immediately. Re-running it is safe and idempotent.
+
+With --print-only, prints the bootstrap line and makes no changes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		def, err := resolveAgent(hooksInitTool)
+		if hooksInstallTool != "tmux" {
+			return fmt.Errorf("unknown tool %q: supported tools: tmux", hooksInstallTool)
+		}
+		out := cmd.OutOrStdout()
+
+		if hooksInstallPrintOnly {
+			fmt.Fprintln(out, tmuxhooks.BootstrapHook)
+			return nil
+		}
+
+		path, err := tmuxhooks.ConfPath()
 		if err != nil {
 			return err
 		}
-		fmt.Print(def.snippet)
+		content, realPath, existed, err := tmuxhooks.LoadConf(path)
+		if err != nil {
+			return err
+		}
+
+		legacy := tmuxhooks.DetectLegacyHooks(content)
+		if len(legacy) > 0 {
+			fmt.Fprintf(out, "Found %d legacy demux hook line(s) in %s:\n", len(legacy), realPath)
+			for _, l := range legacy {
+				fmt.Fprintf(out, "  L%d: %s\n", l.Number, strings.TrimSpace(l.Text))
+			}
+			if promptYesNo(cmd.InOrStdin(), out, "Remove them and replace with the managed block?") {
+				nums := make([]int, len(legacy))
+				for i, l := range legacy {
+					nums[i] = l.Number
+				}
+				content = tmuxhooks.RemoveLines(content, nums)
+				fmt.Fprintf(out, "Removed %d legacy line(s).\n", len(legacy))
+			} else {
+				fmt.Fprintln(out, "Kept legacy lines; they will be de-duplicated at runtime but should be removed.")
+			}
+		}
+
+		content = tmuxhooks.WithManagedBlock(content)
+		if err := tmuxhooks.SaveConf(realPath, content); err != nil {
+			return err
+		}
+		if existed {
+			fmt.Fprintf(out, "Updated %s (backup: %s.demux-bak)\n", realPath, realPath)
+		} else {
+			fmt.Fprintf(out, "Created %s\n", realPath)
+		}
+
+		t := tmuxhooks.Real()
+		if err := t.Run("set-hook", "-g", tmuxhooks.BootstrapEvent, tmuxhooks.BootstrapCommand()); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: live bootstrap registration failed (not in tmux?): %v\n", err)
+			return nil
+		}
+		if err := tmuxhooks.Reconcile(t); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: live hook reconcile failed: %v\n", err)
+			return nil
+		}
+		if err := tmuxhooks.MarkVersion(t); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: recording hook version failed: %v\n", err)
+		}
+		fmt.Fprintln(out, "Registered demux hooks in the live tmux server.")
 		return nil
 	},
 }
 
-type agentDef struct {
-	snippet string
-}
-
-var agentDefs = map[string]agentDef{
-	"tmux": {snippet: tmuxHooksSnippet},
-}
-
-func resolveAgent(name string) (agentDef, error) {
-	if def, ok := agentDefs[name]; ok {
-		return def, nil
-	}
-	supported := make([]string, 0, len(agentDefs))
-	for k := range agentDefs {
-		supported = append(supported, k)
-	}
-	sort.Strings(supported)
-	return agentDef{}, fmt.Errorf("unknown tool %q: supported tools: %s", name, strings.Join(supported, ", "))
+// hooksInitCmd is a hidden deprecated alias for `hooks install --print-only`.
+var hooksInitCmd = &cobra.Command{
+	Use:    "init",
+	Short:  "Deprecated: use `demux hooks install --print-only`",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintln(cmd.OutOrStdout(), tmuxhooks.BootstrapHook)
+		return nil
+	},
 }
 
 // tmuxCurrentIDs returns the stable pane, window, and session IDs for the
 // tmux pane that launched this process.
 func tmuxCurrentIDs() (paneID, windowID, sessionID string, err error) {
-	paneID = os.Getenv("TMUX_PANE") // $TMUX_PANE is set by tmux as %N
+	paneID = os.Getenv("TMUX_PANE")
 	if paneID == "" {
 		return "", "", "", fmt.Errorf("TMUX_PANE not set")
 	}
 	windowID, sessionID, err = tmuxParentIDs(paneID)
 	return paneID, windowID, sessionID, err
+}
+
+func init() {
+	hooksInstallCmd.Flags().StringVar(&hooksInstallTool, "tool", "tmux", "Tool to configure (supported: tmux)")
+	hooksInstallCmd.Flags().BoolVar(&hooksInstallPrintOnly, "print-only", false, "Print the bootstrap line without changing any files")
+	hooksCmd.AddCommand(hooksInstallCmd, hooksInitCmd)
+	rootCmd.AddCommand(hooksCmd)
 }
 
 // resolveParentIDs fills in parent window/session IDs on t by querying tmux.
@@ -112,92 +185,4 @@ func tmuxResolveTarget(target string) (paneID, windowID, sessionID string, err e
 		return "", "", "", fmt.Errorf("unexpected tmux output for %q", target)
 	}
 	return parts[0], parts[1], parts[2], nil
-}
-
-const tmuxHooksSnippet = `# demux tmux hooks
-# ──────────────────────────────────────────────────────────────────────────────
-# Paste the lines below into ~/.tmux.conf, then reload with:
-#   tmux source ~/.tmux.conf
-#
-# How it works:
-#   after-select-pane   — fires when you move focus between panes within a window.
-#   after-select-window — fires when you switch to a different window.
-#   client-session-changed — fires when you switch to a different session.
-#   All three are needed: each navigation action fires a different hook.
-#   Together they cover every way a pane can receive focus.
-#   after-kill-pane     — fires when a pane is closed; removes its state record.
-#
-# Flag syntax note: flags use --flag=value (not --flag value). tmux expands
-# #{session_id} to the raw tmux ID (e.g. $8). The shell then expands $8 as a
-# positional parameter, which is empty. With --flag value, an empty expansion
-# leaves the flag with no argument and the command fails. With --flag=value, an
-# empty expansion produces --flag= (empty string), which is valid.
-#
-# Idempotency note: the hooks below use -g (replace), not -ga (append), so
-# re-sourcing this file (e.g. via a stray after-new-session re-source hook)
-# replaces each hook in place instead of stacking duplicate copies. The two
-# follow hooks on shared events (client-session-changed, after-select-window)
-# keep -ga only because a -g line for the same event resets the array just
-# above them.
-# ──────────────────────────────────────────────────────────────────────────────
-
-# Clears Demux done states when switching between panes within the same window.
-set-hook -g after-select-pane   "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
-
-# Clears Demux done states when switching windows (after-select-pane does not fire for window switches).
-set-hook -g after-select-window "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
-
-# Clears Demux done states when switching sessions (after-select-window does not fire for session switches).
-set-hook -g client-session-changed "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
-
-# Clears Demux done states when switching back from another application.
-set-hook -g client-focus-in "run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'"
-
-# Removes Demux state when a pane is closed (prevents stale state accumulation).
-# #{hook_pane} is the killed pane's ID; #{pane_id} is the new active pane after
-# the kill - using #{pane_id} here would clear the wrong pane's state.
-# #{hook_window} lets demux detect a window left with only a sidebar slot pane
-# (e.g. the user closed the last non-slot pane) and clean it up.
-# run-shell -b backgrounds the handler so closing many panes at once (e.g.
-# 'demux sidebar hide' tearing down every sticky slot pane) never blocks tmux
-# input; concurrent handlers serialize on a file lock instead.
-set-hook -g after-kill-pane "run-shell -b 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
-
-# Sticky sidebar - proactively ejects the sidebar when the process running in a
-# pane exits and the sidebar would be the only pane left in that window. Fires
-# BEFORE after-kill-pane (while the exiting pane is still present), which makes
-# the sidebar return to the previous window without any stranded-sidebar flicker.
-# Complements after-kill-pane for cases where that hook is unreliable (e.g.
-# natural process exits in some tmux versions).
-# run-shell -b backgrounds the handler (see after-kill-pane above) so it never
-# blocks tmux input; it shares the pane_closed handler's file lock.
-set-hook -g pane-exited "run-shell -b 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'"
-
-# Sticky sidebar - moves the demux sidebar pane to the newly active session.
-set-hook -ga client-session-changed "run-shell 'demux sidebar follow 2>/dev/null; true'"
-
-# Sticky sidebar - moves the demux sidebar pane to the newly active window
-# (within the same session). join-pane uses -d so user focus is preserved.
-set-hook -ga after-select-window "run-shell 'demux sidebar follow 2>/dev/null; true'"
-
-# Sticky sidebar - moves the demux sidebar pane into a newly created window and
-# ensures that window gets a slot pane (slots mode; no-op when slots = false or
-# no slots are installed). tmux does NOT fire after-select-window for
-# new-window, so this separate hook is required.
-# run-shell -b backgrounds the handler so creating a window never blocks input
-# while the sidebar relocates. follow + slots ensure run sequentially in one
-# job so they never race each other.
-set-hook -g after-new-window "run-shell -b 'demux sidebar follow 2>/dev/null; demux sidebar slots ensure 2>/dev/null; true'"
-
-# Sticky sidebar auto-show on client attach. Remove this line if you prefer
-# to toggle the sticky sidebar manually with 'demux sidebar toggle'.
-set-hook -g client-attached "run-shell -b 'demux sidebar show 2>/dev/null; true'"
-# ──────────────────────────────────────────────────────────────────────────────
-`
-
-func init() {
-	hooksInitCmd.Flags().StringVar(&hooksInitTool, "tool", "", "Tool to configure (required): tmux")
-	hooksInitCmd.MarkFlagRequired("tool")
-	hooksCmd.AddCommand(hooksInitCmd)
-	rootCmd.AddCommand(hooksCmd)
 }

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -125,7 +125,7 @@ var hooksInitCmd = &cobra.Command{
 // tmuxCurrentIDs returns the stable pane, window, and session IDs for the
 // tmux pane that launched this process.
 func tmuxCurrentIDs() (paneID, windowID, sessionID string, err error) {
-	paneID = os.Getenv("TMUX_PANE")
+	paneID = os.Getenv("TMUX_PANE") // $TMUX_PANE is set by tmux as %N
 	if paneID == "" {
 		return "", "", "", fmt.Errorf("TMUX_PANE not set")
 	}
@@ -136,6 +136,7 @@ func tmuxCurrentIDs() (paneID, windowID, sessionID string, err error) {
 func init() {
 	hooksInstallCmd.Flags().StringVar(&hooksInstallTool, "tool", "tmux", "Tool to configure (supported: tmux)")
 	hooksInstallCmd.Flags().BoolVar(&hooksInstallPrintOnly, "print-only", false, "Print the bootstrap line without changing any files")
+	hooksInitCmd.Flags().String("tool", "tmux", "Deprecated and ignored; kept for backward compatibility")
 	hooksCmd.AddCommand(hooksInstallCmd, hooksInitCmd)
 	rootCmd.AddCommand(hooksCmd)
 }

--- a/cmd/hooks_test.go
+++ b/cmd/hooks_test.go
@@ -5,158 +5,31 @@ import (
 	"testing"
 )
 
-func TestResolveAgent_Unknown(t *testing.T) {
-	_, err := resolveAgent("aider")
-	if err == nil {
-		t.Fatal("expected error for unknown agent")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "aider") {
-		t.Errorf("error should mention the bad value, got: %s", msg)
-	}
-	if !strings.Contains(msg, "tmux") {
-		t.Errorf("error should list tmux as supported agent, got: %s", msg)
-	}
-}
-
-func TestResolveAgent_Tmux(t *testing.T) {
-	def, err := resolveAgent("tmux")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if def.snippet != tmuxHooksSnippet {
-		t.Errorf("snippet mismatch")
-	}
-}
-
-func TestTmuxHooksSnippet_ContainsAfterSelectPane(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "after-select-pane") {
-		t.Error("tmuxHooksSnippet should reference after-select-pane hook")
-	}
-	if !strings.Contains(tmuxHooksSnippet, "demux event pane_focus") {
-		t.Error("tmuxHooksSnippet should call demux event pane_focus")
-	}
-}
-
-func TestTmuxHooksSnippet_ContainsAfterKillPane(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "after-kill-pane") {
-		t.Error("hooks snippet should include after-kill-pane hook for GC")
-	}
-	if !strings.Contains(tmuxHooksSnippet, "pane_closed") {
-		t.Error("hooks snippet after-kill-pane hook should call demux event pane_closed")
-	}
-}
-
-func TestTmuxHooksSnippet_KillHooksBackgrounded(t *testing.T) {
-	// after-kill-pane and pane-exited can fire in a burst when many panes close
-	// at once (e.g. `demux sidebar hide` tearing down every sticky slot pane).
-	// They must run with `run-shell -b` so the cleanup never blocks tmux input.
-	for _, line := range strings.Split(tmuxHooksSnippet, "\n") {
-		if !strings.HasPrefix(line, "set-hook") {
-			continue
-		}
-		if strings.Contains(line, "after-kill-pane") || strings.Contains(line, "pane-exited") {
-			if !strings.Contains(line, "run-shell -b") {
-				t.Errorf("kill-related hook must use 'run-shell -b':\n  %s", line)
-			}
+func TestPromptYesNo(t *testing.T) {
+	cases := map[string]bool{"y\n": true, "Y\n": true, "yes\n": true, "n\n": false, "\n": false, "": false}
+	for in, want := range cases {
+		got := promptYesNo(strings.NewReader(in), &strings.Builder{}, "ok?")
+		if got != want {
+			t.Errorf("promptYesNo(%q) = %v, want %v", in, got, want)
 		}
 	}
 }
 
-func TestTmuxHooksSnippet_ContainsPaneExitedHook(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "pane-exited") {
-		t.Error("snippet should include pane-exited hook for proactive sidebar eject")
-	}
-	if !strings.Contains(tmuxHooksSnippet, "pane_exiting") {
-		t.Error("pane-exited hook should call demux event pane_exiting")
-	}
-	// Must use #{hook_pane}/#{hook_window}, not #{pane_id}/#{window_id}: in global
-	// hooks #{pane_id} resolves to the surviving pane (focus already shifted), not
-	// the one that triggered pane-exited.
-	if !strings.Contains(tmuxHooksSnippet, "--pane=#{hook_pane}") {
-		t.Error("pane_exiting hook must pass --pane=#{hook_pane}, not --pane=#{pane_id}")
-	}
-	if !strings.Contains(tmuxHooksSnippet, "--window=#{hook_window}") {
-		t.Error("pane_exiting hook must pass --window=#{hook_window}, not --window=#{window_id}")
-	}
-}
-
-func TestTmuxHooksSnippet_PaneFocusIncludesPaneID(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "--pane-id=#{pane_id}") {
-		t.Error("pane_focus hooks should pass --pane-id=#{pane_id}")
-	}
-}
-
-func TestTmuxHooksSnippet_ContainsStickyFollowHook(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "client-session-changed") {
-		t.Error("snippet should still include client-session-changed hook")
-	}
-	if !strings.Contains(tmuxHooksSnippet, "demux sidebar follow") {
-		t.Error("snippet should include 'demux sidebar follow' hook for sticky sidebar")
-	}
-	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga client-session-changed") {
-		t.Error("sticky follow hook should use -ga (append), not -g (overwrite)")
-	}
-}
-
-func TestTmuxHooksSnippet_ContainsStickyWindowFollowHook(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "set-hook -ga after-select-window") {
-		t.Error("snippet should include after-select-window -ga hook for sticky window follow")
-	}
-}
-
-func TestTmuxHooksSnippet_ContainsStickySlotsEnsureHook(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "set-hook -g after-new-window") {
-		t.Error("snippet should include after-new-window hook for slots ensure")
-	}
-	if !strings.Contains(tmuxHooksSnippet, "demux sidebar slots ensure") {
-		t.Error("after-new-window hook should call 'demux sidebar slots ensure'")
-	}
-}
-
-func TestTmuxHooksSnippet_ContainsStickyNewWindowFollowHook(t *testing.T) {
-	// after-select-window does NOT fire when a window is created via new-window
-	// (tmux fires after-new-window instead), so the after-new-window hook must
-	// move the sidebar into the fresh window. It uses -g (replace), not -ga, so
-	// re-sourcing ~/.tmux.conf cannot stack duplicate copies, and run-shell -b
-	// so window creation never blocks on the handler.
-	found := false
-	for _, line := range strings.Split(tmuxHooksSnippet, "\n") {
-		if strings.HasPrefix(line, "set-hook -g after-new-window") &&
-			strings.Contains(line, "demux sidebar follow") &&
-			strings.Contains(line, "run-shell -b") {
-			found = true
-			break
+func TestHooksInstallCommandRegistered(t *testing.T) {
+	var install, initCmd bool
+	for _, c := range hooksCmd.Commands() {
+		switch c.Use {
+		case "install":
+			install = true
+		case "init":
+			initCmd = true
 		}
 	}
-	if !found {
-		t.Error("snippet should bind 'demux sidebar follow' to after-new-window via 'set-hook -g' with 'run-shell -b'")
+	if !install {
+		t.Error("hooks install subcommand not registered")
 	}
-}
-
-func TestTmuxHooksSnippet_ContainsStickyAutoShowHook(t *testing.T) {
-	if !strings.Contains(tmuxHooksSnippet, "set-hook -g client-attached") {
-		t.Error("snippet should include client-attached hook for sticky auto-show")
-	}
-	if !strings.Contains(tmuxHooksSnippet, "demux sidebar show") {
-		t.Error("snippet should call 'demux sidebar show' on client-attached")
-	}
-}
-
-func TestTmuxHooksSnippet_NonSharedHooksAreIdempotent(t *testing.T) {
-	// after-new-window, client-attached and pane-exited have no -g reset line
-	// for their event elsewhere in the snippet, so they must use -g (replace),
-	// not -ga (append). With -ga, re-sourcing ~/.tmux.conf stacks a duplicate
-	// copy every time, eventually spawning dozens of demux processes per event.
-	for _, line := range strings.Split(tmuxHooksSnippet, "\n") {
-		if !strings.HasPrefix(line, "set-hook") {
-			continue
-		}
-		for _, ev := range []string{"after-new-window", "client-attached", "pane-exited"} {
-			if strings.Contains(line, ev) && strings.Contains(line, "-ga") {
-				t.Errorf("%s hook must use -g (not -ga) to stay idempotent on re-source:\n  %s", ev, line)
-			}
-		}
+	if !initCmd {
+		t.Error("hooks init alias should remain registered (hidden)")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,6 +92,22 @@ func Execute() {
 	}
 }
 
+// rejectUnknownSubcommand makes a parent (group) command fail loudly — an error
+// on stderr with a non-zero exit — when invoked with an unknown subcommand,
+// instead of cobra's default for a non-runnable parent: printing the command's
+// help to stdout with a zero exit. demux's tmux hooks call subcommands as
+// `demux … 2>/dev/null`; if a hook references a since-removed subcommand, this
+// keeps the failure silent (swallowed by 2>/dev/null) rather than dumping help
+// text into the pane. Invoked bare (no subcommand) it still prints help.
+func rejectUnknownSubcommand(c *cobra.Command) {
+	c.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+		}
+		return cmd.Help()
+	}
+}
+
 func init() {
 	rootCmd.Version = Version
 	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "", "Output format: text|table|json")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// A tmux hook that calls a since-removed demux subcommand must fail silently:
+// an error on stderr with a non-zero exit, so the hook's `2>/dev/null` swallows
+// it. Cobra's default for a non-runnable parent command is to print the help
+// text to stdout with a zero exit, which leaks help into the tmux pane.
+func TestGroupCommandsRejectUnknownSubcommand(t *testing.T) {
+	groups := map[string]*cobra.Command{
+		"event":         eventCmd,
+		"sidebar":       sidebarCmd,
+		"sidebar slots": sidebarSlotsCmd,
+	}
+	for name, c := range groups {
+		if c.RunE == nil {
+			t.Errorf("%s: group command must have a RunE that rejects unknown subcommands", name)
+			continue
+		}
+		if err := c.RunE(c, []string{"definitely-not-a-real-subcommand"}); err == nil {
+			t.Errorf("%s: unknown subcommand must return an error, got nil", name)
+		}
+	}
+}

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -63,18 +63,6 @@ var sidebarToggleCmd = &cobra.Command{
 	},
 }
 
-var sidebarFollowCmd = &cobra.Command{
-	Use:    "follow",
-	Short:  "Internal: move the sticky sidebar pane to the current session",
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := stickyClient().Follow(); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "demux sidebar follow: %v\n", err)
-		}
-		return nil
-	},
-}
-
 var sidebarSlotsCmd = &cobra.Command{
 	Use:   "slots",
 	Short: "Manage per-window sidebar slots (sidebar.sticky.slots mode)",
@@ -126,15 +114,6 @@ func ensureSlots() error {
 	return s.ReconcileSlots(reserved, parts[1], cfg.Sidebar.Sticky.Width)
 }
 
-var sidebarSlotsEnsureCmd = &cobra.Command{
-	Use:    "ensure",
-	Short:  "Internal: reconcile slot panes against the MRU budget (called by tmux hook)",
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return ensureSlots()
-	},
-}
-
 var sidebarSlotCmd = &cobra.Command{
 	Use:    "slot",
 	Short:  "Internal: placeholder process for an inactive sticky sidebar slot",
@@ -172,7 +151,7 @@ func runSidebarSlotPlaceholder(w io.Writer) {
 }
 
 func init() {
-	sidebarSlotsCmd.AddCommand(sidebarSlotsInstallCmd, sidebarSlotsUninstallCmd, sidebarSlotsEnsureCmd)
-	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarFollowCmd, sidebarSlotCmd, sidebarSlotsCmd)
+	sidebarSlotsCmd.AddCommand(sidebarSlotsInstallCmd, sidebarSlotsUninstallCmd)
+	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarSlotCmd, sidebarSlotsCmd)
 	rootCmd.AddCommand(sidebarCmd)
 }

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -97,34 +97,41 @@ var sidebarSlotsUninstallCmd = &cobra.Command{
 	},
 }
 
+// ensureSlots reconciles sidebar slot panes against the MRU budget. It is a
+// no-op when slots mode is disabled or no slot panes have been installed.
+// Called by the after-new-window hook via `demux event new_window`.
+func ensureSlots() error {
+	cfg := loadConfig()
+	if !cfg.Sidebar.Sticky.Slots {
+		return nil
+	}
+	s := stickyClient()
+	any, err := s.AnySlotExists()
+	if err != nil || !any {
+		return err
+	}
+	target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+	if err != nil {
+		return err
+	}
+	parts := strings.SplitN(strings.TrimSpace(target), ":", 2)
+	if len(parts) < 2 {
+		return nil
+	}
+	_ = s.PruneMRU()
+	reserved, err := s.ComputeReservedWindows(parts[1], parts[0])
+	if err != nil {
+		return err
+	}
+	return s.ReconcileSlots(reserved, parts[1], cfg.Sidebar.Sticky.Width)
+}
+
 var sidebarSlotsEnsureCmd = &cobra.Command{
 	Use:    "ensure",
 	Short:  "Internal: reconcile slot panes against the MRU budget (called by tmux hook)",
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg := loadConfig()
-		if !cfg.Sidebar.Sticky.Slots {
-			return nil
-		}
-		s := stickyClient()
-		any, err := s.AnySlotExists()
-		if err != nil || !any {
-			return err
-		}
-		target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
-		if err != nil {
-			return err
-		}
-		parts := strings.SplitN(strings.TrimSpace(target), ":", 2)
-		if len(parts) < 2 {
-			return nil
-		}
-		_ = s.PruneMRU()
-		reserved, err := s.ComputeReservedWindows(parts[1], parts[0])
-		if err != nil {
-			return err
-		}
-		return s.ReconcileSlots(reserved, parts[1], cfg.Sidebar.Sticky.Width)
+		return ensureSlots()
 	},
 }
 

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -151,6 +151,8 @@ func runSidebarSlotPlaceholder(w io.Writer) {
 }
 
 func init() {
+	rejectUnknownSubcommand(sidebarCmd)
+	rejectUnknownSubcommand(sidebarSlotsCmd)
 	sidebarSlotsCmd.AddCommand(sidebarSlotsInstallCmd, sidebarSlotsUninstallCmd)
 	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarSlotCmd, sidebarSlotsCmd)
 	rootCmd.AddCommand(sidebarCmd)

--- a/cmd/sidebar_test.go
+++ b/cmd/sidebar_test.go
@@ -17,7 +17,7 @@ func TestSidebarCmd_Registered(t *testing.T) {
 }
 
 func TestSidebarCmd_Subcommands(t *testing.T) {
-	for _, sub := range []string{"toggle", "show", "hide", "follow"} {
+	for _, sub := range []string{"toggle", "show", "hide"} {
 		cmd, _, _ := rootCmd.Find([]string{"sidebar", sub})
 		if cmd == nil || cmd.Name() != sub {
 			t.Errorf("expected `demux sidebar %s`, got %v", sub, cmd)
@@ -25,32 +25,12 @@ func TestSidebarCmd_Subcommands(t *testing.T) {
 	}
 }
 
-func TestSidebarCmd_FollowIsHidden(t *testing.T) {
-	cmd, _, _ := rootCmd.Find([]string{"sidebar", "follow"})
-	if cmd == nil {
-		t.Fatal("follow subcommand missing")
-	}
-	if !cmd.Hidden {
-		t.Errorf("follow should be hidden from --help")
-	}
-}
-
 func TestSidebarCmd_SlotsSubcommands(t *testing.T) {
-	for _, sub := range []string{"install", "uninstall", "ensure"} {
+	for _, sub := range []string{"install", "uninstall"} {
 		cmd, _, _ := rootCmd.Find([]string{"sidebar", "slots", sub})
 		if cmd == nil || cmd.Name() != sub {
 			t.Errorf("expected `demux sidebar slots %s`, got %v", sub, cmd)
 		}
-	}
-}
-
-func TestSidebarCmd_SlotsEnsureHidden(t *testing.T) {
-	cmd, _, _ := rootCmd.Find([]string{"sidebar", "slots", "ensure"})
-	if cmd == nil {
-		t.Fatal("ensure subcommand missing")
-	}
-	if !cmd.Hidden {
-		t.Errorf("slots ensure should be hidden from --help")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -244,6 +244,7 @@ type SidebarStickyConfig struct {
 	Slots                  bool `toml:"slots"`
 	FocusOnOpen            bool `toml:"focus_on_open"`
 	FocusBeforeToggleClose bool `toml:"focus_before_toggle_close"`
+	AutoShow               bool `toml:"auto_show"`
 }
 
 type SidebarConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -968,3 +968,24 @@ func TestSidebarSticky_LoadOverridesFocusFlags(t *testing.T) {
 		t.Errorf("focus_before_toggle_close override: want true, got false")
 	}
 }
+
+func TestAutoShowDefaultsFalse(t *testing.T) {
+	if config.Default().Sidebar.Sticky.AutoShow {
+		t.Error("Sidebar.Sticky.AutoShow should default to false")
+	}
+}
+
+func TestAutoShowParsesFromTOML(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/demux.toml"
+	if err := os.WriteFile(path, []byte("[sidebar.sticky]\nauto_show = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Sidebar.Sticky.AutoShow {
+		t.Error("auto_show = true did not parse into Sidebar.Sticky.AutoShow")
+	}
+}

--- a/internal/tmuxhooks/conffile.go
+++ b/internal/tmuxhooks/conffile.go
@@ -102,7 +102,7 @@ func SaveConf(realPath, content string) error {
 	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpName)
-		return err
+		return fmt.Errorf("close temp: %w", err)
 	}
 	if err := os.Rename(tmpName, realPath); err != nil {
 		os.Remove(tmpName)

--- a/internal/tmuxhooks/conffile.go
+++ b/internal/tmuxhooks/conffile.go
@@ -1,0 +1,112 @@
+package tmuxhooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	markerBegin = "# >>> demux managed block >>>"
+	markerEnd   = "# <<< demux managed block <<<"
+
+	// bootstrapCommand is the run-shell payload of the bootstrap hook.
+	bootstrapCommand = `run-shell -b 'demux event client_attached 2>/dev/null; true'`
+)
+
+// BootstrapEvent is the tmux hook event demux's bootstrap line registers.
+const BootstrapEvent = "client-attached"
+
+// BootstrapHook is the single set-hook line demux's managed block installs in
+// ~/.tmux.conf. It fires demux's reconciler on every client attach.
+var BootstrapHook = fmt.Sprintf("set-hook -g %s %q", BootstrapEvent, bootstrapCommand)
+
+// BootstrapCommand returns the run-shell payload for live registration via
+// `tmux set-hook -g client-attached <payload>`.
+func BootstrapCommand() string { return bootstrapCommand }
+
+// managedBlock returns the full marker-delimited block text (no trailing
+// newline).
+func managedBlock() string {
+	return markerBegin + "\n" + BootstrapHook + "\n" + markerEnd
+}
+
+// ConfPath returns the path to the user's tmux config (~/.tmux.conf).
+func ConfPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".tmux.conf"), nil
+}
+
+// LoadConf reads the tmux config at path, following a symlink to its real
+// target. It returns the file content, the real (symlink-resolved) path to
+// write back to, and whether the file existed.
+func LoadConf(path string) (content, realPath string, existed bool, err error) {
+	realPath = path
+	if target, rerr := os.Readlink(path); rerr == nil {
+		if filepath.IsAbs(target) {
+			realPath = target
+		} else {
+			realPath = filepath.Join(filepath.Dir(path), target)
+		}
+	}
+	b, rerr := os.ReadFile(realPath)
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return "", realPath, false, nil
+		}
+		return "", realPath, false, fmt.Errorf("read %s: %w", realPath, rerr)
+	}
+	return string(b), realPath, true, nil
+}
+
+// WithManagedBlock returns content with demux's managed block inserted. If the
+// markers already exist the block is replaced in place; otherwise it is
+// appended with one blank line of separation.
+func WithManagedBlock(content string) string {
+	begin := strings.Index(content, markerBegin)
+	end := strings.Index(content, markerEnd)
+	if begin >= 0 && end > begin {
+		return content[:begin] + managedBlock() + content[end+len(markerEnd):]
+	}
+	trimmed := strings.TrimRight(content, "\n")
+	if trimmed == "" {
+		return managedBlock() + "\n"
+	}
+	return trimmed + "\n\n" + managedBlock() + "\n"
+}
+
+// SaveConf writes content to realPath atomically (temp file + rename) after
+// backing up the existing file to <realPath>.demux-bak.
+func SaveConf(realPath, content string) error {
+	if existing, err := os.ReadFile(realPath); err == nil {
+		if err := os.WriteFile(realPath+".demux-bak", existing, 0o644); err != nil {
+			return fmt.Errorf("write backup: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read for backup: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(realPath), ".demux-tmuxconf-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, realPath); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename temp: %w", err)
+	}
+	return nil
+}

--- a/internal/tmuxhooks/conffile.go
+++ b/internal/tmuxhooks/conffile.go
@@ -11,21 +11,18 @@ import (
 const (
 	markerBegin = "# >>> demux managed block >>>"
 	markerEnd   = "# <<< demux managed block <<<"
-
-	// bootstrapCommand is the run-shell payload of the bootstrap hook.
-	bootstrapCommand = `run-shell -b 'demux event client_attached 2>/dev/null; true'`
 )
 
 // BootstrapEvent is the tmux hook event demux's bootstrap line registers.
 const BootstrapEvent = "client-attached"
 
+// BootstrapCommand is the run-shell payload of the bootstrap hook, used for
+// live registration via `tmux set-hook -g client-attached <payload>`.
+const BootstrapCommand = `run-shell -b 'demux event client_attached 2>/dev/null; true'`
+
 // BootstrapHook is the single set-hook line demux's managed block installs in
 // ~/.tmux.conf. It fires demux's reconciler on every client attach.
-var BootstrapHook = fmt.Sprintf("set-hook -g %s %q", BootstrapEvent, bootstrapCommand)
-
-// BootstrapCommand returns the run-shell payload for live registration via
-// `tmux set-hook -g client-attached <payload>`.
-func BootstrapCommand() string { return bootstrapCommand }
+var BootstrapHook = fmt.Sprintf("set-hook -g %s %q", BootstrapEvent, BootstrapCommand)
 
 // managedBlock returns the full marker-delimited block text (no trailing
 // newline).

--- a/internal/tmuxhooks/conffile.go
+++ b/internal/tmuxhooks/conffile.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -109,4 +110,56 @@ func SaveConf(realPath, content string) error {
 		return fmt.Errorf("rename temp: %w", err)
 	}
 	return nil
+}
+
+// legacyHookRE matches a tmux set-hook line that registers a demux command,
+// i.e. a line from the old pasted snippet. Comment lines (leading #) and lines
+// that do not start with set-hook are excluded.
+var legacyHookRE = regexp.MustCompile(`^\s*set-hook\b.*\bdemux (event|sidebar)\b`)
+
+// LegacyLine is a recognized old-snippet hook line found outside the managed
+// block.
+type LegacyLine struct {
+	Number int // 1-based line number
+	Text   string
+}
+
+// DetectLegacyHooks finds old-style demux hook lines outside the managed
+// block. Lines inside the managed block (including the bootstrap line) are
+// never reported.
+func DetectLegacyHooks(content string) []LegacyLine {
+	var out []LegacyLine
+	inBlock := false
+	for i, line := range strings.Split(content, "\n") {
+		switch {
+		case strings.Contains(line, markerBegin):
+			inBlock = true
+			continue
+		case strings.Contains(line, markerEnd):
+			inBlock = false
+			continue
+		}
+		if inBlock {
+			continue
+		}
+		if legacyHookRE.MatchString(line) {
+			out = append(out, LegacyLine{Number: i + 1, Text: line})
+		}
+	}
+	return out
+}
+
+// RemoveLines returns content with the given 1-based line numbers removed.
+func RemoveLines(content string, numbers []int) string {
+	drop := make(map[int]bool, len(numbers))
+	for _, n := range numbers {
+		drop[n] = true
+	}
+	var kept []string
+	for i, line := range strings.Split(content, "\n") {
+		if !drop[i+1] {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
 }

--- a/internal/tmuxhooks/conffile_test.go
+++ b/internal/tmuxhooks/conffile_test.go
@@ -1,0 +1,75 @@
+package tmuxhooks
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWithManagedBlockAppendsWhenAbsent(t *testing.T) {
+	got := WithManagedBlock("set -g mouse on\n")
+	if !strings.Contains(got, markerBegin) || !strings.Contains(got, markerEnd) {
+		t.Fatalf("managed block markers missing:\n%s", got)
+	}
+	if !strings.Contains(got, "set -g mouse on") {
+		t.Errorf("original content lost:\n%s", got)
+	}
+	if !strings.Contains(got, BootstrapHook) {
+		t.Errorf("bootstrap line missing:\n%s", got)
+	}
+}
+
+func TestWithManagedBlockReplacesInPlace(t *testing.T) {
+	first := WithManagedBlock("# top\n")
+	second := WithManagedBlock(first)
+	if first != second {
+		t.Errorf("WithManagedBlock not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	if strings.Count(second, markerBegin) != 1 {
+		t.Errorf("want exactly one managed block, got %d", strings.Count(second, markerBegin))
+	}
+}
+
+func TestSaveConfBacksUpAndWrites(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/.tmux.conf"
+	if err := os.WriteFile(path, []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveConf(path, "updated\n"); err != nil {
+		t.Fatalf("SaveConf: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "updated\n" {
+		t.Errorf("file not updated: %q", got)
+	}
+	bak, err := os.ReadFile(path + ".demux-bak")
+	if err != nil {
+		t.Fatalf("backup not written: %v", err)
+	}
+	if string(bak) != "original\n" {
+		t.Errorf("backup wrong: %q", bak)
+	}
+}
+
+func TestLoadConfResolvesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	real := dir + "/real.conf"
+	link := dir + "/link.conf"
+	if err := os.WriteFile(real, []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	content, realPath, existed, err := LoadConf(link)
+	if err != nil || !existed {
+		t.Fatalf("LoadConf: existed=%v err=%v", existed, err)
+	}
+	if content != "hi\n" {
+		t.Errorf("content = %q", content)
+	}
+	if realPath != real {
+		t.Errorf("realPath = %q, want %q", realPath, real)
+	}
+}

--- a/internal/tmuxhooks/conffile_test.go
+++ b/internal/tmuxhooks/conffile_test.go
@@ -73,3 +73,35 @@ func TestLoadConfResolvesSymlink(t *testing.T) {
 		t.Errorf("realPath = %q, want %q", realPath, real)
 	}
 }
+
+func TestDetectLegacyHooks(t *testing.T) {
+	content := strings.Join([]string{
+		"set -g mouse on", // 1: not a hook
+		`set-hook -g after-select-pane "run-shell 'demux event pane_focus'"`, // 2: legacy
+		"# set-hook -g foo 'demux event bar'",                                // 3: comment, ignored
+		`set-hook -ga after-new-window "run-shell 'demux sidebar follow'"`,   // 4: legacy
+		`set-hook -g client-resized 'run-shell "other tool"'`,                // 5: not demux
+	}, "\n")
+	got := DetectLegacyHooks(content)
+	if len(got) != 2 {
+		t.Fatalf("want 2 legacy lines, got %d: %+v", len(got), got)
+	}
+	if got[0].Number != 2 || got[1].Number != 4 {
+		t.Errorf("wrong line numbers: %+v", got)
+	}
+}
+
+func TestDetectLegacyHooksIgnoresManagedBlock(t *testing.T) {
+	content := WithManagedBlock("set -g mouse on\n")
+	if got := DetectLegacyHooks(content); len(got) != 0 {
+		t.Errorf("bootstrap line inside managed block must not be flagged: %+v", got)
+	}
+}
+
+func TestRemoveLines(t *testing.T) {
+	content := "a\nb\nc\nd\n"
+	got := RemoveLines(content, []int{2, 4})
+	if got != "a\nc\n" {
+		t.Errorf("RemoveLines = %q, want %q", got, "a\nc\n")
+	}
+}

--- a/internal/tmuxhooks/conffile_test.go
+++ b/internal/tmuxhooks/conffile_test.go
@@ -98,6 +98,23 @@ func TestDetectLegacyHooksIgnoresManagedBlock(t *testing.T) {
 	}
 }
 
+func TestDetectLegacyHooksBeforeAndAfterBlock(t *testing.T) {
+	content := strings.Join([]string{
+		`set-hook -g after-select-pane "run-shell 'demux event pane_focus'"`, // 1: legacy, before block
+		markerBegin,
+		`set-hook -g client-attached "run-shell 'demux event client_attached'"`, // 3: inside block, skipped
+		markerEnd,
+		`set-hook -ga after-new-window "run-shell 'demux sidebar follow'"`, // 5: legacy, after block
+	}, "\n")
+	got := DetectLegacyHooks(content)
+	if len(got) != 2 {
+		t.Fatalf("want 2 legacy lines, got %d: %+v", len(got), got)
+	}
+	if got[0].Number != 1 || got[1].Number != 5 {
+		t.Errorf("wrong line numbers: %+v", got)
+	}
+}
+
 func TestRemoveLines(t *testing.T) {
 	content := "a\nb\nc\nd\n"
 	got := RemoveLines(content, []int{2, 4})

--- a/internal/tmuxhooks/fake_test.go
+++ b/internal/tmuxhooks/fake_test.go
@@ -38,6 +38,15 @@ func (f *fakeTmux) Output(args ...string) (string, error) {
 	return out, nil
 }
 
+// scriptShowHooks scripts the per-event `show-hooks -g <event>` responses for
+// every demux event. Events absent from byEvent return empty output; pass nil
+// for "every event empty".
+func (f *fakeTmux) scriptShowHooks(byEvent map[string]string) {
+	for _, h := range DesiredHooks() {
+		f.outputs["show-hooks -g "+h.Event] = byEvent[h.Event]
+	}
+}
+
 // runStrings returns every recorded Run call as a space-joined string.
 func (f *fakeTmux) runStrings() []string {
 	var out []string

--- a/internal/tmuxhooks/fake_test.go
+++ b/internal/tmuxhooks/fake_test.go
@@ -1,0 +1,50 @@
+package tmuxhooks
+
+import (
+	"fmt"
+	"strings"
+)
+
+// fakeTmux records Run calls and returns scripted Output responses.
+type fakeTmux struct {
+	outputs map[string]string // key: space-joined args -> stdout
+	errs    map[string]error  // key: space-joined args -> error
+	runs    [][]string        // every Run call, in order
+}
+
+func newFakeTmux() *fakeTmux {
+	return &fakeTmux{outputs: map[string]string{}, errs: map[string]error{}}
+}
+
+func key(args []string) string { return strings.Join(args, " ") }
+
+func (f *fakeTmux) Run(args ...string) error {
+	f.runs = append(f.runs, append([]string(nil), args...))
+	if err, ok := f.errs[key(args)]; ok {
+		return err
+	}
+	return nil
+}
+
+func (f *fakeTmux) Output(args ...string) (string, error) {
+	k := key(args)
+	if err, ok := f.errs[k]; ok {
+		return "", err
+	}
+	out, ok := f.outputs[k]
+	if !ok {
+		return "", fmt.Errorf("fakeTmux: no scripted output for %q", k)
+	}
+	return out, nil
+}
+
+// runStrings returns every recorded Run call as a space-joined string.
+func (f *fakeTmux) runStrings() []string {
+	var out []string
+	for _, r := range f.runs {
+		out = append(out, strings.Join(r, " "))
+	}
+	return out
+}
+
+var _ Tmux = (*fakeTmux)(nil)

--- a/internal/tmuxhooks/hooks.go
+++ b/internal/tmuxhooks/hooks.go
@@ -1,0 +1,54 @@
+// Package tmuxhooks defines demux's tmux hook set and keeps a running tmux
+// server registered with it. The hook definitions live here as structured
+// data so the runtime reconciler and `demux hooks install` share one source
+// of truth.
+package tmuxhooks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// Hook is one demux-owned tmux hook entry: a tmux hook event and the
+// run-shell command registered on it.
+type Hook struct {
+	Event   string
+	Command string
+}
+
+// DesiredHooks returns demux's full canonical hook set. The client-attached
+// bootstrap hook is intentionally excluded: it is owned by the demux managed
+// block in ~/.tmux.conf and is what triggers reconciliation, so the
+// reconciler must never manage it.
+func DesiredHooks() []Hook {
+	const paneFocus = `run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'`
+	const follow = `run-shell 'demux sidebar follow 2>/dev/null; true'`
+	return []Hook{
+		{Event: "after-select-pane", Command: paneFocus},
+		{Event: "after-select-window", Command: paneFocus},
+		{Event: "after-select-window", Command: follow},
+		{Event: "client-session-changed", Command: paneFocus},
+		{Event: "client-session-changed", Command: follow},
+		{Event: "client-focus-in", Command: paneFocus},
+		{Event: "after-kill-pane", Command: `run-shell -b 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'`},
+		{Event: "pane-exited", Command: `run-shell -b 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'`},
+		{Event: "after-new-window", Command: `run-shell -b 'demux sidebar follow 2>/dev/null; demux sidebar slots ensure 2>/dev/null; true'`},
+	}
+}
+
+// HooksHash returns a stable 12-hex-char hash of the desired hook set. It
+// changes exactly when DesiredHooks changes, so an upgraded demux binary
+// triggers exactly one reconcile. Stored in the @demux_hooks_version tmux
+// option as the staleness key.
+func HooksHash() string {
+	var b strings.Builder
+	for _, h := range DesiredHooks() {
+		b.WriteString(h.Event)
+		b.WriteByte('\n')
+		b.WriteString(h.Command)
+		b.WriteByte('\n')
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])[:12]
+}

--- a/internal/tmuxhooks/hooks.go
+++ b/internal/tmuxhooks/hooks.go
@@ -17,23 +17,24 @@ type Hook struct {
 	Command string
 }
 
-// DesiredHooks returns demux's full canonical hook set. The client-attached
-// bootstrap hook is intentionally excluded: it is owned by the demux managed
-// block in ~/.tmux.conf and is what triggers reconciliation, so the
-// reconciler must never manage it.
+// DesiredHooks returns demux's full canonical hook set. Each entry calls a
+// `demux event …` command that names the tmux event; the event handler decides
+// the reaction (clear done-states, move the sidebar, reconcile slot panes). The
+// client-attached bootstrap hook is intentionally excluded: it is owned by the
+// demux managed block in ~/.tmux.conf and is what triggers reconciliation, so
+// the reconciler must never manage it.
 func DesiredHooks() []Hook {
 	const paneFocus = `run-shell 'demux event pane_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'`
-	const follow = `run-shell 'demux sidebar follow 2>/dev/null; true'`
+	const windowFocus = `run-shell 'demux event window_focus --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'`
+	const sessionChanged = `run-shell 'demux event session_changed --pane-id=#{pane_id} --window-id=#{window_id} --session-id=#{session_id} 2>/dev/null; true'`
 	return []Hook{
 		{Event: "after-select-pane", Command: paneFocus},
-		{Event: "after-select-window", Command: paneFocus},
-		{Event: "after-select-window", Command: follow},
-		{Event: "client-session-changed", Command: paneFocus},
-		{Event: "client-session-changed", Command: follow},
+		{Event: "after-select-window", Command: windowFocus},
+		{Event: "client-session-changed", Command: sessionChanged},
 		{Event: "client-focus-in", Command: paneFocus},
 		{Event: "after-kill-pane", Command: `run-shell -b 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'`},
 		{Event: "pane-exited", Command: `run-shell -b 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'`},
-		{Event: "after-new-window", Command: `run-shell -b 'demux sidebar follow 2>/dev/null; demux sidebar slots ensure 2>/dev/null; true'`},
+		{Event: "after-new-window", Command: `run-shell -b 'demux event new_window 2>/dev/null; true'`},
 	}
 }
 

--- a/internal/tmuxhooks/hooks_test.go
+++ b/internal/tmuxhooks/hooks_test.go
@@ -1,0 +1,47 @@
+package tmuxhooks
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestDesiredHooksExcludesClientAttached(t *testing.T) {
+	hooks := DesiredHooks()
+	if len(hooks) == 0 {
+		t.Fatal("DesiredHooks returned empty set")
+	}
+	for _, h := range hooks {
+		if h.Event == "client-attached" {
+			t.Errorf("client-attached must not be in DesiredHooks (it is the bootstrap)")
+		}
+		if h.Event == "" || h.Command == "" {
+			t.Errorf("hook has empty field: %+v", h)
+		}
+	}
+}
+
+func TestDesiredHooksCoversExpectedEvents(t *testing.T) {
+	want := []string{
+		"after-select-pane", "after-select-window", "client-session-changed",
+		"client-focus-in", "after-kill-pane", "pane-exited", "after-new-window",
+	}
+	got := map[string]bool{}
+	for _, h := range DesiredHooks() {
+		got[h.Event] = true
+	}
+	for _, ev := range want {
+		if !got[ev] {
+			t.Errorf("DesiredHooks missing event %q", ev)
+		}
+	}
+}
+
+func TestHooksHashIsStableHex12(t *testing.T) {
+	a, b := HooksHash(), HooksHash()
+	if a != b {
+		t.Errorf("HooksHash not deterministic: %q != %q", a, b)
+	}
+	if !regexp.MustCompile(`^[0-9a-f]{12}$`).MatchString(a) {
+		t.Errorf("HooksHash %q is not 12 lowercase hex chars", a)
+	}
+}

--- a/internal/tmuxhooks/hooks_test.go
+++ b/internal/tmuxhooks/hooks_test.go
@@ -10,8 +10,8 @@ func TestDesiredHooksExcludesClientAttached(t *testing.T) {
 	if len(hooks) == 0 {
 		t.Fatal("DesiredHooks returned empty set")
 	}
-	if len(hooks) != 9 {
-		t.Errorf("DesiredHooks: want 9 entries, got %d", len(hooks))
+	if len(hooks) != 7 {
+		t.Errorf("DesiredHooks: want 7 entries, got %d", len(hooks))
 	}
 	for _, h := range hooks {
 		if h.Event == "client-attached" {

--- a/internal/tmuxhooks/hooks_test.go
+++ b/internal/tmuxhooks/hooks_test.go
@@ -10,6 +10,9 @@ func TestDesiredHooksExcludesClientAttached(t *testing.T) {
 	if len(hooks) == 0 {
 		t.Fatal("DesiredHooks returned empty set")
 	}
+	if len(hooks) != 9 {
+		t.Errorf("DesiredHooks: want 9 entries, got %d", len(hooks))
+	}
 	for _, h := range hooks {
 		if h.Event == "client-attached" {
 			t.Errorf("client-attached must not be in DesiredHooks (it is the bootstrap)")

--- a/internal/tmuxhooks/reconcile.go
+++ b/internal/tmuxhooks/reconcile.go
@@ -32,4 +32,75 @@ func isDemuxEntry(cmd string) bool {
 		strings.Contains(cmd, "demux sidebar ")
 }
 
-var _ = demuxlog.Warn // referenced by Reconcile in the next task
+const versionOption = "@demux_hooks_version"
+
+// Reconcile registers demux's desired hook set into the running tmux server.
+// For each event it clears the hook array, then re-adds the user's own
+// (non-demux) entries followed by demux's canonical entries — so the result is
+// idempotent and can never stack duplicates. Per-event errors are logged and
+// skipped (e.g. a tmux build without the pane-exited hook) so one unsupported
+// event never aborts the rest.
+func Reconcile(t Tmux) error {
+	out, err := t.Output("show-hooks", "-g")
+	if err != nil {
+		return err
+	}
+	current := parseShowHooks(out)
+
+	desired := map[string][]string{}
+	var events []string
+	for _, h := range DesiredHooks() {
+		if _, seen := desired[h.Event]; !seen {
+			events = append(events, h.Event)
+		}
+		desired[h.Event] = append(desired[h.Event], h.Command)
+	}
+
+	for _, event := range events {
+		var keep []string
+		for _, cmd := range current[event] {
+			if !isDemuxEntry(cmd) {
+				keep = append(keep, cmd) // preserve the user's own hooks
+			}
+		}
+		newEntries := append(keep, desired[event]...)
+
+		if err := t.Run("set-hook", "-gu", event); err != nil {
+			demuxlog.Warn("tmuxhooks: clear hook failed", "event", event, "err", err)
+			continue
+		}
+		for _, cmd := range newEntries {
+			if err := t.Run("set-hook", "-ga", event, cmd); err != nil {
+				demuxlog.Warn("tmuxhooks: set hook failed", "event", event, "err", err)
+			}
+		}
+	}
+	return nil
+}
+
+// CurrentVersion returns the @demux_hooks_version tmux option, or "" if unset.
+func CurrentVersion(t Tmux) string {
+	out, err := t.Output("show", "-gv", versionOption)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+// MarkVersion records the current desired-hook hash in @demux_hooks_version.
+func MarkVersion(t Tmux) error {
+	return t.Run("set", "-g", versionOption, HooksHash())
+}
+
+// Sync reconciles hooks only when the recorded version differs from the
+// current desired-hook hash. It is the fast path for the client-attached
+// bootstrap: a single tmux query when nothing changed.
+func Sync(t Tmux) error {
+	if CurrentVersion(t) == HooksHash() {
+		return nil
+	}
+	if err := Reconcile(t); err != nil {
+		return err
+	}
+	return MarkVersion(t)
+}

--- a/internal/tmuxhooks/reconcile.go
+++ b/internal/tmuxhooks/reconcile.go
@@ -63,13 +63,11 @@ func Reconcile(t Tmux) error {
 				keep = append(keep, cmd) // preserve the user's own hooks
 			}
 		}
-		newEntries := append(keep, desired[event]...)
-
 		if err := t.Run("set-hook", "-gu", event); err != nil {
 			demuxlog.Warn("tmuxhooks: clear hook failed", "event", event, "err", err)
 			continue
 		}
-		for _, cmd := range newEntries {
+		for _, cmd := range append(keep, desired[event]...) {
 			if err := t.Run("set-hook", "-ga", event, cmd); err != nil {
 				demuxlog.Warn("tmuxhooks: set hook failed", "event", event, "err", err)
 			}

--- a/internal/tmuxhooks/reconcile.go
+++ b/internal/tmuxhooks/reconcile.go
@@ -1,0 +1,35 @@
+package tmuxhooks
+
+import (
+	"regexp"
+	"strings"
+
+	demuxlog "github.com/rtalexk/demux/internal/log"
+)
+
+// hookLineRE matches one line of `tmux show-hooks -g` output, e.g.
+//
+//	after-new-window[0] run-shell -b "demux ..."
+var hookLineRE = regexp.MustCompile(`^([a-zA-Z-]+)\[\d+\]\s+(.*)$`)
+
+// parseShowHooks groups `tmux show-hooks -g` output by event name, preserving
+// per-event order. The value is the list of hook command strings.
+func parseShowHooks(out string) map[string][]string {
+	result := map[string][]string{}
+	for _, line := range strings.Split(out, "\n") {
+		m := hookLineRE.FindStringSubmatch(strings.TrimRight(line, "\r"))
+		if m == nil {
+			continue
+		}
+		result[m[1]] = append(result[m[1]], m[2])
+	}
+	return result
+}
+
+// isDemuxEntry reports whether a hook command was registered by demux.
+func isDemuxEntry(cmd string) bool {
+	return strings.Contains(cmd, "demux event ") ||
+		strings.Contains(cmd, "demux sidebar ")
+}
+
+var _ = demuxlog.Warn // referenced by Reconcile in the next task

--- a/internal/tmuxhooks/reconcile.go
+++ b/internal/tmuxhooks/reconcile.go
@@ -12,8 +12,8 @@ import (
 //	after-new-window[0] run-shell -b "demux ..."
 var hookLineRE = regexp.MustCompile(`^([a-zA-Z-]+)\[\d+\]\s+(.*)$`)
 
-// parseShowHooks groups `tmux show-hooks -g` output by event name, preserving
-// per-event order. The value is the list of hook command strings.
+// parseShowHooks groups `tmux show-hooks -g [event]` output by event name,
+// preserving per-event order. The value is the list of hook command strings.
 func parseShowHooks(out string) map[string][]string {
 	result := map[string][]string{}
 	for _, line := range strings.Split(out, "\n") {
@@ -35,18 +35,16 @@ func isDemuxEntry(cmd string) bool {
 const versionOption = "@demux_hooks_version"
 
 // Reconcile registers demux's desired hook set into the running tmux server.
-// For each event it clears the hook array, then re-adds the user's own
-// (non-demux) entries followed by demux's canonical entries — so the result is
-// idempotent and can never stack duplicates. Per-event errors are logged and
-// skipped (e.g. a tmux build without the pane-exited hook) so one unsupported
-// event never aborts the rest.
+// For each event it queries that event's current hooks, clears the array, then
+// re-adds the user's own (non-demux) entries followed by demux's canonical
+// entries — so the result is idempotent and can never stack duplicates.
+//
+// Each event is queried individually with `show-hooks -g <event>`: the bare
+// `show-hooks -g` dump omits some events entirely (e.g. pane-exited on tmux
+// 3.x), and a missing event would hide the user's own hook so the clear below
+// silently destroys it. Per-event errors are logged and skipped (e.g. a tmux
+// build without a given hook) so one unsupported event never aborts the rest.
 func Reconcile(t Tmux) error {
-	out, err := t.Output("show-hooks", "-g")
-	if err != nil {
-		return err
-	}
-	current := parseShowHooks(out)
-
 	desired := map[string][]string{}
 	var events []string
 	for _, h := range DesiredHooks() {
@@ -57,8 +55,13 @@ func Reconcile(t Tmux) error {
 	}
 
 	for _, event := range events {
+		out, err := t.Output("show-hooks", "-g", event)
+		if err != nil {
+			demuxlog.Warn("tmuxhooks: show hook failed", "event", event, "err", err)
+			continue
+		}
 		var keep []string
-		for _, cmd := range current[event] {
+		for _, cmd := range parseShowHooks(out)[event] {
 			if !isDemuxEntry(cmd) {
 				keep = append(keep, cmd) // preserve the user's own hooks
 			}

--- a/internal/tmuxhooks/reconcile_test.go
+++ b/internal/tmuxhooks/reconcile_test.go
@@ -45,12 +45,14 @@ func TestIsDemuxEntry(t *testing.T) {
 func TestReconcileDedupesAndPreservesUserHooks(t *testing.T) {
 	f := newFakeTmux()
 	// after-new-window has 3 stale demux copies + 1 user hook.
-	f.outputs["show-hooks -g"] = strings.Join([]string{
-		`after-new-window[0] run-shell -b "demux sidebar follow"`,
-		`after-new-window[1] run-shell -b "demux sidebar follow"`,
-		`after-new-window[2] run-shell "my own hook"`,
-		`after-new-window[3] run-shell -b "demux sidebar slots ensure"`,
-	}, "\n")
+	f.scriptShowHooks(map[string]string{
+		"after-new-window": strings.Join([]string{
+			`after-new-window[0] run-shell -b "demux sidebar follow"`,
+			`after-new-window[1] run-shell -b "demux sidebar follow"`,
+			`after-new-window[2] run-shell "my own hook"`,
+			`after-new-window[3] run-shell -b "demux sidebar slots ensure"`,
+		}, "\n"),
+	})
 
 	if err := Reconcile(f); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -85,6 +87,41 @@ func TestReconcileDedupesAndPreservesUserHooks(t *testing.T) {
 	}
 }
 
+func TestReconcilePreservesUserHookForPerEventQuery(t *testing.T) {
+	f := newFakeTmux()
+	// Scripts only the per-event queries — mirroring real tmux, whose bare
+	// `show-hooks -g` dump omits some events entirely (e.g. pane-exited on
+	// tmux 3.x). Reconcile must query each event individually so a user's own
+	// hook on such an event is preserved rather than destroyed by the clear.
+	f.scriptShowHooks(map[string]string{
+		"pane-exited": `pane-exited[0] run-shell "my own pane-exited hook"`,
+	})
+
+	if err := Reconcile(f); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	runs := f.runStrings()
+	userIdx, demuxIdx := -1, -1
+	for i, r := range runs {
+		if r == `set-hook -ga pane-exited run-shell "my own pane-exited hook"` {
+			userIdx = i
+		}
+		if strings.HasPrefix(r, "set-hook -ga pane-exited run-shell -b 'demux event pane_exiting") {
+			demuxIdx = i
+		}
+	}
+	if userIdx < 0 {
+		t.Fatalf("user pane-exited hook was not preserved; runs=%v", runs)
+	}
+	if demuxIdx < 0 {
+		t.Fatalf("demux pane-exited hook was not registered; runs=%v", runs)
+	}
+	if userIdx > demuxIdx {
+		t.Errorf("user hook re-added after demux hook: user=%d demux=%d", userIdx, demuxIdx)
+	}
+}
+
 func TestSyncFastPathSkipsWhenHashMatches(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["show -gv @demux_hooks_version"] = HooksHash()
@@ -101,7 +138,7 @@ func TestSyncFastPathSkipsWhenHashMatches(t *testing.T) {
 func TestSyncReconcilesWhenHashStale(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["show -gv @demux_hooks_version"] = "stale000000"
-	f.outputs["show-hooks -g"] = ""
+	f.scriptShowHooks(nil)
 	if err := Sync(f); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -118,7 +155,7 @@ func TestSyncReconcilesWhenHashStale(t *testing.T) {
 
 func TestReconcileSkipsEventWhenClearFails(t *testing.T) {
 	f := newFakeTmux()
-	f.outputs["show-hooks -g"] = ""
+	f.scriptShowHooks(nil)
 	// Simulate a tmux build that rejects clearing the after-select-pane hook.
 	f.errs["set-hook -gu after-select-pane"] = errors.New("unknown hook")
 

--- a/internal/tmuxhooks/reconcile_test.go
+++ b/internal/tmuxhooks/reconcile_test.go
@@ -1,6 +1,9 @@
 package tmuxhooks
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseShowHooks(t *testing.T) {
 	out := `after-new-window[0] run-shell -b "demux sidebar follow"
@@ -34,5 +37,79 @@ func TestIsDemuxEntry(t *testing.T) {
 		if got := isDemuxEntry(in); got != want {
 			t.Errorf("isDemuxEntry(%q) = %v, want %v", in, got, want)
 		}
+	}
+}
+
+func TestReconcileDedupesAndPreservesUserHooks(t *testing.T) {
+	f := newFakeTmux()
+	// after-new-window has 3 stale demux copies + 1 user hook.
+	f.outputs["show-hooks -g"] = strings.Join([]string{
+		`after-new-window[0] run-shell -b "demux sidebar follow"`,
+		`after-new-window[1] run-shell -b "demux sidebar follow"`,
+		`after-new-window[2] run-shell "my own hook"`,
+		`after-new-window[3] run-shell -b "demux sidebar slots ensure"`,
+	}, "\n")
+
+	if err := Reconcile(f); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	runs := f.runStrings()
+	// after-new-window must be cleared exactly once.
+	clears := 0
+	for _, r := range runs {
+		if r == "set-hook -gu after-new-window" {
+			clears++
+		}
+	}
+	if clears != 1 {
+		t.Errorf("want 1 clear of after-new-window, got %d in %v", clears, runs)
+	}
+	// The user hook must be re-added before demux's canonical entry.
+	userIdx, demuxIdx := -1, -1
+	for i, r := range runs {
+		if strings.Contains(r, `set-hook -ga after-new-window run-shell "my own hook"`) {
+			userIdx = i
+		}
+		if strings.Contains(r, "set-hook -ga after-new-window run-shell -b 'demux sidebar follow 2>/dev/null; demux sidebar slots ensure") {
+			demuxIdx = i
+		}
+	}
+	if userIdx < 0 || demuxIdx < 0 {
+		t.Fatalf("missing re-add calls: user=%d demux=%d runs=%v", userIdx, demuxIdx, runs)
+	}
+	if userIdx > demuxIdx {
+		t.Errorf("user hook re-added after demux hook: user=%d demux=%d", userIdx, demuxIdx)
+	}
+}
+
+func TestSyncFastPathSkipsWhenHashMatches(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show -gv @demux_hooks_version"] = HooksHash()
+	if err := Sync(f); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	for _, r := range f.runStrings() {
+		if strings.HasPrefix(r, "set-hook") {
+			t.Errorf("fast path must not touch hooks, got run %q", r)
+		}
+	}
+}
+
+func TestSyncReconcilesWhenHashStale(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show -gv @demux_hooks_version"] = "stale000000"
+	f.outputs["show-hooks -g"] = ""
+	if err := Sync(f); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	wrote := false
+	for _, r := range f.runStrings() {
+		if r == "set -g @demux_hooks_version "+HooksHash() {
+			wrote = true
+		}
+	}
+	if !wrote {
+		t.Errorf("Sync must record the new hash; runs=%v", f.runStrings())
 	}
 }

--- a/internal/tmuxhooks/reconcile_test.go
+++ b/internal/tmuxhooks/reconcile_test.go
@@ -73,7 +73,7 @@ func TestReconcileDedupesAndPreservesUserHooks(t *testing.T) {
 		if strings.Contains(r, `set-hook -ga after-new-window run-shell "my own hook"`) {
 			userIdx = i
 		}
-		if strings.Contains(r, "set-hook -ga after-new-window run-shell -b 'demux sidebar follow 2>/dev/null; demux sidebar slots ensure") {
+		if strings.Contains(r, "set-hook -ga after-new-window run-shell -b 'demux event new_window") {
 			demuxIdx = i
 		}
 	}

--- a/internal/tmuxhooks/reconcile_test.go
+++ b/internal/tmuxhooks/reconcile_test.go
@@ -28,10 +28,11 @@ garbage line with no bracket
 
 func TestIsDemuxEntry(t *testing.T) {
 	cases := map[string]bool{
-		`run-shell 'demux event pane_focus'`:  true,
-		`run-shell -b 'demux sidebar follow'`: true,
-		`run-shell 'tmux_claude_layout open'`: false,
-		`run-shell 'echo demuxing'`:           false,
+		`run-shell 'demux event pane_focus'`:     true,
+		`run-shell -b 'demux sidebar follow'`:    true,
+		`run-shell 'tmux_claude_layout open'`:    false,
+		`run-shell 'echo demuxing'`:              false,
+		`run-shell 'echo "demux sidebar rocks"'`: true, // known limitation: substring match
 	}
 	for in, want := range cases {
 		if got := isDemuxEntry(in); got != want {

--- a/internal/tmuxhooks/reconcile_test.go
+++ b/internal/tmuxhooks/reconcile_test.go
@@ -1,6 +1,7 @@
 package tmuxhooks
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -112,5 +113,34 @@ func TestSyncReconcilesWhenHashStale(t *testing.T) {
 	}
 	if !wrote {
 		t.Errorf("Sync must record the new hash; runs=%v", f.runStrings())
+	}
+}
+
+func TestReconcileSkipsEventWhenClearFails(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["show-hooks -g"] = ""
+	// Simulate a tmux build that rejects clearing the after-select-pane hook.
+	f.errs["set-hook -gu after-select-pane"] = errors.New("unknown hook")
+
+	if err := Reconcile(f); err != nil {
+		t.Fatalf("Reconcile must not return an error on a per-event failure: %v", err)
+	}
+
+	runs := f.runStrings()
+	// after-select-pane was never cleared successfully, so it must not be re-added.
+	for _, r := range runs {
+		if strings.HasPrefix(r, "set-hook -ga after-select-pane ") {
+			t.Errorf("after-select-pane must be skipped after clear failure, got run %q", r)
+		}
+	}
+	// A later event must still reconcile despite the earlier failure.
+	reconciled := false
+	for _, r := range runs {
+		if strings.HasPrefix(r, "set-hook -ga after-new-window ") {
+			reconciled = true
+		}
+	}
+	if !reconciled {
+		t.Errorf("after-new-window must still reconcile despite the earlier event failure; runs=%v", runs)
 	}
 }

--- a/internal/tmuxhooks/reconcile_test.go
+++ b/internal/tmuxhooks/reconcile_test.go
@@ -1,0 +1,38 @@
+package tmuxhooks
+
+import "testing"
+
+func TestParseShowHooks(t *testing.T) {
+	out := `after-new-window[0] run-shell -b "demux sidebar follow"
+after-new-window[1] run-shell "user thing"
+after-select-pane[0] run-shell 'demux event pane_focus'
+garbage line with no bracket
+`
+	got := parseShowHooks(out)
+	if len(got["after-new-window"]) != 2 {
+		t.Fatalf("after-new-window: want 2 entries, got %v", got["after-new-window"])
+	}
+	if got["after-new-window"][0] != `run-shell -b "demux sidebar follow"` {
+		t.Errorf("entry 0 mismatch: %q", got["after-new-window"][0])
+	}
+	if got["after-new-window"][1] != `run-shell "user thing"` {
+		t.Errorf("entry 1 mismatch: %q", got["after-new-window"][1])
+	}
+	if len(got["after-select-pane"]) != 1 {
+		t.Errorf("after-select-pane: want 1, got %v", got["after-select-pane"])
+	}
+}
+
+func TestIsDemuxEntry(t *testing.T) {
+	cases := map[string]bool{
+		`run-shell 'demux event pane_focus'`:  true,
+		`run-shell -b 'demux sidebar follow'`: true,
+		`run-shell 'tmux_claude_layout open'`: false,
+		`run-shell 'echo demuxing'`:           false,
+	}
+	for in, want := range cases {
+		if got := isDemuxEntry(in); got != want {
+			t.Errorf("isDemuxEntry(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/tmuxhooks/tmux.go
+++ b/internal/tmuxhooks/tmux.go
@@ -1,0 +1,45 @@
+package tmuxhooks
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Tmux abstracts the tmux invocations the reconciler needs. The production
+// implementation shells out; tests substitute a fake.
+type Tmux interface {
+	Run(args ...string) error
+	Output(args ...string) (string, error)
+}
+
+type realTmux struct{}
+
+// Real returns a Tmux that shells out to the tmux binary.
+func Real() Tmux { return realTmux{} }
+
+func (realTmux) Run(args ...string) error {
+	cmd := exec.Command("tmux", args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
+}
+
+func (realTmux) Output(args ...string) (string, error) {
+	cmd := exec.Command("tmux", args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return string(out), fmt.Errorf("%w: %s", err, msg)
+		}
+	}
+	return string(out), err
+}


### PR DESCRIPTION
## Context

demux's tmux integration (done-state clearing, the sticky sidebar follow/slot
hooks) is delivered through tmux hooks. Until now those hooks were installed by
hand: `demux hooks init --tool tmux` printed a multi-line snippet the user
pasted into `~/.tmux.conf` and re-sourced.

That snippet is a maintenance trap. Every time demux's hook set changes — a new
event, a corrected flag, an added `run-shell -b` — the pasted copy goes stale.
A stale snippet silently misbehaves (wrong flags expand to empty values) or
stacks duplicate hooks on re-source, and nothing tells the user to re-paste.
The hook set and the user's config drift apart with no feedback loop.

This PR closes that gap: the user runs one command once, and demux keeps its
own hook set current in every running tmux server from then on.

Scope is **tmux** — `hooks install --tool` only accepts `tmux`.

## What does this PR do

Replaces the paste-a-snippet model with a self-registering managed block.

- New `demux hooks install --tool tmux` writes a marker-delimited managed block
  to `~/.tmux.conf` containing a single bootstrap line:
  ```
  # >>> demux managed block >>>
  set-hook -g client-attached "run-shell -b 'demux event client_attached 2>/dev/null; true'"
  # <<< demux managed block <<<
  ```
  It also registers the hook set in the live server immediately. The write is
  atomic (temp file + rename) and backs up the prior file to `~/.tmux.conf.demux-bak`.
- On every tmux client attach, the bootstrap fires `demux event client_attached`,
  which **reconciles** demux's full canonical hook set into the running server:
  clears each event, re-adds the user's own (non-demux) entries, then re-adds
  demux's — idempotent, never stacks duplicates, self-heals after a demux upgrade.
  A version gate (`@demux_hooks_version`, a hash of the desired set) makes the
  steady-state attach a single tmux query.
- `demux hooks install --print-only` prints the bootstrap line without touching
  any file or server.
- Re-running `hooks install` is idempotent (replaces the block in place). If an
  older pasted multi-line snippet is detected outside the managed block, the user
  is prompted to remove it.
- New `demux event` subcommands name the tmux event rather than the reaction:
  `window_focus`, `session_changed`, `new_window`, `client_attached`. The hook
  handler decides the reaction (clear done-states, move the sidebar, reconcile
  slot panes).
- New config `[sidebar.sticky] auto_show` — when `true`, the sticky sidebar is
  shown automatically on client attach. Default `false`.
- Group commands (`demux event`, …) now reject an unknown subcommand with an
  error on stderr and a non-zero exit, instead of cobra's default of printing
  help to stdout with exit 0. Hooks run `demux … 2>/dev/null`; a since-removed
  subcommand now fails silently rather than dumping help text into a pane.
- `demux hooks init` is kept as a hidden, deprecated alias for
  `hooks install --print-only`.

### Out of scope

- Tools other than tmux. `hooks install --tool` rejects anything but `tmux`;
  there is no shell/zsh integration in this iteration.

## Manual QA

> CLI feature. Verify by building the binary and driving `demux hooks` /
> `demux event` against a tmux server, observing `~/.tmux.conf` content and
> `tmux show-hooks -g` output.

> ⚠️ **`demux hooks install` mutates real state — `~/.tmux.conf` *and* the live
> tmux server.** Do **not** run it bare during QA. Every scenario below runs the
> binary against an **isolated tmux server** (`tmux -L demuxqa`) and a **temp
> `$HOME`**, so your real config and real tmux server are never touched. The
> `$TMUX` override is what redirects demux's tmux calls to the isolated server —
> if you omit it, an empty/unset `$TMUX` routes to your **default** server.

### Prerequisites

<details>

<summary>1. tmux 3.x+ is installed.</summary>

```bash
tmux -V
```

Expect `tmux 3.x` or `next-3.x`. The reconcile path was verified on `next-3.7`.

</details>

<details>

<summary>2. Go toolchain available to build the binary.</summary>

```bash
go version
```

Expect `go1.2x`. If missing, install Go or use a prebuilt `demux` binary from this branch.

</details>

### Setup

Build the binary and stand up the isolated server + temp `$HOME`. Run this once;
later scenarios reuse `$D`, `$QAHOME`, `$QATMUX`.

```bash
mkdir -p /tmp/demux-qa && go build -o /tmp/demux-qa/demux .
export D=/tmp/demux-qa/demux
export QAHOME=$(mktemp -d /tmp/demux-qa-home.XXXXXX)

HOME="$QAHOME" tmux -L demuxqa new-session -d -s qa -x 200 -y 50
SOCK=$(tmux -L demuxqa display-message -p -t qa '#{socket_path}')
PID=$(tmux -L demuxqa display-message -p -t qa '#{pid}')
SID=$(tmux -L demuxqa display-message -p -t qa '#{session_id}')
export QATMUX="$SOCK,$PID,$SID"

# baseline: isolated server has no demux hooks
tmux -L demuxqa show-hooks -g | grep -c demux   # expect: 0
```

<details>

<summary>Scenario 1 — `--print-only` prints the bootstrap line, touches nothing</summary>

1. Run print-only:
   ```bash
   HOME="$QAHOME" $D hooks install --print-only
   ```
   Expected stdout, exit 0:
   ```
   set-hook -g client-attached "run-shell -b 'demux event client_attached 2>/dev/null; true'"
   ```
2. Confirm no file was written:
   ```bash
   ls "$QAHOME/.tmux.conf"
   ```
   Expected: `No such file or directory`.

</details>

<details>

<summary>Scenario 2 — `hooks install` writes the managed block and registers live hooks</summary>

1. Install into the isolated env:
   ```bash
   env HOME="$QAHOME" TMUX="$QATMUX" $D hooks install --tool tmux
   ```
   Expected stdout: `Created <QAHOME>/.tmux.conf` and
   `Registered demux hooks in the live tmux server.`, exit 0.
2. Inspect the file:
   ```bash
   cat "$QAHOME/.tmux.conf"
   ```
   Expected: exactly the 3-line managed block (begin marker, `set-hook -g
   client-attached …`, end marker).
3. Inspect the live server:
   ```bash
   tmux -L demuxqa show-hooks -g | grep demux
   ```
   Expected: 7 lines — `client-attached` (bootstrap) plus `after-kill-pane`,
   `after-new-window`, `after-select-pane`, `after-select-window`,
   `client-focus-in`, `client-session-changed`.

</details>

<details>

<summary>Scenario 3 — re-running `hooks install` is idempotent</summary>

1. Run install a second time:
   ```bash
   env HOME="$QAHOME" TMUX="$QATMUX" $D hooks install --tool tmux
   ```
   Expected stdout: `Updated <QAHOME>/.tmux.conf (backup: …/.tmux.conf.demux-bak)`.
2. File is still a single 3-line block:
   ```bash
   wc -l < "$QAHOME/.tmux.conf"          # expect: 3
   ls "$QAHOME/.tmux.conf.demux-bak"     # backup exists
   ```
3. No duplicate hooks on the server:
   ```bash
   tmux -L demuxqa show-hooks -g | grep demux | sed -E 's/\[[0-9]+\].*//' | sort | uniq -c
   ```
   Expected: every event shows count `1`.

</details>

<details>

<summary>Scenario 4 — legacy pasted snippet is detected and removed on confirm</summary>

1. Stage a temp `$HOME` with an old-style snippet plus user-owned config:
   ```bash
   LH=$(mktemp -d /tmp/demux-qa-legacy.XXXXXX)
   printf '%s\n' \
     '# my own tmux config' \
     'set -g mouse on' \
     'set-hook -g after-select-pane "run-shell '\''demux event pane_focus 2>/dev/null; true'\''"' \
     'set-hook -ga client-session-changed "run-shell '\''demux sidebar follow'\''"' \
     'bind r source-file ~/.tmux.conf' > "$LH/.tmux.conf"
   ```
2. Install, answering `y` at the prompt:
   ```bash
   printf 'y\n' | env HOME="$LH" TMUX="$QATMUX" $D hooks install --tool tmux
   ```
   Expected: lists `2 legacy demux hook line(s)` at `L3`/`L4`, prints
   `Removed 2 legacy line(s).`
3. Verify only the legacy hook lines were removed:
   ```bash
   cat "$LH/.tmux.conf"
   ```
   Expected: `# my own tmux config`, `set -g mouse on`, `bind r …` all retained;
   the two `set-hook … demux …` lines gone; managed block appended.
4. Cleanup: `rm -rf "$LH"`.

</details>

<details>

<summary>Scenario 5 — end-to-end: a real client attach self-registers the full hook set</summary>

1. Clear the isolated server's hooks and source only `~/.tmux.conf` (simulating
   a fresh server start that loads just the managed block):
   ```bash
   for ev in after-select-pane after-select-window client-session-changed \
             client-focus-in after-kill-pane after-new-window pane-exited \
             client-attached; do tmux -L demuxqa set-hook -gu "$ev" 2>/dev/null; done
   tmux -L demuxqa set -gu @demux_hooks_version 2>/dev/null
   tmux -L demuxqa source-file "$QAHOME/.tmux.conf"
   tmux -L demuxqa show-hooks -g | grep demux     # expect: only client-attached
   ```
2. Run the reconcile entry point directly (this is exactly what the bootstrap
   hook invokes on attach):
   ```bash
   env HOME="$QAHOME" TMUX="$QATMUX" $D event client_attached
   ```
3. Verify the full canonical set is now registered:
   ```bash
   tmux -L demuxqa show-hooks -g | grep demux
   tmux -L demuxqa show-hooks -g pane-exited
   tmux -L demuxqa show -gv @demux_hooks_version
   ```
   Expected: 7 event hooks present (including `pane-exited`, which the bare
   `show-hooks -g` dump omits — query it explicitly), and `@demux_hooks_version`
   set to a 12-hex-char hash.
4. Re-run `demux event client_attached` — the version gate makes it a no-op;
   `show-hooks -g` is unchanged, no duplicates.

</details>

<details>

<summary>Scenario 6 — reconcile preserves the user's own hooks (incl. `pane-exited`)</summary>

1. Seed a user-owned hook on `pane-exited` and on `after-select-pane`:
   ```bash
   tmux -L demuxqa set-hook -ga pane-exited 'run-shell "echo USER-pane-exited"'
   tmux -L demuxqa set-hook -ga after-select-pane 'run-shell "echo USER-select-pane"'
   tmux -L demuxqa set -gu @demux_hooks_version
   ```
2. Reconcile:
   ```bash
   env HOME="$QAHOME" TMUX="$QATMUX" $D event client_attached
   ```
3. Verify both user hooks survived at index `[0]`, demux's at `[1]`:
   ```bash
   tmux -L demuxqa show-hooks -g pane-exited
   tmux -L demuxqa show-hooks -g after-select-pane
   ```
   Expected, for each event: `[0]` = the `echo USER-…` hook, `[1]` = the
   `demux event …` hook. (This is the case fixed by commit `643f13e` — the bare
   `show-hooks -g` dump omits `pane-exited`, so reconcile queries each event
   individually to avoid wiping the user's hook.)

</details>

<details>

<summary>Scenario 7 — unknown subcommand fails on stderr, bare parent prints help</summary>

1. Unknown subcommand:
   ```bash
   HOME="$QAHOME" $D event bogus; echo "exit=$?"
   ```
   Expected: `Error: unknown command "bogus" for "demux event"` on **stderr**,
   `exit=1`, empty stdout.
2. Bare parent still prints help:
   ```bash
   HOME="$QAHOME" $D event; echo "exit=$?"
   ```
   Expected: help text on stdout, `exit=0`.

</details>

### Teardown

```bash
tmux -L demuxqa kill-server
rm -rf "$QAHOME" /tmp/demux-qa /tmp/demux-qa-home.* /tmp/demux-qa-legacy.*
```

`-L demuxqa` is a dedicated test server created in Setup — killing it does not
affect your real tmux server.
