### PR TITLE
feat(sidebar): invert proc label colors on focused session card

### DIFF
--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 	runewidth "github.com/mattn/go-runewidth"
@@ -759,22 +760,17 @@ func styledIconPrefix(iconPrefix string, highlighted bool) string {
 	return sessionIconStyle.Render(iconPrefix)
 }
 
-// isIconLabel reports whether a proc-label text is an icon glyph (emoji,
-// Nerd Font, symbol) rather than ASCII text like "py" or "node". Icons
-// carry their own visual weight and read better without a chip background.
-// Surrounding whitespace is ignored so labels like "󰵰 " (glyph + padding
-// space) still register as icons.
+// isIconLabel reports whether a proc-label text is a single icon glyph
+// (emoji, Nerd Font, symbol) rather than text like "py" or "node". A label
+// is either pure text or a single icon, so we check the first non-space
+// rune. Icons read better without a chip background.
 func isIconLabel(text string) bool {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
 		return false
 	}
-	for _, r := range trimmed {
-		if !isIconRune(r) {
-			return false
-		}
-	}
-	return true
+	r, _ := utf8.DecodeRuneInString(trimmed)
+	return isIconRune(r)
 }
 
 // resolveProcLabelColors picks the effective fg/bg for a sidebar proc label.

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -759,21 +759,48 @@ func styledIconPrefix(iconPrefix string, highlighted bool) string {
 	return sessionIconStyle.Render(iconPrefix)
 }
 
+// isIconLabel reports whether a proc-label text is an icon glyph (emoji,
+// Nerd Font, symbol) rather than ASCII text like "py" or "node". Icons
+// carry their own visual weight and read better without a chip background.
+// Surrounding whitespace is ignored so labels like "󰵰 " (glyph + padding
+// space) still register as icons.
+func isIconLabel(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return false
+	}
+	for _, r := range trimmed {
+		if r < 128 {
+			return false
+		}
+	}
+	return true
+}
+
 // resolveProcLabelColors picks the effective fg/bg for a sidebar proc label.
