### PR TITLE
fix(sidebar): make slot reconcile additive, rebalance on split

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,8 +787,10 @@ demux sidebar slots uninstall   # remove every slot pane
 demux sidebar slots prune       # reconcile now: kill duplicate / stale slots without waiting for a tmux event
 ```
 
-demux's tmux hooks already include an `after-new-window` hook that
-reconciles the slot set when a new window appears (no-op when `slots = false`).
+demux's tmux hooks already include an `after-new-window` hook that adds
+missing slot panes to MRU-reserved windows when a new window appears (no-op
+when `slots = false`). It never kills panes - dedupe and stale-slot eviction
+belong to `demux sidebar slots prune`.
 
 Trade-offs:
 

--- a/README.md
+++ b/README.md
@@ -749,6 +749,12 @@ strategy:
 - Switching to a window that fell out of the MRU triggers a one-time
   `split-window` to recreate its slot, then the swap; that window enters the
   MRU and is flicker-free on subsequent visits.
+- Switching sessions with no active sidebar tracked (e.g. you ran
+  `demux sidebar hide`, then later jumped sessions with a tmux binding) will
+  re-promote the destination window's slot to active sidebar so navigating
+  between configured sessions never leaves a bare placeholder behind. Triggered
+  only when slots have been installed at least once; respects `auto_show=false`
+  on initial client attach.
 
 #### Reserved-set priority
 

--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ demux sidebar show              # installs slots in MRU + activates current wind
 demux sidebar hide              # removes every slot pane (full teardown)
 demux sidebar slots install     # idempotent: ensure every reserved window has a slot
 demux sidebar slots uninstall   # remove every slot pane
+demux sidebar slots prune       # reconcile now: kill duplicate / stale slots without waiting for a tmux event
 ```
 
 demux's tmux hooks already include an `after-new-window` hook that

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -283,9 +283,12 @@ var eventClientAttachedCmd = &cobra.Command{
 
 		cfg := loadConfig()
 		if cfg.Sidebar.Sticky.AutoShow {
-			if err := stickyClient().Show(sidebarShowOpts()); err != nil {
-				demuxlog.Warn("client_attached: sidebar show failed", "err", err)
-			}
+			_ = withEventLock(func() error {
+				if err := stickyClient().Show(sidebarShowOpts()); err != nil {
+					demuxlog.Warn("client_attached: sidebar show failed", "err", err)
+				}
+				return nil
+			})
 		}
 
 		warnLegacyTmuxHooks()

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -229,16 +229,25 @@ var eventSessionChangedCmd = &cobra.Command{
 	RunE:  runWindowFocus,
 }
 
-// eventNewWindowCmd is fired by the after-new-window hook. It moves the sticky
-// sidebar into the new window and reconciles slot panes. Both steps are
-// best-effort: failures are logged, not returned.
+// eventNewWindowCmd is fired by the after-new-window hook. It adds missing
+// sidebar slot panes to MRU-reserved windows. Best-effort: failures are
+// logged, not returned.
+//
+// Follow is intentionally NOT called here. A new window does not imply the
+// client switched - tmux fires after-select-window separately for that, and
+// that handler (runWindowFocus) is the right place for Follow. Calling Follow
+// here races against the after-select-window Follow and, when a multi-window
+// session is being launched (e.g. `demux session connect <config-session>`),
+// against itself across the burst of after-new-window hooks - thrashing the
+// swap-pane state and stranding the sidebar in the wrong window.
+//
+// Not wrapped in withEventLock because ensureSlots is now additive only
+// (AddMissingSlots, never kill-pane), so the lock contention with backgrounded
+// pane_closed sweeps that used to freeze tmux input no longer applies.
 var eventNewWindowCmd = &cobra.Command{
 	Use:   "new_window",
-	Short: "Move the sticky sidebar into a new window and reconcile slot panes",
+	Short: "Add missing sidebar slot panes for MRU-reserved windows",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := stickyClient().Follow(); err != nil {
-			demuxlog.Warn("new_window: sidebar follow failed", "err", err)
-		}
 		if err := ensureSlots(); err != nil {
 			demuxlog.Warn("new_window: slots ensure failed", "err", err)
 		}

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -205,8 +205,12 @@ func runWindowFocus(cmd *cobra.Command, args []string) error {
 	if err := applyPaneFocus(d, paneID, windowID, sessionID); err != nil {
 		return err
 	}
-	if err := stickyClient().Follow(); err != nil {
+	s := stickyClient()
+	if err := s.Follow(); err != nil {
 		demuxlog.Warn(cmd.Use+": sidebar follow failed", "err", err)
+	}
+	if err := s.MaybePromoteSlot(sidebarShowOpts()); err != nil {
+		demuxlog.Warn(cmd.Use+": sidebar promote failed", "err", err)
 	}
 	return nil
 }

--- a/cmd/event_ensure_slots_test.go
+++ b/cmd/event_ensure_slots_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rtalexk/demux/internal/config"
+	"github.com/rtalexk/demux/internal/sticky"
+)
+
+// Regression: ensureSlots (called by the after-new-window hook) must use the
+// additive AddMissingSlots path, never ReconcileSlots. ReconcileSlots issues
+// kill-pane for stale/duplicate slots; each kill fires after-kill-pane ->
+// backgrounded `demux event pane_closed` -> SweepOrphanWindows, which may
+// itself kill more panes. On a multi-window session launch the cascade
+// saturates tmux's command queue and freezes input.
+func TestEnsureSlots_NeverKillsPanes(t *testing.T) {
+	tmux := &stubTmux{
+		outputs: map[string]string{
+			// AnySlotExists: 2 duplicate slots in @7, 1 stale slot in @99 (non-reserved).
+			// Naive ReconcileSlots would kill all three extras.
+			"list-panes -aF #{pane_id} #{@demux_slot}":      "%10 1\n%11 1\n%99 1\n",
+			"display-message -p #{session_id}:#{window_id}": "$1:@7\n",
+			// Reservation queries.
+			"list-windows -aF #{window_id}":                          "@7\n",
+			"list-windows -t $1 -F #{window_id} #{window_last_flag}": "@7 0\n",
+			"display-message -p #{client_last_session}":              "\n",
+			"show-environment -g " + sticky.MRUEnvKey:                "-" + sticky.MRUEnvKey + "\n",
+			// AddMissingSlots -> EnsureSlotInWindow -> FindSlotInWindow per
+			// reserved window. @7 already has a slot, so no split-window fires.
+			"list-panes -t @7 -F #{pane_id} #{@demux_slot}": "%10 1\n",
+		},
+	}
+
+	cfg := config.Default()
+	cfg.Sidebar.Sticky.Slots = true
+	cfg.Sidebar.Sticky.Width = 35
+	oldCfg := loadConfig
+	oldClient := stickyClient
+	loadConfig = func() config.Config { return cfg }
+	stickyClient = func() *sticky.Sticky {
+		return &sticky.Sticky{T: tmux, Slots: true}
+	}
+	t.Cleanup(func() {
+		loadConfig = oldCfg
+		stickyClient = oldClient
+	})
+
+	if err := ensureSlots(); err != nil {
+		t.Fatalf("ensureSlots: %v", err)
+	}
+
+	for _, r := range tmux.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane") {
+			t.Errorf("ensureSlots must not kill panes (cleanup belongs to `slots prune`), got: %v", r)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,7 +117,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&stickyFlag, "sticky", false, "Sticky sidebar mode: forces compact + card view, disables quit (used by `demux sidebar`)")
 }
 
-func loadConfig() config.Config {
+var loadConfig = func() config.Config {
 	path, err := config.DefaultPath()
 	if err != nil {
 		demuxlog.Warn("cannot determine config path", "err", err)

--- a/cmd/session_connect.go
+++ b/cmd/session_connect.go
@@ -144,7 +144,30 @@ func dispatchConnect(target *session.Session, scfg session.SessionsConfig) error
 		for _, id := range unknown {
 			fmt.Fprintf(os.Stderr, "demux: unknown window_template id %q (skipped)\n", id)
 		}
-		return session.LaunchAndConnectConfigSession(ce.Name, ce.Path, ce.Windows, scfg.WindowTemplates)
+		return launchConfigSessionAndConnect(ce, scfg)
 	}
 	return fmt.Errorf("session %q is neither live nor in config", target.DisplayName)
+}
+
+// launchConfigSessionAndConnect creates the configured session + windows with
+// the after-new-window hook suppressed, then runs the switch-client step
+// without suppression so the client-session-changed handler fires normally.
+//
+// The suppression closes the race that otherwise strands the sticky sidebar
+// in the source session: each new-window during launch normally fires a
+// backgrounded `demux event new_window` handler, and the burst races with the
+// (also backgrounded) client-session-changed handler that follows
+// switch-client. With multiple concurrent Follow / ensureSlots invocations
+// thrashing swap-pane state, the final sidebar location is non-deterministic.
+//
+// Hooks are restored before tmux.Connect so the session-changed handler still
+// fires - one handler, no race.
+func launchConfigSessionAndConnect(ce *session.ConfigEntry, scfg session.SessionsConfig) error {
+	s := stickyClient()
+	if err := withHooksSuppressed(s.T, []string{"after-new-window"}, func() error {
+		return session.LaunchConfigSession(ce.Name, ce.Path, ce.Windows, scfg.WindowTemplates)
+	}); err != nil {
+		return err
+	}
+	return tmux.Connect(ce.Name)
 }

--- a/cmd/session_connect.go
+++ b/cmd/session_connect.go
@@ -162,12 +162,17 @@ func dispatchConnect(target *session.Session, scfg session.SessionsConfig) error
 //
 // Hooks are restored before tmux.Connect so the session-changed handler still
 // fires - one handler, no race.
+// launchConfigSession and tmuxConnect are package-level vars so the
+// integration test can inject fakes without spawning real tmux processes.
+var launchConfigSession = session.LaunchConfigSession
+var tmuxConnect = tmux.Connect
+
 func launchConfigSessionAndConnect(ce *session.ConfigEntry, scfg session.SessionsConfig) error {
 	s := stickyClient()
 	if err := withHooksSuppressed(s.T, []string{"after-new-window"}, func() error {
-		return session.LaunchConfigSession(ce.Name, ce.Path, ce.Windows, scfg.WindowTemplates)
+		return launchConfigSession(ce.Name, ce.Path, ce.Windows, scfg.WindowTemplates)
 	}); err != nil {
 		return err
 	}
-	return tmux.Connect(ce.Name)
+	return tmuxConnect(ce.Name)
 }

--- a/cmd/session_connect_test.go
+++ b/cmd/session_connect_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/rtalexk/demux/internal/session"
+	"github.com/rtalexk/demux/internal/sticky"
 )
 
 func TestResolveTarget_PositionalFound(t *testing.T) {
@@ -53,5 +54,81 @@ func TestValidateConnectArgs_NameOnly(t *testing.T) {
 func TestValidateConnectArgs_FuzzyOnly(t *testing.T) {
 	if err := validateConnectArgs("", true); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Integration regression for the `demux session connect <config>` race: the
+// after-new-window hook must be suppressed during the launch sequence
+// (NewSessionDetached + CreateSessionWindows) and restored before the
+// client-side Connect. Without this, backgrounded `demux event new_window`
+// handlers race the eventual client-session-changed handler and strand the
+// sidebar in the source session.
+func TestLaunchConfigSessionAndConnect_SuppressesAfterNewWindow(t *testing.T) {
+	tmux := &stubTmux{
+		outputs: map[string]string{
+			"show-hooks -g after-new-window": `after-new-window[0] run-shell -b "demux event new_window 2>/dev/null; true"` + "\n",
+		},
+	}
+
+	type callOrder struct {
+		name string
+		idx  int
+	}
+	var order []callOrder
+	track := func(name string) {
+		order = append(order, callOrder{name: name, idx: len(tmux.runs)})
+	}
+
+	oldLaunch := launchConfigSession
+	oldConnect := tmuxConnect
+	oldClient := stickyClient
+	launchConfigSession = func(name, path string, windowIDs []string, templates map[string]session.WindowTemplate) error {
+		track("launch")
+		return nil
+	}
+	tmuxConnect = func(name string) error {
+		track("connect")
+		return nil
+	}
+	stickyClient = func() *sticky.Sticky {
+		return &sticky.Sticky{T: tmux}
+	}
+	t.Cleanup(func() {
+		launchConfigSession = oldLaunch
+		tmuxConnect = oldConnect
+		stickyClient = oldClient
+	})
+
+	ce := &session.ConfigEntry{Name: "dotf-main", Path: "/tmp"}
+	if err := launchConfigSessionAndConnect(ce, session.SessionsConfig{}); err != nil {
+		t.Fatalf("launchConfigSessionAndConnect: %v", err)
+	}
+
+	if len(order) != 2 || order[0].name != "launch" || order[1].name != "connect" {
+		t.Fatalf("want launch then connect, got: %+v", order)
+	}
+
+	idxUnset, idxRestore := -1, -1
+	for i, r := range tmux.runs {
+		j := strings.Join(r, " ")
+		if j == "set-hook -gu after-new-window" {
+			idxUnset = i
+		}
+		if strings.HasPrefix(j, "set-hook -ga after-new-window") {
+			idxRestore = i
+		}
+	}
+	if idxUnset < 0 {
+		t.Fatalf("after-new-window must be suppressed before launch, got runs: %v", tmux.runs)
+	}
+	if idxRestore < 0 {
+		t.Fatalf("after-new-window must be restored after launch (defer), got runs: %v", tmux.runs)
+	}
+
+	launchIdx := order[0].idx
+	connectIdx := order[1].idx
+	if !(idxUnset < launchIdx && launchIdx <= idxRestore && idxRestore <= connectIdx) {
+		t.Errorf("want order: set-hook -gu (%d) < launch (%d) <= set-hook -ga (%d) <= connect (%d); runs: %v",
+			idxUnset, launchIdx, idxRestore, connectIdx, tmux.runs)
 	}
 }

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -187,9 +187,14 @@ func parseSuppressedHookCmds(out, event string) []string {
 	return cmds
 }
 
-// ensureSlots reconciles sidebar slot panes against the MRU budget. It is a
-// no-op when slots mode is disabled or no slot panes have been installed.
-// Called by the after-new-window hook via `demux event new_window`.
+// ensureSlots adds missing sidebar slot panes for the MRU-reserved windows.
+// It is a no-op when slots mode is disabled or no slot panes have been
+// installed. Called by the after-new-window hook via `demux event new_window`.
+//
+// Additive only - never kills panes. ReconcileSlots used to live here, but its
+// kill-pane fan-out cascades through the backgrounded after-kill-pane /
+// pane-exited handlers and saturates tmux's command queue. Dedupe and eviction
+// belong to `demux sidebar slots prune`.
 func ensureSlots() error {
 	cfg := loadConfig()
 	if !cfg.Sidebar.Sticky.Slots {
@@ -213,7 +218,7 @@ func ensureSlots() error {
 	if err != nil {
 		return err
 	}
-	return s.ReconcileSlots(reserved, parts[1], cfg.Sidebar.Sticky.Width)
+	return s.AddMissingSlots(reserved, cfg.Sidebar.Sticky.Width)
 }
 
 var sidebarSlotCmd = &cobra.Command{

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -148,8 +148,14 @@ func withHooksSuppressed(t sticky.Tmux, events []string, fn func() error) error 
 			continue
 		}
 		cmds := parseSuppressedHookCmds(out, ev)
+		// Snapshot the cmds only after the unset actually succeeds. Otherwise a
+		// failed `set-hook -gu` would leave the original hooks in place AND the
+		// deferred restore would re-append them, doubling every subsequent hook
+		// firing.
+		if err := t.Run("set-hook", "-gu", ev); err != nil {
+			continue
+		}
 		snapshots = append(snapshots, saved{event: ev, cmds: cmds})
-		_ = t.Run("set-hook", "-gu", ev)
 	}
 	defer func() {
 		for _, snap := range snapshots {

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -113,12 +113,22 @@ var sidebarSlotsPruneCmd = &cobra.Command{
 				if len(parts) < 2 {
 					return fmt.Errorf("unexpected current target %q", target)
 				}
+				// Look up the env-tracked active sidebar so ReconcileSlots
+				// preserves it across the current-window dedup. Best-effort:
+				// missing tty / unset env / read failure all degrade to no
+				// protection, which is the same behavior prune had before.
+				var protected string
+				if tty, ttyErr := s.CurrentClientTTY(); ttyErr == nil {
+					if v, set, envErr := s.ReadEnv(sticky.EnvKey(tty)); envErr == nil && set {
+						protected = v
+					}
+				}
 				_ = s.PruneMRU()
 				reserved, err := s.ComputeReservedWindows(parts[1], parts[0])
 				if err != nil {
 					return err
 				}
-				return s.ReconcileSlots(reserved, parts[1], cfg.Sidebar.Sticky.Width)
+				return s.ReconcileSlots(reserved, parts[1], protected, cfg.Sidebar.Sticky.Width)
 			})
 		})
 	},

--- a/cmd/sidebar.go
+++ b/cmd/sidebar.go
@@ -43,7 +43,7 @@ var sidebarShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Create the sticky sidebar pane if it does not already exist",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return stickyClient().Show(sidebarShowOpts())
+		return withEventLock(func() error { return stickyClient().Show(sidebarShowOpts()) })
 	},
 }
 
@@ -51,7 +51,7 @@ var sidebarHideCmd = &cobra.Command{
 	Use:   "hide",
 	Short: "Kill the sticky sidebar pane if it is currently shown",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return stickyClient().Hide()
+		return withEventLock(func() error { return stickyClient().Hide() })
 	},
 }
 
