### PR TITLE
docs(readme): document key binding for sticky sidebar toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,27 @@ demux sidebar hide     # idempotent: kill if present
 All three require the invoking shell to be inside tmux (`$TMUX` set). Running
 them outside tmux exits with status 1.
 
+### Bind a key to toggle
+
+`demux sidebar toggle` is an ordinary shell command, so you can bind it to any
+tmux key:
+
+```tmux
+bind-key -n M-E run-shell "demux sidebar toggle"
+```
+
+The `-n` flag drops the prefix requirement. Terminals do not forward
+`cmd`-based shortcuts to tmux, so to drive the toggle from a `cmd` chord you map
+the chord in your terminal emulator to the escape sequence the tmux binding
+listens for. In Ghostty:
+
+```
+keybind = cmd+shift+e=text:\x1bE
+```
+
+`\x1bE` is `Alt-E` (`M-E`), which the `bind-key -n M-E` binding above catches.
+The result: `CMD + Shift + E` toggles the sticky sidebar from anywhere.
+
 Internally, the tmux hooks call `demux event window_focus` and
 `demux event session_changed` when you switch windows or sessions; each
 physically moves the existing sidebar pane (preserving its current width) into


### PR DESCRIPTION
## Context

The sticky sidebar is toggled with `demux sidebar toggle`, but the README never showed how to bind that command to a key. Driving it from a `cmd` chord is non-obvious: terminals do not forward `cmd` shortcuts to tmux, so the terminal emulator has to translate the chord into an escape sequence tmux can catch.

## What does this PR do

Adds a "Bind a key to toggle" subsection under `## Sticky sidebar`:

- tmux side: `bind-key -n M-E run-shell "demux sidebar toggle"`
- terminal side (Ghostty): `keybind = cmd+shift+e=text:\x1bE`
- explains that `\x1bE` is `Alt-E` (`M-E`), the sequence the tmux binding catches

Docs-only change; no code touched.

## Manual QA

- Rendered the updated README and confirmed the new "Bind a key to toggle" subsection appears under "Sticky sidebar", after the Lifecycle block, with both code blocks formatting correctly.
- Verified the documented binding works end to end: with `bind-key -n M-E run-shell "demux sidebar toggle"` in `~/.tmux.conf` and `keybind = cmd+shift+e=text:\x1bE` in the Ghostty config, pressing `CMD + Shift + E` toggles the sticky sidebar.