-// When selected and focused, both fg and bg are overridden to match the
-// selection row so the label stays readable against the selection bg.
+// Text labels get a chip background (theme default or, when selected+focused,
+// the inverted session-name color so the chip pops against the selection
+// row). Icon labels never get a chip background applied by us — but when
+// the row is selected+focused, they must adopt the selection bg so the
+// icon blends into the row rather than punching a hole to terminal default.
 func resolveProcLabelColors(lbl procmatch.Label, selected, focused bool) (fg, bg lipgloss.Color) {
 	fg = lipgloss.Color(lbl.FG)
 	if fg == "" {
 		fg = activeTheme.ColorProcLabelFG
 	}
 	bg = lipgloss.Color(lbl.BG)
-	if bg == "" {
-		bg = activeTheme.ColorProcLabelBG
-	}
-	if selected && focused {
-		fg = activeTheme.ColorFgPrimary
+
+	icon := isIconLabel(lbl.Text)
+	highlighted := selected && focused
+
+	switch {
+	case highlighted && icon:
 		bg = activeTheme.ColorSelected
+	case highlighted:
+		fg = activeTheme.ColorSelected
+		bg = activeTheme.ColorFgPrimary
+	case !icon && bg == "":
+		bg = activeTheme.ColorProcLabelBG
 	}
 	return fg, bg
 }

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -770,7 +770,7 @@ func isIconLabel(text string) bool {
 		return false
 	}
 	for _, r := range trimmed {
-		if r < 128 {
+		if !isIconRune(r) {
 			return false
 		}
 	}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1528,8 +1528,8 @@ func TestSidebar_ResolveProcLabelColors_FocusedOverridesPerEntry(t *testing.T) {
 		t.Fatalf("selected-only should keep entry colors, got fg=%v bg=%v", fg, bg)
 	}
 	fg, bg = resolveProcLabelColors(lbl, true, true)
-	if fg != lipgloss.Color("#cdd6f4") || bg != lipgloss.Color("#2a2a4a") {
-		t.Fatalf("selected+focused should override to theme colors, got fg=%v bg=%v", fg, bg)
+	if fg != lipgloss.Color("#2a2a4a") || bg != lipgloss.Color("#cdd6f4") {
+		t.Fatalf("selected+focused should invert to selection fg=ColorSelected bg=ColorFgPrimary, got fg=%v bg=%v", fg, bg)
 	}
 }
 
@@ -1543,6 +1543,48 @@ func TestSidebar_ResolveProcLabelColors_FallsBackToThemeDefaults(t *testing.T) {
 	fg, bg := resolveProcLabelColors(lbl, false, false)
 	if fg != lipgloss.Color("#aaa") || bg != lipgloss.Color("#222") {
 		t.Fatalf("expected theme fallback, got fg=%v bg=%v", fg, bg)
+	}
+}
+
+func TestSidebar_ResolveProcLabelColors_IconLabelNeverGetsBackground(t *testing.T) {
+	initStyles(Theme{
+		ColorFgPrimary:   lipgloss.Color("#cdd6f4"),
+		ColorSelected:    lipgloss.Color("#2a2a4a"),
+		ColorProcLabelFG: lipgloss.Color("#aaa"),
+		ColorProcLabelBG: lipgloss.Color("#222"),
+	}, config.ProcessesConfig{}, nil)
+	lbl := procmatch.Label{Text: "🤖"}
+
+	if _, bg := resolveProcLabelColors(lbl, false, false); bg != "" {
+		t.Fatalf("icon unfocused: expected no bg, got %v", bg)
+	}
+	fg, bg := resolveProcLabelColors(lbl, true, true)
+	if bg != lipgloss.Color("#2a2a4a") {
+		t.Fatalf("icon selected+focused: expected bg=ColorSelected to blend into row, got %v", bg)
+	}
+	if fg != lipgloss.Color("#aaa") {
+		t.Fatalf("icon selected+focused: fg should not be overridden, got %v", fg)
+	}
+}
+
+func TestSidebar_IsIconLabel(t *testing.T) {
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"py", false},
+		{"node", false},
+		{"", false},
+		{"🤖", true},
+		{"", true}, // Nerd Font PUA glyph
+		{" 🤖 ", true}, // padded with whitespace
+		{"Go!", false},
+		{"   ", false},
+	}
+	for _, c := range cases {
+		if got := isIconLabel(c.text); got != c.want {
+			t.Errorf("isIconLabel(%q) = %v, want %v", c.text, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Focused session card now inverts text proc labels (e.g. `py`, `node`): bg = session-name color (`ColorFgPrimary`), fg = selection color (`ColorSelected`). Chip pops against the selection row instead of disappearing into it.
- Icon proc labels (emoji, Nerd Font glyphs) skip the chip background entirely and adopt the selection bg, so they read as part of the row rather than as a separate chip.
- Added `isIconLabel` helper (whitespace-trimmed, all-non-ASCII rune check) so labels like `"󰵰 "` (glyph + padding space) are recognized as icons.
- Refactored `resolveProcLabelColors` into a 3-arm switch so the override paths read top-to-bottom.

## Test plan

Automated:
- [x] `go test ./internal/tui/ -count=1` — 336 passed
- [x] `go build ./...`
- [x] New tests cover focused/unfocused, icon vs text, and the trimmed-icon case

Manual:
- [ ] Launch `demux` against a session list that includes:
  - a text proc label (e.g. `py`, `node`) configured with custom fg/bg
  - an icon proc label (e.g. `"󰵰 "` for `claude*`, or any emoji)
- [ ] Focus the sidebar and move the selection onto each kind of session card
- [ ] Verify the focused text label renders as a chip (light bg, purple fg)
- [ ] Verify the focused icon renders with no chip — it sits on the purple selection bg cleanly, with no light-gray box behind it
- [ ] Unfocus the sidebar and confirm both label kinds revert to their configured colors