@@ -59,7 +59,7 @@ var sidebarToggleCmd = &cobra.Command{
 	Use:   "toggle",
 	Short: "Show the sticky sidebar pane if hidden, hide it if shown",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return stickyClient().Toggle(sidebarShowOpts())
+		return withEventLock(func() error { return stickyClient().Toggle(sidebarShowOpts()) })
 	},
 }
 
@@ -73,7 +73,7 @@ var sidebarSlotsInstallCmd = &cobra.Command{
 	Short: "Create a sidebar slot pane in every existing window",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := loadConfig()
-		return stickyClient().InstallSlotsInAllWindows(cfg.Sidebar.Sticky.Width)
+		return withEventLock(func() error { return stickyClient().InstallSlotsInAllWindows(cfg.Sidebar.Sticky.Width) })
 	},
 }
 
@@ -81,8 +81,110 @@ var sidebarSlotsUninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Kill every sidebar slot pane",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return stickyClient().UninstallSlots()
+		return withEventLock(func() error { return stickyClient().UninstallSlots() })
 	},
+}
+
+// sidebarSlotsPruneCmd reconciles the slot set against the MRU budget right
+// now, without waiting for an after-new-window event. Use it to clean up
+// corrupt state - e.g. duplicate slots in the same window from an old race,
+// or slot panes left behind in non-reserved windows.
+//
+// Each kill-pane issued by reconcile normally fires the after-kill-pane and
+// pane-exited tmux hooks, which fork backgrounded `demux event pane_closed` /
+// `demux event pane_exiting` handlers. Each handler walks every window on the
+// server and may itself issue more kill-pane calls, snowballing the cascade
+// until tmux's command queue is saturated. To make prune cheap and bounded
+// we temporarily clear those two hooks for the duration of the reconcile and
+// restore them afterwards.
+var sidebarSlotsPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Reconcile slot panes against the MRU budget right now (fixes duplicates and stale slots)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return withEventLock(func() error {
+			cfg := loadConfig()
+			s := stickyClient()
+			return withHooksSuppressed(s.T, []string{"after-kill-pane", "pane-exited"}, func() error {
+				target, err := s.T.Output("display-message", "-p", "#{session_id}:#{window_id}")
+				if err != nil {
+					return err
+				}
+				parts := strings.SplitN(strings.TrimSpace(target), ":", 2)
+				if len(parts) < 2 {
+					return fmt.Errorf("unexpected current target %q", target)
+				}
+				_ = s.PruneMRU()
+				reserved, err := s.ComputeReservedWindows(parts[1], parts[0])
+				if err != nil {
+					return err
+				}
+				return s.ReconcileSlots(reserved, parts[1], cfg.Sidebar.Sticky.Width)
+			})
+		})
+	},
+}
+
+// withHooksSuppressed clears the given tmux global hooks for the duration of
+// fn, restoring their original commands when fn returns. Used by prune to
+// stop pane_closed/pane_exiting handlers from cascading on every kill-pane
+// it issues.
+//
+// Both clear and restore are best-effort: if show-hooks fails for an event,
+// we skip it (no clear, nothing to restore). The restore runs via defer so
+// it fires even when fn panics.
+//
+// Side effects beyond fn: any third party that kills panes elsewhere on this
+// tmux server during the suppression window will also miss those hooks. The
+// window is short (a few tmux RPCs) so the trade is worth it.
+func withHooksSuppressed(t sticky.Tmux, events []string, fn func() error) error {
+	type saved struct {
+		event string
+		cmds  []string
+	}
+	var snapshots []saved
+	for _, ev := range events {
+		out, err := t.Output("show-hooks", "-g", ev)
+		if err != nil {
+			continue
+		}
+		cmds := parseSuppressedHookCmds(out, ev)
+		snapshots = append(snapshots, saved{event: ev, cmds: cmds})
+		_ = t.Run("set-hook", "-gu", ev)
+	}
+	defer func() {
+		for _, snap := range snapshots {
+			for _, c := range snap.cmds {
+				_ = t.Run("set-hook", "-ga", snap.event, c)
+			}
+		}
+	}()
+	return fn()
+}
+
+// parseSuppressedHookCmds extracts the command strings registered on event
+// from `tmux show-hooks -g <event>` output. Each input line has the form
+//
+//	after-kill-pane[0] run-shell -b "demux ..."
+//
+// and we return the trailing command portion (`run-shell -b "demux ..."`)
+// for each line whose prefix matches event.
+func parseSuppressedHookCmds(out, event string) []string {
+	var cmds []string
+	prefix := event + "["
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		// Skip past "event[N] " - the closing bracket may be followed by
+		// any digits, so find the first space after the prefix.
+		sp := strings.IndexByte(line, ' ')
+		if sp < 0 || sp+1 >= len(line) {
+			continue
+		}
+		cmds = append(cmds, line[sp+1:])
+	}
+	return cmds
 }
 
 // ensureSlots reconciles sidebar slot panes against the MRU budget. It is a
@@ -153,7 +255,7 @@ func runSidebarSlotPlaceholder(w io.Writer) {
 func init() {
 	rejectUnknownSubcommand(sidebarCmd)
 	rejectUnknownSubcommand(sidebarSlotsCmd)
-	sidebarSlotsCmd.AddCommand(sidebarSlotsInstallCmd, sidebarSlotsUninstallCmd)
+	sidebarSlotsCmd.AddCommand(sidebarSlotsInstallCmd, sidebarSlotsUninstallCmd, sidebarSlotsPruneCmd)
 	sidebarCmd.AddCommand(sidebarShowCmd, sidebarHideCmd, sidebarToggleCmd, sidebarSlotCmd, sidebarSlotsCmd)
 	rootCmd.AddCommand(sidebarCmd)
 }

--- a/cmd/sidebar_suppress_test.go
+++ b/cmd/sidebar_suppress_test.go
@@ -135,11 +135,55 @@ pane-exited[0] run-shell "logger b"
 	if len(got) != len(want) {
 		t.Fatalf("got %d cmds, want %d: %v", len(got), len(want), got)
 	}
+	// Order must match the input: tmux's bracket index ([0], [1], ...) reflects
+	// the registration order, and the restore loop re-appends via `set-hook
+	// -ga` in slice order. A future refactor that uses a map (unordered) would
+	// silently swap the bracket-indices on restore.
 	for i := range got {
 		if got[i] != want[i] {
 			t.Errorf("[%d] got %q want %q", i, got[i], want[i])
 		}
 	}
+}
+
+// Regression for the duplicate-hook bug: if `set-hook -gu` fails, the snapshot
+// for that event must not be saved, otherwise the deferred restore would
+// re-append the original hooks on top of the still-installed originals,
+// doubling every subsequent hook firing.
+func TestWithHooksSuppressed_UnsetFails_NoRestore(t *testing.T) {
+	tmux := &stubTmux{
+		outputs: map[string]string{
+			"show-hooks -g after-kill-pane": `after-kill-pane[0] run-shell -b "demux event pane_closed"` + "\n",
+		},
+	}
+	// Make `set-hook -gu after-kill-pane` fail.
+	// stubTmux.Run unconditionally returns nil today, so simulate failure by
+	// extending it via a wrapping struct.
+	wrapped := &failingUnsetTmux{stubTmux: tmux, failOn: "set-hook -gu after-kill-pane"}
+
+	if err := withHooksSuppressed(wrapped, []string{"after-kill-pane"}, func() error { return nil }); err != nil {
+		t.Fatalf("withHooksSuppressed: %v", err)
+	}
+	// No restore must have been attempted, since the snapshot wasn't taken.
+	for _, r := range tmux.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "set-hook -ga after-kill-pane") {
+			t.Errorf("expected NO restore when unset failed (would double hooks), got: %v", r)
+		}
+	}
+}
+
+type failingUnsetTmux struct {
+	*stubTmux
+	failOn string
+}
+
+func (f *failingUnsetTmux) Run(args ...string) error {
+	key := strings.Join(args, " ")
+	if key == f.failOn {
+		f.stubTmux.runs = append(f.stubTmux.runs, append([]string(nil), args...))
+		return errors.New("tmux: set-hook failed")
+	}
+	return f.stubTmux.Run(args...)
 }
 
 func indexOf(haystack []string, needle string) int {

--- a/cmd/sidebar_suppress_test.go
+++ b/cmd/sidebar_suppress_test.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stubTmux is a minimal sticky.Tmux for testing hook suppression.
+type stubTmux struct {
+	outputs map[string]string
+	outErrs map[string]error
+	runs    [][]string
+}
+
+func (s *stubTmux) key(args []string) string { return strings.Join(args, " ") }
+
+func (s *stubTmux) Run(args ...string) error {
+	s.runs = append(s.runs, append([]string(nil), args...))
+	return nil
+}
+
+func (s *stubTmux) Output(args ...string) (string, error) {
+	k := s.key(args)
+	if err, ok := s.outErrs[k]; ok {
+		return "", err
+	}
+	if v, ok := s.outputs[k]; ok {
+		return v, nil
+	}
+	return "", errors.New("no scripted output for: " + k)
+}
+
+func TestWithHooksSuppressed_ClearsAndRestores(t *testing.T) {
+	tmux := &stubTmux{
+		outputs: map[string]string{
+			"show-hooks -g after-kill-pane": `after-kill-pane[0] run-shell -b "demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true"
+`,
+			"show-hooks -g pane-exited": `pane-exited[0] run-shell -b "demux event pane_exiting --pane=#{hook_pane} 2>/dev/null; true"
+pane-exited[1] run-shell "logger second hook"
+`,
+		},
+	}
+
+	called := false
+	if err := withHooksSuppressed(tmux, []string{"after-kill-pane", "pane-exited"}, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("withHooksSuppressed: %v", err)
+	}
+	if !called {
+		t.Fatal("fn was not called")
+	}
+
+	wantOrder := []string{
+		"set-hook -gu after-kill-pane",
+		"set-hook -gu pane-exited",
+		`set-hook -ga after-kill-pane run-shell -b "demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true"`,
+		`set-hook -ga pane-exited run-shell -b "demux event pane_exiting --pane=#{hook_pane} 2>/dev/null; true"`,
+		`set-hook -ga pane-exited run-shell "logger second hook"`,
+	}
+	got := make([]string, len(tmux.runs))
+	for i, r := range tmux.runs {
+		got[i] = strings.Join(r, " ")
+	}
+	for _, want := range wantOrder {
+		found := false
+		for _, g := range got {
+			if g == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing tmux call %q\nactual: %v", want, got)
+		}
+	}
+	// Critical ordering: every clear must precede its matching restore.
+	idxClearKill := indexOf(got, "set-hook -gu after-kill-pane")
+	idxRestoreKill := indexOf(got, `set-hook -ga after-kill-pane run-shell -b "demux event pane_closed --pane=#{hook_pane} 2>/dev/null; true"`)
+	if idxClearKill < 0 || idxRestoreKill < 0 || idxClearKill > idxRestoreKill {
+		t.Errorf("after-kill-pane: clear must precede restore; clear=%d restore=%d", idxClearKill, idxRestoreKill)
+	}
+}
+
+func TestWithHooksSuppressed_RestoresOnFnError(t *testing.T) {
+	tmux := &stubTmux{
+		outputs: map[string]string{
+			"show-hooks -g after-kill-pane": `after-kill-pane[0] run-shell -b "demux event pane_closed ..."` + "\n",
+		},
+	}
+	sentinel := errors.New("boom")
+	err := withHooksSuppressed(tmux, []string{"after-kill-pane"}, func() error { return sentinel })
+	if err != sentinel {
+		t.Fatalf("want sentinel error, got %v", err)
+	}
+	// Restore must still run.
+	sawRestore := false
+	for _, r := range tmux.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "set-hook -ga after-kill-pane ") {
+			sawRestore = true
+		}
+	}
+	if !sawRestore {
+		t.Errorf("expected hook restore even when fn returned error, got runs: %v", tmux.runs)
+	}
+}
+
+func TestWithHooksSuppressed_NoHooksRegistered_StillCallsFn(t *testing.T) {
+	tmux := &stubTmux{
+		outputs: map[string]string{
+			"show-hooks -g after-kill-pane": "",
+		},
+	}
+	called := false
+	if err := withHooksSuppressed(tmux, []string{"after-kill-pane"}, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("withHooksSuppressed: %v", err)
+	}
+	if !called {
+		t.Errorf("fn must run even when no hooks were registered")
+	}
+}
+
+func TestParseSuppressedHookCmds_HandlesMultipleEntries(t *testing.T) {
+	in := `after-kill-pane[0] run-shell -b "demux event pane_closed"
+after-kill-pane[1] run-shell "logger a"
+pane-exited[0] run-shell "logger b"
+`
+	got := parseSuppressedHookCmds(in, "after-kill-pane")
+	want := []string{`run-shell -b "demux event pane_closed"`, `run-shell "logger a"`}
+	if len(got) != len(want) {
+		t.Fatalf("got %d cmds, want %d: %v", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func indexOf(haystack []string, needle string) int {
+	for i, h := range haystack {
+		if h == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/cmd/sidebar_test.go
+++ b/cmd/sidebar_test.go
@@ -26,7 +26,7 @@ func TestSidebarCmd_Subcommands(t *testing.T) {
 }
 
 func TestSidebarCmd_SlotsSubcommands(t *testing.T) {
-	for _, sub := range []string{"install", "uninstall"} {
+	for _, sub := range []string{"install", "uninstall", "prune"} {
 		cmd, _, _ := rootCmd.Find([]string{"sidebar", "slots", sub})
 		if cmd == nil || cmd.Name() != sub {
 			t.Errorf("expected `demux sidebar slots %s`, got %v", sub, cmd)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -103,11 +103,12 @@ func Merge(panes []tmux.Pane, entries []ConfigEntry) []Session {
 // from config. It does NOT switch or attach the client - callers that want to
 // connect should follow up with tmux.Connect.
 //
-// Split from connect so callers (e.g. `demux session connect`) can wrap the
-// launch in withHooksSuppressed("after-new-window"). Without that, each
-// new-window during launch fires a backgrounded `demux event new_window`
-// handler; the burst races with the eventual client-session-changed handler
-// and can leave the sidebar stranded in the source session.
+// Callers in the cmd layer (e.g. `demux session connect`) wrap this in
+// withHooksSuppressed("after-new-window") before invoking tmux.Connect.
+// Without the suppression, each new-window during launch fires a backgrounded
+// `demux event new_window` handler; the burst races with the eventual
+// client-session-changed handler and can leave the sidebar stranded in the
+// source session.
 func LaunchConfigSession(name, path string, windowIDs []string, templates map[string]WindowTemplate) error {
 	if err := tmux.NewSessionDetached(name, path); err != nil {
 		return err
@@ -119,13 +120,4 @@ func LaunchConfigSession(name, path string, windowIDs []string, templates map[st
 		}
 	}
 	return nil
-}
-
-// LaunchAndConnectConfigSession launches a new session from config and connects to it.
-// It creates a detached session, sets up windows, and connects the client.
-func LaunchAndConnectConfigSession(name, path string, windowIDs []string, templates map[string]WindowTemplate) error {
-	if err := LaunchConfigSession(name, path, windowIDs, templates); err != nil {
-		return err
-	}
-	return tmux.Connect(name)
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -99,9 +99,16 @@ func Merge(panes []tmux.Pane, entries []ConfigEntry) []Session {
 	return sessions
 }
 
-// LaunchAndConnectConfigSession launches a new session from config and connects to it.
-// It creates a detached session, sets up windows, and connects the client.
-func LaunchAndConnectConfigSession(name, path string, windowIDs []string, templates map[string]WindowTemplate) error {
+// LaunchConfigSession creates a detached tmux session and sets up its windows
+// from config. It does NOT switch or attach the client - callers that want to
+// connect should follow up with tmux.Connect.
+//
+// Split from connect so callers (e.g. `demux session connect`) can wrap the
+// launch in withHooksSuppressed("after-new-window"). Without that, each
+// new-window during launch fires a backgrounded `demux event new_window`
+// handler; the burst races with the eventual client-session-changed handler
+// and can leave the sidebar stranded in the source session.
+func LaunchConfigSession(name, path string, windowIDs []string, templates map[string]WindowTemplate) error {
 	if err := tmux.NewSessionDetached(name, path); err != nil {
 		return err
 	}
@@ -110,6 +117,15 @@ func LaunchAndConnectConfigSession(name, path string, windowIDs []string, templa
 		if err := tmux.CreateSessionWindows(name, path, specs); err != nil {
 			return fmt.Errorf("window setup: %w", err)
 		}
+	}
+	return nil
+}
+
+// LaunchAndConnectConfigSession launches a new session from config and connects to it.
+// It creates a detached session, sets up windows, and connects the client.
+func LaunchAndConnectConfigSession(name, path string, windowIDs []string, templates map[string]WindowTemplate) error {
+	if err := LaunchConfigSession(name, path, windowIDs, templates); err != nil {
+		return err
 	}
 	return tmux.Connect(name)
 }

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -87,7 +87,7 @@ func (s *Sticky) Follow() error {
 // windows. It does NOT kill stale or duplicate slots: the kill cascade
 // (after-kill-pane -> pane_closed -> SweepOrphanWindows -> more kill-pane)
 // can saturate tmux's command queue and freeze input. Eviction and dedupe
-// live in `demux sidebar slots prune` and the after-new-window event.
+// live in `demux sidebar slots prune`.
 //
 // Best-effort: errors are swallowed so the hook driving Follow never
 // crashes navigation.

--- a/internal/sticky/follow.go
+++ b/internal/sticky/follow.go
@@ -83,16 +83,21 @@ func (s *Sticky) Follow() error {
 }
 
 // maintainSlotsBudget prunes stale MRU entries, recomputes the reserved set
-// for currWindow/currSession, and reconciles slot panes so only reserved
-// windows hold placeholder slots. Best-effort: errors are swallowed so the
-// hook driving Follow never crashes navigation.
+// for currWindow/currSession, and ADDS missing slot panes for reserved
+// windows. It does NOT kill stale or duplicate slots: the kill cascade
+// (after-kill-pane -> pane_closed -> SweepOrphanWindows -> more kill-pane)
+// can saturate tmux's command queue and freeze input. Eviction and dedupe
+// live in `demux sidebar slots prune` and the after-new-window event.
+//
+// Best-effort: errors are swallowed so the hook driving Follow never
+// crashes navigation.
 func (s *Sticky) maintainSlotsBudget(currWindow, currSession string, width int) {
 	_ = s.PruneMRU()
 	reserved, err := s.ComputeReservedWindows(currWindow, currSession)
 	if err != nil {
 		return
 	}
-	_ = s.ReconcileSlots(reserved, currWindow, width)
+	_ = s.AddMissingSlots(reserved, width)
 }
 
 // ejectFocusIfOnSidebar moves the client focus to the next pane in the

--- a/internal/sticky/prepare.go
+++ b/internal/sticky/prepare.go
@@ -6,9 +6,15 @@ package sticky
 // without a one-time split-window flicker.
 //
 // Steps: push target to the head of the MRU, prune stale entries, recompute
-// the reserved set against the still-current window, and reconcile slot
-// panes. Reconcile will install the slot in target (it sits at MRU head, so
-// it's reserved) and evict any non-reserved slot that fell out of budget.
+// the reserved set against the still-current window, and add missing slots
+// for reserved windows. The target sits at MRU head and so is reserved -
+// AddMissingSlots installs it.
+//
+// Additive only: PrepareWindow never kills panes. Reconciling stale or
+// duplicate slots here would fire after-kill-pane -> backgrounded
+// pane_closed -> SweepOrphanWindows on every TUI session switch, the same
+// cascade that froze tmux input from the now-explicit `slots prune` path.
+// Eviction belongs to `demux sidebar slots prune`.
 //
 // No-op when slots mode is disabled, when no sidebar is active anywhere on
 // the server, or when targetWindowID is empty. Best-effort overall: callers
@@ -33,5 +39,5 @@ func (s *Sticky) PrepareWindow(targetWindowID string, width int) error {
 	if err != nil {
 		return err
 	}
-	return s.ReconcileSlots(reserved, window, width)
+	return s.AddMissingSlots(reserved, width)
 }

--- a/internal/sticky/prepare_test.go
+++ b/internal/sticky/prepare_test.go
@@ -85,3 +85,32 @@ func TestPrepareWindow_PushesMRUAndReconciles(t *testing.T) {
 		t.Errorf("expected new slot %%50 tagged in @5, got: %v", f.runs)
 	}
 }
+
+// Regression: PrepareWindow runs on every TUI session switch. ReconcileSlots
+// used to live here, which fired kill-pane for stale/duplicate slots and
+// cascaded through the backgrounded after-kill-pane -> pane_closed ->
+// SweepOrphanWindows path. Eviction now belongs to `demux sidebar slots
+// prune` only.
+func TestPrepareWindow_NeverKillsPanes(t *testing.T) {
+	f := newFakeTmux()
+	// Sidebar exists. Stale slot in non-reserved window @99 + duplicate in @1.
+	// Reconcile-based PrepareWindow would kill all three extras.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n%51 1\n%99 1\n"}
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{out: MRUEnvKey + "=@5\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@1\n"}
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@1\n@5\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@1 1\n"}
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	// AddMissingSlots -> EnsureSlotInWindow -> FindSlotInWindow for @5.
+	f.outputs["list-panes -t @5 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%5 1\n"}
+
+	s := &Sticky{T: f, Slots: true}
+	if err := s.PrepareWindow("@5", 35); err != nil {
+		t.Fatalf("PrepareWindow: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "kill-pane") {
+			t.Errorf("PrepareWindow must not kill panes (cleanup belongs to `slots prune`), got: %v", r)
+		}
+	}
+}

--- a/internal/sticky/promote.go
+++ b/internal/sticky/promote.go
@@ -51,6 +51,13 @@ func (s *Sticky) MaybePromoteSlot(opts ShowOpts) error {
 	if err != nil || slot == "" {
 		return nil
 	}
+	// Cross-client caveat: if a different client already tracks this slot as
+	// its active sidebar, the respawn-pane below kills that client's TUI
+	// process. This is acceptable for single-user multi-client setups (which
+	// is the demux target audience) - both clients end up with a fresh TUI
+	// in the same slot, and the env rewrite below repoints THIS client's
+	// tracking. Multi-user shared-tmux setups should not rely on the
+	// auto-promote behavior.
 	if err := s.T.Run("respawn-pane", "-k", "-t", slot, opts.Cmd); err != nil {
 		return nil
 	}

--- a/internal/sticky/promote.go
+++ b/internal/sticky/promote.go
@@ -1,0 +1,62 @@
+package sticky
+
+// MaybePromoteSlot activates the current window's sidebar slot if all of:
+//   - slots mode is enabled (s.Slots),
+//   - this client has no tracked sidebar (env unset or its pane is dead),
+//   - at least one slot pane exists somewhere on the server (i.e. the user has
+//     opted into slots via `demux sidebar slots install` or a prior `show`),
+//   - the current window already has a slot pane.
+//
+// Hooked into the session_changed / window_focus event so that switching to a
+// session with installed slots brings the sidebar along, without forcing every
+// session change through `auto_show=true` (which also fires on client attach).
+//
+// Unlike Show, this path is deliberately narrow: respawn the slot, record the
+// env, optionally focus. NO ReconcileSlots, NO EnsureSlotInWindow elsewhere.
+// Reconciliation would kick off a server-wide kill-pane cascade on every
+// keystroke that promotes a slot, and the resulting after-kill-pane sweeps
+// piling up would freeze tmux input. Slot hygiene is left to the
+// after-new-window event and the interactive `slots prune` escape hatch.
+//
+// Best-effort: any tmux failure short-circuits to nil so the navigation hook
+// driving this never crashes the user.
+func (s *Sticky) MaybePromoteSlot(opts ShowOpts) error {
+	if !s.Slots {
+		return nil
+	}
+	tty, err := s.CurrentClientTTY()
+	if err != nil {
+		return nil
+	}
+	key := EnvKey(tty)
+	val, set, err := s.ReadEnv(key)
+	if err != nil {
+		return nil
+	}
+	if set && val != "" {
+		alive, err := s.PaneAlive(val)
+		if err == nil && alive {
+			return nil
+		}
+	}
+	any, err := s.AnySlotExists()
+	if err != nil || !any {
+		return nil
+	}
+	target, _, _, err := s.currentTarget()
+	if err != nil {
+		return nil
+	}
+	slot, err := s.FindSlotInWindow(target)
+	if err != nil || slot == "" {
+		return nil
+	}
+	if err := s.T.Run("respawn-pane", "-k", "-t", slot, opts.Cmd); err != nil {
+		return nil
+	}
+	if err := s.WriteEnv(key, slot); err != nil {
+		return nil
+	}
+	s.maybeFocusOnOpen(slot)
+	return nil
+}

--- a/internal/sticky/promote_test.go
+++ b/internal/sticky/promote_test.go
@@ -1,0 +1,129 @@
+package sticky
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaybePromoteSlot_NotSlotsMode_Noop(t *testing.T) {
+	f := newFakeTmux()
+	s := &Sticky{T: f, Slots: false}
+	if err := s.MaybePromoteSlot(ShowOpts{Cmd: "demux --sticky", Width: 35}); err != nil {
+		t.Fatalf("MaybePromoteSlot: %v", err)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("expected no tmux runs when slots disabled, got: %v", f.runs)
+	}
+}
+
+func TestMaybePromoteSlot_EnvSetAndAlive_Noop(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{out: "DEMUX_STICKY_PANE__dev_ttys001=%42\n"}
+	f.outputs["list-panes -aF #{pane_id}"] = fakeReply{out: "%42\n"}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.MaybePromoteSlot(ShowOpts{Cmd: "demux --sticky", Width: 35}); err != nil {
+		t.Fatalf("MaybePromoteSlot: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "respawn-pane") {
+			t.Errorf("expected no respawn (env set, alive), got: %v", r)
+		}
+	}
+}
+
+func TestMaybePromoteSlot_NoAnySlot_Noop(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	// No slots anywhere.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: ""}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.MaybePromoteSlot(ShowOpts{Cmd: "demux --sticky", Width: 35}); err != nil {
+		t.Fatalf("MaybePromoteSlot: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "respawn-pane") {
+			t.Errorf("expected no respawn (user hasn't opted into slots), got: %v", r)
+		}
+	}
+}
+
+func TestMaybePromoteSlot_NoSlotInCurrentWindow_Noop(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	// Some other window has a slot, but not the current.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%99 1\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 \n"}
+	s := &Sticky{T: f, Slots: true}
+	if err := s.MaybePromoteSlot(ShowOpts{Cmd: "demux --sticky", Width: 35}); err != nil {
+		t.Fatalf("MaybePromoteSlot: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "respawn-pane") {
+			t.Errorf("expected no respawn (current window has no slot), got: %v", r)
+		}
+	}
+}
+
+func TestMaybePromoteSlot_HappyPath_RespawnsAndTracks(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+
+	s := &Sticky{T: f, Slots: true}
+	if err := s.MaybePromoteSlot(ShowOpts{Cmd: "demux --sticky", Width: 35}); err != nil {
+		t.Fatalf("MaybePromoteSlot: %v", err)
+	}
+
+	var respawned, wroteEnv bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "respawn-pane -k -t %50 demux --sticky" {
+			respawned = true
+		}
+		if j == "set-environment -g DEMUX_STICKY_PANE__dev_ttys001 %50" {
+			wroteEnv = true
+		}
+	}
+	if !respawned {
+		t.Errorf("expected respawn-pane of %%50, got: %v", f.runs)
+	}
+	if !wroteEnv {
+		t.Errorf("expected env to be written to %%50, got: %v", f.runs)
+	}
+}
+
+// Regression: MaybePromoteSlot must NOT call ReconcileSlots. Reconcile fires
+// kill-pane for stale/duplicate slots, which cascades into a backgrounded
+// pane_closed sweep storm. Doing that on every nav into a fresh-slot window
+// froze tmux input.
+func TestMaybePromoteSlot_DoesNotReconcileOrKill(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	// Two duplicate slots in current window plus a stale slot in a non-reserved
+	// window. A naive Show()-based promote would kill both extras.
+	f.outputs["list-panes -aF #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n%51 1\n%99 1\n"}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%50 1\n"}
+
+	s := &Sticky{T: f, Slots: true}
+	if err := s.MaybePromoteSlot(ShowOpts{Cmd: "demux --sticky", Width: 35}); err != nil {
+		t.Fatalf("MaybePromoteSlot: %v", err)
+	}
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "kill-pane") {
+			t.Errorf("promote must not kill panes (cleanup belongs to slots prune / new_window), got: %v", r)
+		}
+		if strings.HasPrefix(j, "list-windows") {
+			t.Errorf("promote must not enumerate windows for reconciliation, got: %v", r)
+		}
+	}
+}

--- a/internal/sticky/reconcile.go
+++ b/internal/sticky/reconcile.go
@@ -5,18 +5,21 @@ package sticky
 // placeholder is installed via EnsureSlotInWindow. For each window that has
 // a slot but is neither reserved nor currentWindow, the slot is killed.
 //
-// Within any single window, only one slot is kept (the first listed); extras
-// are killed. This recovers from corrupt state where a race in
-// EnsureSlotInWindow or a swap-pane edge case left two slot-tagged panes in
-// the same window.
+// Within any single window, only one slot is kept; extras are killed. This
+// recovers from corrupt state where a race in EnsureSlotInWindow or a
+// swap-pane edge case left two slot-tagged panes in the same window.
 //
-// currentWindow's first slot (the active sidebar) is never touched here - that
-// is the caller's responsibility via Show / Follow / swap-pane. Duplicates in
-// currentWindow ARE killed.
+// protectedPane is the env-tracked active sidebar pane id for the invoking
+// client ("" if none). When duplicates exist in currentWindow and one of
+// them is protectedPane, the protected pane is kept as survivor. This stops
+// prune from yanking the user's active sidebar - which would cascade: next
+// Follow sees the tracked pane dead and tears down every other slot via
+// UninstallSlots. Without the protection the survivor is whichever slot
+// tmux happens to list first.
 //
 // width is the column count passed to EnsureSlotInWindow when creating new
 // slots.
-func (s *Sticky) ReconcileSlots(reserved []string, currentWindow string, width int) error {
+func (s *Sticky) ReconcileSlots(reserved []string, currentWindow, protectedPane string, width int) error {
 	reservedSet := make(map[string]struct{}, len(reserved))
 	for _, w := range reserved {
 		reservedSet[w] = struct{}{}
@@ -29,11 +32,16 @@ func (s *Sticky) ReconcileSlots(reserved []string, currentWindow string, width i
 	existing := make(map[string]string)
 	for _, row := range slotLines(out, 3) {
 		wid, pid := row[0], row[1]
-		if _, has := existing[wid]; has {
-			// Duplicate slot in same window: kill the extra regardless of
-			// reserved/current status. Keeps invariant: at most one slot per
-			// window.
-			_ = s.T.Run("kill-pane", "-t", pid)
+		if prev, has := existing[wid]; has {
+			// Duplicate slot in same window: kill the extra. In currentWindow,
+			// if the incoming pane is the protected one and the kept pane is
+			// not, swap so the protected pane survives.
+			toKill := pid
+			if wid == currentWindow && protectedPane != "" && pid == protectedPane && prev != protectedPane {
+				toKill = prev
+				existing[wid] = pid
+			}
+			_ = s.T.Run("kill-pane", "-t", toKill)
 			continue
 		}
 		existing[wid] = pid

--- a/internal/sticky/reconcile.go
+++ b/internal/sticky/reconcile.go
@@ -5,8 +5,14 @@ package sticky
 // placeholder is installed via EnsureSlotInWindow. For each window that has
 // a slot but is neither reserved nor currentWindow, the slot is killed.
 //
-// currentWindow's slot (the active sidebar) is never touched here - that is
-// the caller's responsibility via Show / Follow / swap-pane.
+// Within any single window, only one slot is kept (the first listed); extras
+// are killed. This recovers from corrupt state where a race in
+// EnsureSlotInWindow or a swap-pane edge case left two slot-tagged panes in
+// the same window.
+//
+// currentWindow's first slot (the active sidebar) is never touched here - that
+// is the caller's responsibility via Show / Follow / swap-pane. Duplicates in
+// currentWindow ARE killed.
 //
 // width is the column count passed to EnsureSlotInWindow when creating new
 // slots.
@@ -23,9 +29,14 @@ func (s *Sticky) ReconcileSlots(reserved []string, currentWindow string, width i
 	existing := make(map[string]string)
 	for _, row := range slotLines(out, 3) {
 		wid, pid := row[0], row[1]
-		if _, has := existing[wid]; !has {
-			existing[wid] = pid
+		if _, has := existing[wid]; has {
+			// Duplicate slot in same window: kill the extra regardless of
+			// reserved/current status. Keeps invariant: at most one slot per
+			// window.
+			_ = s.T.Run("kill-pane", "-t", pid)
+			continue
 		}
+		existing[wid] = pid
 	}
 
 	for wid, pid := range existing {

--- a/internal/sticky/reconcile_test.go
+++ b/internal/sticky/reconcile_test.go
@@ -91,3 +91,79 @@ func TestReconcileSlots_IgnoresNonSlotPanes(t *testing.T) {
 		}
 	}
 }
+
+// Reproduces the corrupt-state bug observed in the wild: a window that ended up
+// with two slot-tagged panes (race in EnsureSlotInWindow + swap-pane edge case).
+// Reconcile must keep one and kill the rest so the duplicate placeholder pane
+// stops haunting the user.
+func TestReconcileSlots_DedupesDuplicatesWithinReservedWindow(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@1 %10 1\n@1 %11 1\n"}
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots([]string{"@1"}, "@9", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	var killed10, killed11 bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "kill-pane -t %10" {
+			killed10 = true
+		}
+		if j == "kill-pane -t %11" {
+			killed11 = true
+		}
+	}
+	if killed10 == killed11 {
+		t.Errorf("expected exactly one of %%10/%%11 to be killed (kept the other), got killed10=%v killed11=%v runs=%v",
+			killed10, killed11, f.runs)
+	}
+}
+
+// Same dedupe, but for the current window: the kept slot must not be killed
+// (that would yank the sidebar), and the extra must still go.
+func TestReconcileSlots_DedupesDuplicatesInCurrentWindow(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@9 %90 1\n@9 %91 1\n"}
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots(nil, "@9", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	var killed90, killed91 bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "kill-pane -t %90" {
+			killed90 = true
+		}
+		if j == "kill-pane -t %91" {
+			killed91 = true
+		}
+	}
+	if killed90 == killed91 {
+		t.Errorf("expected exactly one of %%90/%%91 to be killed (kept the other), got killed90=%v killed91=%v runs=%v",
+			killed90, killed91, f.runs)
+	}
+}
+
+// Non-reserved, non-current window with duplicate slots: kill them all.
+func TestReconcileSlots_KillsAllDuplicatesInNonReservedWindow(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@7 %70 1\n@7 %71 1\n"}
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots(nil, "@9", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	var killed70, killed71 bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "kill-pane -t %70" {
+			killed70 = true
+		}
+		if j == "kill-pane -t %71" {
+			killed71 = true
+		}
+	}
+	if !killed70 || !killed71 {
+		t.Errorf("expected both %%70 and %%71 killed (non-reserved window), got killed70=%v killed71=%v runs=%v",
+			killed70, killed71, f.runs)
+	}
+}

--- a/internal/sticky/reconcile_test.go
+++ b/internal/sticky/reconcile_test.go
@@ -14,7 +14,7 @@ func TestReconcileSlots_InstallsMissing(t *testing.T) {
 	f.outputs["split-window -f -h -b -d -l 35 -t @5 -P -F #{pane_id} "+SlotPlaceholderCmd] = fakeReply{out: "%900\n"}
 
 	s := &Sticky{T: f}
-	if err := s.ReconcileSlots([]string{"@5"}, "@1", 35); err != nil {
+	if err := s.ReconcileSlots([]string{"@5"}, "@1", "", 35); err != nil {
 		t.Fatalf("ReconcileSlots: %v", err)
 	}
 	saw := false
@@ -34,7 +34,7 @@ func TestReconcileSlots_EvictsNonReserved(t *testing.T) {
 	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@1 %10 1\n@2 %20 1\n@3 %30 1\n"}
 	// @1 already has slot - no install path needed.
 	s := &Sticky{T: f}
-	if err := s.ReconcileSlots([]string{"@1"}, "@3", 35); err != nil {
+	if err := s.ReconcileSlots([]string{"@1"}, "@3", "", 35); err != nil {
 		t.Fatalf("ReconcileSlots: %v", err)
 	}
 	var killed10, killed20, killed30 bool
@@ -65,7 +65,7 @@ func TestReconcileSlots_NoOpWhenAlreadyMatching(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@1 %10 1\n@2 %20 1\n"}
 	s := &Sticky{T: f}
-	if err := s.ReconcileSlots([]string{"@1", "@2"}, "@3", 35); err != nil {
+	if err := s.ReconcileSlots([]string{"@1", "@2"}, "@3", "", 35); err != nil {
 		t.Fatalf("ReconcileSlots: %v", err)
 	}
 	for _, r := range f.runs {
@@ -81,7 +81,7 @@ func TestReconcileSlots_IgnoresNonSlotPanes(t *testing.T) {
 	// Mix of slot and non-slot panes; only slots should be considered.
 	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@5 %50 1\n@5 %51 \n@6 %60 \n"}
 	s := &Sticky{T: f}
-	if err := s.ReconcileSlots([]string{"@5"}, "@1", 35); err != nil {
+	if err := s.ReconcileSlots([]string{"@5"}, "@1", "", 35); err != nil {
 		t.Fatalf("ReconcileSlots: %v", err)
 	}
 	for _, r := range f.runs {
@@ -100,7 +100,7 @@ func TestReconcileSlots_DedupesDuplicatesWithinReservedWindow(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@1 %10 1\n@1 %11 1\n"}
 	s := &Sticky{T: f}
-	if err := s.ReconcileSlots([]string{"@1"}, "@9", 35); err != nil {
+	if err := s.ReconcileSlots([]string{"@1"}, "@9", "", 35); err != nil {
 		t.Fatalf("ReconcileSlots: %v", err)
 	}
 	var killed10, killed11 bool
@@ -125,7 +125,7 @@ func TestReconcileSlots_DedupesDuplicatesInCurrentWindow(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@9 %90 1\n@9 %91 1\n"}
 	s := &Sticky{T: f}
-	if err := s.ReconcileSlots(nil, "@9", 35); err != nil {
+	if err := s.ReconcileSlots(nil, "@9", "", 35); err != nil {
 		t.Fatalf("ReconcileSlots: %v", err)
 	}
 	var killed90, killed91 bool
@@ -144,12 +144,70 @@ func TestReconcileSlots_DedupesDuplicatesInCurrentWindow(t *testing.T) {
 	}
 }
 
+// When the env-tracked active sidebar pane is among the duplicates in the
+// current window, ReconcileSlots must preserve it as survivor even when it
+// is not the first-listed pane. Otherwise prune would kill the user's
+// sidebar and the next Follow would cascade into UninstallSlots, tearing
+// down every other slot on the server.
+func TestReconcileSlots_DedupesDuplicatesInCurrentWindow_PreservesProtected(t *testing.T) {
+	f := newFakeTmux()
+	// %90 listed first, %91 is the env-tracked active sidebar.
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@9 %90 1\n@9 %91 1\n"}
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots(nil, "@9", "%91", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	var killed90, killed91 bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "kill-pane -t %90" {
+			killed90 = true
+		}
+		if j == "kill-pane -t %91" {
+			killed91 = true
+		}
+	}
+	if !killed90 {
+		t.Errorf("expected %%90 (non-protected duplicate) to be killed, got: %v", f.runs)
+	}
+	if killed91 {
+		t.Errorf("must not kill %%91 (env-tracked active sidebar), got: %v", f.runs)
+	}
+}
+
+// Symmetric to the above: protected pane happens to be listed first. The
+// non-protected duplicate must still be the one killed.
+func TestReconcileSlots_DedupesDuplicatesInCurrentWindow_ProtectedListedFirst(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@9 %91 1\n@9 %90 1\n"}
+	s := &Sticky{T: f}
+	if err := s.ReconcileSlots(nil, "@9", "%91", 35); err != nil {
+		t.Fatalf("ReconcileSlots: %v", err)
+	}
+	var killed90, killed91 bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "kill-pane -t %90" {
+			killed90 = true
+		}
+		if j == "kill-pane -t %91" {
+			killed91 = true
+		}
+	}
+	if !killed90 {
+		t.Errorf("expected %%90 (non-protected duplicate) to be killed, got: %v", f.runs)
+	}
+	if killed91 {
+		t.Errorf("must not kill %%91 (env-tracked active sidebar), got: %v", f.runs)
+	}
+}
+
 // Non-reserved, non-current window with duplicate slots: kill them all.
 func TestReconcileSlots_KillsAllDuplicatesInNonReservedWindow(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["list-panes -aF #{window_id} #{pane_id} #{@demux_slot}"] = fakeReply{out: "@7 %70 1\n@7 %71 1\n"}
 	s := &Sticky{T: f}
-	if err := s.ReconcileSlots(nil, "@9", 35); err != nil {
+	if err := s.ReconcileSlots(nil, "@9", "", 35); err != nil {
 		t.Fatalf("ReconcileSlots: %v", err)
 	}
 	var killed70, killed71 bool

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -102,12 +102,15 @@ func (s *Sticky) showSlotsMode(key string, opts ShowOpts) error {
 		return err
 	}
 	s.maybeFocusOnOpen(slot)
-	// Install slots only in the MRU-reserved set (capped at MRUMaxLen).
-	// Current window already has its own slot (the sidebar), so we pass it
-	// in explicitly so reconcile won't touch it.
+	// Install slots in MRU-reserved windows that lack one (additive only).
+	// Eviction and dedupe of stale/duplicate slots is deferred to
+	// `demux sidebar slots prune` so Show never triggers a kill-pane storm:
+	// each kill fires after-kill-pane -> backgrounded pane_closed ->
+	// SweepOrphanWindows -> potentially more kill-pane, saturating tmux's
+	// command queue enough to freeze input.
 	reserved, err := s.ComputeReservedWindows(currWindow, currSession)
 	if err == nil {
-		_ = s.ReconcileSlots(reserved, currWindow, opts.Width)
+		_ = s.AddMissingSlots(reserved, opts.Width)
 	}
 	return nil
 }

--- a/internal/sticky/show.go
+++ b/internal/sticky/show.go
@@ -2,8 +2,6 @@ package sticky
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 )
 
 // ShowOpts controls a Show invocation.
@@ -56,19 +54,9 @@ func (s *Sticky) showSplitMode(key string, opts ShowOpts) error {
 	if err != nil {
 		return err
 	}
-	out, err := s.T.Output(
-		"split-window", "-f", "-h", "-b", "-d",
-		"-l", strconv.Itoa(opts.Width),
-		"-t", target,
-		"-P", "-F", "#{pane_id}",
-		opts.Cmd,
-	)
+	newPane, err := s.splitSidebarPane(target, opts.Width, opts.Cmd)
 	if err != nil {
-		return fmt.Errorf("tmux split-window: %w", err)
-	}
-	newPane := strings.TrimSpace(out)
-	if newPane == "" {
-		return fmt.Errorf("tmux split-window returned empty pane id")
+		return err
 	}
 	if err := s.WriteEnv(key, newPane); err != nil {
 		return err

--- a/internal/sticky/show_test.go
+++ b/internal/sticky/show_test.go
@@ -204,6 +204,36 @@ func TestShow_FocusOnOpen_SlotsMode_SelectsSlot(t *testing.T) {
 	}
 }
 
+// Regression: Show must NOT issue kill-pane. Each kill fires after-kill-pane
+// -> backgrounded pane_closed -> SweepOrphanWindows, which can itself kill
+// more panes. A user with corrupt state (duplicate slots) running `demux
+// sidebar show` triggered a cascade that saturated tmux's command queue and
+// froze input. All slot eviction now belongs to `demux sidebar slots prune`.
+func TestShow_SlotsMode_NeverKillsPanes(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}
+	f.outputs["display-message -p #{client_tty}"] = fakeReply{out: "/dev/ttys001\n"}
+	f.outputs["show-environment -g DEMUX_STICKY_PANE__dev_ttys001"] = fakeReply{err: stderrExitError("unknown variable\n")}
+	f.outputs["display-message -p #{session_id}:#{window_id}"] = fakeReply{out: "$1:@7\n"}
+	// Two duplicate slots in current window plus a stale slot in @8 that's not
+	// in the reserved set. Naive ReconcileSlots would kill all three extras.
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{@demux_slot}"] = fakeReply{out: "%10 1\n%11 1\n"}
+	f.outputs["list-windows -aF #{window_id}"] = fakeReply{out: "@7\n"}
+	f.outputs["list-windows -t $1 -F #{window_id} #{window_last_flag}"] = fakeReply{out: "@7 0\n"}
+	f.outputs["display-message -p #{client_last_session}"] = fakeReply{out: "\n"}
+	f.outputs["show-environment -g "+MRUEnvKey] = fakeReply{err: stderrExitError("unknown variable\n")}
+
+	s := &Sticky{T: f, Slots: true}
+	if err := s.Show(ShowOpts{Width: 35, Cmd: "demux --sticky"}); err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "kill-pane") {
+			t.Errorf("Show must not kill panes, got: %v", r)
+		}
+	}
+}
+
 func TestShow_SplitFailure_Surfaces(t *testing.T) {
 	f := newFakeTmux()
 	f.outputs["-V"] = fakeReply{out: "tmux 3.3\n"}

--- a/internal/sticky/slots.go
+++ b/internal/sticky/slots.go
@@ -94,6 +94,20 @@ func (s *Sticky) EnsureSlotInWindow(target string, width int) error {
 	return nil
 }
 
+// AddMissingSlots ensures each window in reserved has at least one slot pane,
+// creating placeholders only where missing. Unlike ReconcileSlots it never
+// kills existing panes - safe to call from hot paths (Show, Follow) where a
+// kill-pane storm would cascade into pane_closed sweeps and saturate tmux.
+// Idempotent.
+func (s *Sticky) AddMissingSlots(reserved []string, width int) error {
+	for _, wid := range reserved {
+		if err := s.EnsureSlotInWindow(wid, width); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // InstallSlotsInAllWindows ensures every window on the server has a sidebar
 // slot pane at the given width. Idempotent.
 func (s *Sticky) InstallSlotsInAllWindows(width int) error {

--- a/internal/sticky/slots.go
+++ b/internal/sticky/slots.go
@@ -2,7 +2,6 @@ package sticky
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -72,19 +71,9 @@ func (s *Sticky) EnsureSlotInWindow(target string, width int) error {
 	if existing != "" {
 		return nil
 	}
-	out, err := s.T.Output(
-		"split-window", "-f", "-h", "-b", "-d",
-		"-l", strconv.Itoa(width),
-		"-t", target,
-		"-P", "-F", "#{pane_id}",
-		SlotPlaceholderCmd,
-	)
+	pane, err := s.splitSidebarPane(target, width, SlotPlaceholderCmd)
 	if err != nil {
-		return fmt.Errorf("tmux split-window slot: %w", err)
-	}
-	pane := strings.TrimSpace(out)
-	if pane == "" {
-		return fmt.Errorf("tmux split-window slot returned empty pane id")
+		return err
 	}
 	if err := s.T.Run("set-option", "-p", "-t", pane, SlotMarker, "1"); err != nil {
 		return fmt.Errorf("tmux set-option %s: %w", SlotMarker, err)

--- a/internal/sticky/split.go
+++ b/internal/sticky/split.go
@@ -1,0 +1,102 @@
+package sticky
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// splitSidebarPane runs the standard sidebar split-window invocation
+// (full-height, horizontal, before target, detached, exact width) and then
+// rebalances pane widths so the sidebar's footprint is absorbed by the
+// pane(s) immediately adjacent to it - not by tmux's default victim, which
+// for a left-side `-b` split is typically the rightmost pane.
+//
+// Without this rebalance, repeatedly opening + closing the sidebar ratchets
+// the rightmost pane smaller on every cycle: open shrinks the rightmost
+// (tmux default), close grows the leftmost-adjacent (also tmux default on
+// pane removal). The asymmetry compounds. With this rebalance both directions
+// move width through the same neighbour, so cycling open/close is stable.
+//
+// Algorithm: snapshot each pane's pane_left + pane_width before the split,
+// run split-window, then resize every original pane (rightmost-first by
+// pane_left) back to its recorded width - skipping the pane(s) in the
+// originally-leftmost column, which absorb the sidebar's width. Iterating
+// rightmost-first lets the width deficit propagate one neighbour at a time
+// until it lands on the adjacent column.
+//
+// Returns the new pane id.
+func (s *Sticky) splitSidebarPane(windowTarget string, width int, cmd string) (string, error) {
+	// Best-effort: if geometry can't be read, skip rebalance but still split.
+	// The rebalance is a cosmetic adjustment; failing to perform it must not
+	// block the user from opening the sidebar.
+	pre, minLeft, _ := s.listPaneGeometry(windowTarget)
+
+	out, err := s.T.Output(
+		"split-window", "-f", "-h", "-b", "-d",
+		"-l", strconv.Itoa(width),
+		"-t", windowTarget,
+		"-P", "-F", "#{pane_id}",
+		cmd,
+	)
+	if err != nil {
+		return "", fmt.Errorf("tmux split-window: %w", err)
+	}
+	newPane := strings.TrimSpace(out)
+	if newPane == "" {
+		return "", fmt.Errorf("tmux split-window returned empty pane id")
+	}
+
+	// Rightmost-first so each resize takes from its left neighbour, walking the
+	// deficit toward the leftmost-original column.
+	sort.SliceStable(pre, func(i, j int) bool { return pre[i].left > pre[j].left })
+	for _, p := range pre {
+		if p.left == minLeft {
+			continue
+		}
+		_ = s.T.Run("resize-pane", "-t", p.id, "-x", strconv.Itoa(p.width))
+	}
+	return newPane, nil
+}
+
+type paneGeometry struct {
+	id    string
+	left  int
+	width int
+}
+
+// listPaneGeometry returns one entry per pane in windowTarget plus the
+// smallest pane_left value (the originally-leftmost column). Lines that
+// don't parse cleanly are skipped; a window with no parseable panes returns
+// (nil, 0, nil) and callers should treat that as "nothing to rebalance."
+func (s *Sticky) listPaneGeometry(windowTarget string) ([]paneGeometry, int, error) {
+	out, err := s.T.Output("list-panes", "-t", windowTarget, "-F", "#{pane_id} #{pane_left} #{pane_width}")
+	if err != nil {
+		return nil, 0, fmt.Errorf("tmux list-panes: %w", err)
+	}
+	var panes []paneGeometry
+	minLeft := -1
+	for _, line := range nonEmptyLines(out) {
+		parts := strings.Fields(line)
+		if len(parts) < 3 {
+			continue
+		}
+		left, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		w, err := strconv.Atoi(parts[2])
+		if err != nil {
+			continue
+		}
+		panes = append(panes, paneGeometry{id: parts[0], left: left, width: w})
+		if minLeft < 0 || left < minLeft {
+			minLeft = left
+		}
+	}
+	if minLeft < 0 {
+		minLeft = 0
+	}
+	return panes, minLeft, nil
+}

--- a/internal/sticky/split.go
+++ b/internal/sticky/split.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	demuxlog "github.com/rtalexk/demux/internal/log"
 )
 
 // splitSidebarPane runs the standard sidebar split-window invocation
@@ -31,7 +33,10 @@ func (s *Sticky) splitSidebarPane(windowTarget string, width int, cmd string) (s
 	// Best-effort: if geometry can't be read, skip rebalance but still split.
 	// The rebalance is a cosmetic adjustment; failing to perform it must not
 	// block the user from opening the sidebar.
-	pre, minLeft, _ := s.listPaneGeometry(windowTarget)
+	pre, minLeft, geomErr := s.listPaneGeometry(windowTarget)
+	if geomErr != nil {
+		demuxlog.Debug("splitSidebarPane: geometry read failed, skipping rebalance", "target", windowTarget, "err", geomErr)
+	}
 
 	out, err := s.T.Output(
 		"split-window", "-f", "-h", "-b", "-d",

--- a/internal/sticky/split_test.go
+++ b/internal/sticky/split_test.go
@@ -1,0 +1,156 @@
+package sticky
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// 2-pane horizontal layout: nvim (left, 80 cols) + claude (right, 80 cols).
+// After the sidebar split tmux's default victim is the rightmost pane
+// (claude). We expect a resize-pane -t claude -x 80 so the width comes from
+// the leftmost-adjacent column (nvim) instead, keeping claude stable across
+// repeated open/close cycles.
+func TestSplitSidebarPane_RebalancesAdjacentAbsorbsWidth(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{pane_left} #{pane_width}"] = fakeReply{
+		out: "%nvim 0 80\n%claude 80 80\n",
+	}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%sidebar\n"}
+
+	s := &Sticky{T: f}
+	pane, err := s.splitSidebarPane("$1:@7", 35, "demux --sticky")
+	if err != nil {
+		t.Fatalf("splitSidebarPane: %v", err)
+	}
+	if pane != "%sidebar" {
+		t.Errorf("want pane %%sidebar, got %q", pane)
+	}
+
+	wantResize := "resize-pane -t %claude -x 80"
+	var sawResize bool
+	var sawNvimResize bool
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == wantResize {
+			sawResize = true
+		}
+		if j == "resize-pane -t %nvim -x 80" {
+			sawNvimResize = true
+		}
+	}
+	if !sawResize {
+		t.Errorf("expected %q so the rightmost pane keeps its width and the leftmost absorbs the sidebar's footprint, got runs: %v", wantResize, f.runs)
+	}
+	if sawNvimResize {
+		t.Errorf("must not resize the leftmost original pane back to its width - it has to absorb the sidebar's footprint; got: %v", f.runs)
+	}
+}
+
+// 3-pane horizontal layout (nvim, code, claude). Resizes must run
+// rightmost-first so the deficit propagates leftward and lands on nvim.
+func TestSplitSidebarPane_ThreePanes_RestoresRightmostFirst(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @9 -F #{pane_id} #{pane_left} #{pane_width}"] = fakeReply{
+		out: "%nvim 0 80\n%code 80 80\n%claude 160 80\n",
+	}
+	f.outputs["split-window -f -h -b -d -l 35 -t @9 -P -F #{pane_id} demux sidebar slot"] = fakeReply{out: "%sidebar\n"}
+
+	s := &Sticky{T: f}
+	if _, err := s.splitSidebarPane("@9", 35, SlotPlaceholderCmd); err != nil {
+		t.Fatalf("splitSidebarPane: %v", err)
+	}
+
+	var resizeOrder []string
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if strings.HasPrefix(j, "resize-pane -t %") {
+			resizeOrder = append(resizeOrder, j)
+		}
+	}
+	want := []string{
+		"resize-pane -t %claude -x 80",
+		"resize-pane -t %code -x 80",
+	}
+	if len(resizeOrder) != len(want) {
+		t.Fatalf("want %d resize calls, got %d: %v", len(want), len(resizeOrder), resizeOrder)
+	}
+	for i := range want {
+		if resizeOrder[i] != want[i] {
+			t.Errorf("resize order[%d]: want %q, got %q (full: %v)", i, want[i], resizeOrder[i], resizeOrder)
+		}
+	}
+}
+
+// Vertically-stacked panes in the leftmost column (nvim top, log bottom,
+// claude right). Both leftmost-column panes share pane_left=0 and must be
+// skipped from the rebalance so the column absorbs the sidebar's width.
+func TestSplitSidebarPane_VerticalStackInLeftColumn_SkipsAllLeftmost(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t @3 -F #{pane_id} #{pane_left} #{pane_width}"] = fakeReply{
+		out: "%nvim 0 80\n%log 0 80\n%claude 80 80\n",
+	}
+	f.outputs["split-window -f -h -b -d -l 35 -t @3 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%sidebar\n"}
+
+	s := &Sticky{T: f}
+	if _, err := s.splitSidebarPane("@3", 35, "demux --sticky"); err != nil {
+		t.Fatalf("splitSidebarPane: %v", err)
+	}
+
+	for _, r := range f.runs {
+		j := strings.Join(r, " ")
+		if j == "resize-pane -t %nvim -x 80" || j == "resize-pane -t %log -x 80" {
+			t.Errorf("must not resize panes in the leftmost column - the column has to absorb the sidebar's width; got: %v", r)
+		}
+	}
+	var sawClaude bool
+	for _, r := range f.runs {
+		if strings.Join(r, " ") == "resize-pane -t %claude -x 80" {
+			sawClaude = true
+		}
+	}
+	if !sawClaude {
+		t.Errorf("expected claude to be restored to its original width; got: %v", f.runs)
+	}
+}
+
+// Geometry-read failures must not block the split. The split itself still
+// runs and returns the new pane id; rebalance is silently skipped.
+func TestSplitSidebarPane_GeometryReadFails_StillSplits(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{pane_left} #{pane_width}"] = fakeReply{err: errors.New("tmux exploded")}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%88\n"}
+
+	s := &Sticky{T: f}
+	pane, err := s.splitSidebarPane("$1:@7", 35, "demux --sticky")
+	if err != nil {
+		t.Fatalf("splitSidebarPane: %v", err)
+	}
+	if pane != "%88" {
+		t.Errorf("want %%88, got %q", pane)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "resize-pane") {
+			t.Errorf("no rebalance possible without geometry, but got resize call: %v", r)
+		}
+	}
+}
+
+// Single-pane window has no neighbours to rebalance against. Split should run
+// and emit zero resize-pane calls (the lone pane is the leftmost and is
+// always skipped).
+func TestSplitSidebarPane_SinglePane_NoResize(t *testing.T) {
+	f := newFakeTmux()
+	f.outputs["list-panes -t $1:@7 -F #{pane_id} #{pane_left} #{pane_width}"] = fakeReply{out: "%only 0 160\n"}
+	f.outputs["split-window -f -h -b -d -l 35 -t $1:@7 -P -F #{pane_id} demux --sticky"] = fakeReply{out: "%new\n"}
+
+	s := &Sticky{T: f}
+	if _, err := s.splitSidebarPane("$1:@7", 35, "demux --sticky"); err != nil {
+		t.Fatalf("splitSidebarPane: %v", err)
+	}
+	for _, r := range f.runs {
+		if strings.HasPrefix(strings.Join(r, " "), "resize-pane") {
+			t.Errorf("single-pane window has nothing to rebalance, got: %v", r)
+		}
+	}
+}


### PR DESCRIPTION
## Context

Sticky sidebar slots mode shipped with three latent hazards that surfaced under heavy multi-window use:

1. **Kill-pane cascades during hot paths.** `Show`, `Follow`, `PrepareWindow`, and the `after-new-window` hook all reconciled the slot set on every fire, which meant a single kill-pane could fan out through backgrounded `pane_closed` / `pane_exiting` handlers, each running its own server-wide sweep. Under bursts (e.g. `demux session connect <multi-window-config>`) the cascade saturated tmux's command queue and froze input.
2. **Rightmost pane ratcheted smaller on every sidebar open/close cycle.** Tmux's default victim for a left `-b` split is the rightmost pane, but its default victim on pane removal is the leftmost-adjacent. The asymmetry compounded — open shrinks rightmost, close grows leftmost — so repeatedly toggling the sidebar slowly ate the user's chat / claude column.
3. **`demux session connect` against a multi-window config stranded the sidebar.** The new-window handler's `Follow` raced the legitimate `client-session-changed` handler's `Follow` during the launch burst, leaving the sidebar in the wrong window.

## What does this PR do

- **Additive-only slot reconciliation.** Adds `AddMissingSlots` and routes `Show`, `Follow`, `PrepareWindow`, `MaybePromoteSlot`, and the `after-new-window` event through it. Slot eviction and dedupe now live exclusively in `demux sidebar slots prune`.
- **`demux sidebar slots prune` subcommand.** Reconciles the slot set on demand. Wraps the work in `withHooksSuppressed`, which clears `after-kill-pane` / `pane-exited` for the duration of the reconcile so its kill-pane calls do not cascade into a sweep storm. Snapshot is taken only after `set-hook -gu` succeeds (so a failed unset cannot leak doubled hooks on restore).
- **Preserves env-tracked active sidebar across prune dedup.** `ReconcileSlots` now takes a `protectedPane` parameter; when duplicates exist in the current window and one of them is the env-tracked sidebar, the protected pane wins. Without this, prune could yank the user's sidebar and cascade into `UninstallSlots` via the next `Follow`.
- **Auto-promote slot on session change.** `MaybePromoteSlot` (called from `session_changed` / `window_focus` handlers) activates the current window's slot when the client has no live sidebar tracked, without going through `Show` (which would Reconcile and kick off a cascade).
- **Rebalance pane widths after sidebar split.** `splitSidebarPane` snapshots pre-split widths, then issues `resize-pane` calls rightmost-first to restore them, so the leftmost original column absorbs the sidebar's footprint instead of the rightmost. Open/close cycles are now stable.
- **session-connect race fix.** `launchConfigSessionAndConnect` wraps only window creation in `after-new-window` suppression, restores the hook before `tmux.Connect`, so the legitimate `client-session-changed` Follow still fires.
- **Drops dead `LaunchAndConnectConfigSession`** and tightens stale comments around the rename.

### Out of scope (known gaps, follow-ups)

- `internal/sticky/reconcile.go:56` swallows errors from `EnsureSlotInWindow` in the install loop. Self-heals on next nav via `AddMissingSlots`, so left as-is.
- README troubleshooting does not link the slot placeholder SIGHUP / pty-leak rationale documented in `cmd/sidebar.go:240-251`. Doc polish only.

## Manual QA

> Sticky sidebar feature is per-client tmux state. Verify by opening tmux, attaching demux, and exercising each scenario against a live tmux server. Run all scenarios with `[sidebar.sticky] slots = true` set in `~/.config/demux/demux.toml`.

### Prerequisites

<details>

<summary>1. tmux >= 2.6 attached with demux hooks installed.</summary>

\`\`\`bash
tmux -V
demux hooks install
tmux show-hooks -g | grep demux
\`\`\`

Expect demux entries on `after-new-window`, `after-kill-pane`, `pane-exited`, `client-session-changed`, `after-select-window`, `client-attached`. If missing, rerun `demux hooks install`.

</details>

<details>

<summary>2. Slots mode enabled in config.</summary>

\`\`\`bash
grep -A2 "sidebar.sticky" ~/.config/demux/demux.toml
\`\`\`

Expect `slots = true` under `[sidebar.sticky]`. If not, edit the file or run `demux config init` and toggle it.

</details>

<details>

<summary>3. Built demux on this branch.</summary>

\`\`\`bash
go build -o demux . && ./demux --version
\`\`\`

Confirm the binary is from the current checkout.

</details>

### Setup

Start with a clean slate so changes are observable:

\`\`\`bash
demux sidebar hide          # tear down any prior slots
tmux show-environment -g | grep DEMUX_STICKY
\`\`\`

Expect no `DEMUX_STICKY_PANE_*` and no `DEMUX_STICKY_MRU` entries.

<details>

<summary>Scenario 1 — Sidebar open/close cycle preserves rightmost pane width</summary>

Reproduces the pre-fix ratchet on the rightmost pane.

1. In a fresh tmux window with two horizontal panes (nvim left, claude right, both ~80 cols), record widths:
   \`\`\`bash
   tmux list-panes -F "#{pane_id} #{pane_left} #{pane_width}"
   \`\`\`
2. `demux sidebar show` — sidebar appears as leftmost column. Re-list panes; expected: claude (rightmost) still has its original width, nvim (leftmost-adjacent) is `original - sidebar_width`.
3. `demux sidebar hide`. Re-list panes; expected: claude unchanged, nvim restored to its original width.
4. Repeat steps 2-3 four more times. Expected: claude width stays constant across every cycle. Pre-fix: claude shrinks by a few columns each cycle.

</details>

<details>

<summary>Scenario 2 — Multi-window session connect lands sidebar in the right window</summary>

Reproduces the session-connect race.

1. Add a multi-window session config:
   \`\`\`toml
   [[session]]
   name = "qa-multi"
   path = "~"
   [[session.window]]
   name = "a"
   [[session.window]]
   name = "b"
   [[session.window]]
   name = "c"
   \`\`\`
2. From a tmux client with the sidebar already shown (`demux sidebar show`), run:
   \`\`\`bash
   demux session connect qa-multi
   \`\`\`
3. After connect settles, the active window should be `c` (last defined). Confirm sidebar is in window `c`:
   \`\`\`bash
   tmux display-message -p "#{window_id} #{window_name}"
   tmux list-panes -t :. -F "#{pane_id} #{@demux_slot} #{pane_title}"
   \`\`\`
   Expected: at most one `@demux_slot=1` row, the active pane is the user pane (not the sidebar).
4. Confirm no stranded duplicate slots elsewhere:
   \`\`\`bash
   tmux list-panes -aF "#{window_id} #{pane_id} #{@demux_slot}" | awk '$3==1'
   \`\`\`
   Expected: at most one slot per window.

</details>

<details>

<summary>Scenario 3 — Auto-promote slot on session change</summary>

1. With two demux-configured sessions `A` and `B` both having `demux sidebar slots install` run at least once, attach to `A`, run `demux sidebar show`, then close the sidebar pane manually via `prefix x`.
2. Switch to session `B` (`prefix s`, select B). Expected: the slot in B's current window automatically respawns as the active sidebar (you see `demux --sticky` running in the slot pane).
3. Verify env tracking:
   \`\`\`bash
   tmux show-environment -g | grep DEMUX_STICKY_PANE
   \`\`\`
   Expected: one entry, pointing at the now-active slot pane.

</details>

<details>

<summary>Scenario 4 — slots prune preserves the active sidebar across dedup (F1 regression)</summary>

Forces the corrupt-state case where the current window has two slot-tagged panes and the env-tracked one is not first-listed.

1. With sidebar shown, capture the active sidebar pane id:
   \`\`\`bash
   tmux show-environment -g | grep DEMUX_STICKY_PANE
   \`\`\`
2. Manually tag a second pane in the same window as a slot (simulating corruption):
   \`\`\`bash
   tmux split-window -h -d
   tmux set-option -p -t :.+ @demux_slot 1
   \`\`\`
3. Confirm two slot panes in current window, env-tracked one second:
   \`\`\`bash
   tmux list-panes -F "#{pane_id} #{@demux_slot}" | awk '$2==1'
   \`\`\`
4. Run `demux sidebar slots prune`.
5. Re-list slot panes; expected: exactly one slot pane in the current window, and it is the **same pane id** captured in step 1 (the env-tracked one).
6. Navigate to another window and back. Expected: sidebar follows correctly, no cascade into `UninstallSlots` (other windows still have their slots — check `tmux list-panes -aF "#{window_id} #{@demux_slot}" | awk '$2==1'`).

</details>

<details>

<summary>Scenario 5 — new-window burst does not freeze tmux input</summary>

Stress-tests the additive invariant.

1. With slots mode active and an existing sidebar, rapidly create windows:
   \`\`\`bash
   for i in $(seq 1 10); do tmux new-window; done
   \`\`\`
2. Immediately try to type / send keys. Expected: tmux remains responsive throughout. Pre-fix: input could freeze for several seconds while the cascade drained.
3. After the burst settles, confirm slots populated additively:
   \`\`\`bash
   tmux list-panes -aF "#{window_id} #{@demux_slot}" | awk '$2==1' | sort -u
   \`\`\`
   Expected: at most one slot per MRU-reserved window, capped at `MRUMaxLen` (8 placeholders + 1 active sidebar).

</details>

### Automated checks

\`\`\`bash
go build ./...
go test ./...
gofmt -l .
\`\`\`

All pass on this branch (204 tests in `internal/sticky` + `cmd`).