### PR TITLE
Auto-clean demux state on pane/window/session close

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,9 +962,13 @@ If the named session is configured in `sessions.toml` or `private.toml` but not 
 
 demux uses tmux hooks to clear `done` states when you navigate between panes,
 windows, or sessions, so you always know if a tool finished while you were
-away, plus the hooks that drive the sticky sidebar. These hooks are registered
-and kept up to date automatically by `demux hooks install` — see
-[Enable the tmux hooks](#enable-the-tmux-hooks) for the one-time setup.
+away, plus the hooks that drive the sticky sidebar. demux also clears a
+target's state automatically when its pane, window, or session is closed
+(`after-kill-pane`, `window-unlinked`, and `session-closed`), cascading to
+descendant panes, so killing a window or session leaves no stale rows behind.
+These hooks are registered and kept up to date automatically by
+`demux hooks install`, see [Enable the tmux hooks](#enable-the-tmux-hooks)
+for the one-time setup.
 
 ### Tmux Status Bar
 
@@ -1165,6 +1169,8 @@ demux status --format text         # plain text summary
 # Hooks
 demux event pane_focus             # clear done states for the focused pane (used by tmux hooks)
 demux event pane_focus [--pane-id <%N>] [--window-id <@N>] [--session-id <$N>]
+demux event window_closed --window <@N>   # clear state for a closed window + its panes (used by tmux hooks)
+demux event session_closed --session <$N> # clear state for a closed session + its windows/panes (used by tmux hooks)
 
 # Config
 demux config init                  # print default config to stdout

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -216,6 +216,10 @@ var eventSessionClosedCmd = &cobra.Command{
 // then runs the orphan sweep as a catch-all. Both steps are best-effort: a
 // failure is logged and the handler still returns nil so the tmux hook stays
 // quiet. The hook ID may be empty on some tmux versions; the sweep covers that.
+//
+// Unlike pane_closed, this handler does no sticky-sidebar mutation - it is pure
+// DB work, like applyPaneFocus - so it intentionally does not take
+// withEventLock. The state writes serialize at the SQLite layer.
 func applyWindowClosed(d *db.DB, windowID string) error {
 	demuxlog.Debug("window_closed", "window_id", windowID)
 	if windowID != "" {

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -220,6 +220,11 @@ var eventSessionClosedCmd = &cobra.Command{
 // Unlike pane_closed, this handler does no sticky-sidebar mutation - it is pure
 // DB work, like applyPaneFocus - so it intentionally does not take
 // withEventLock. The state writes serialize at the SQLite layer.
+//
+// Known limitation: window-unlinked also fires for a window that is still alive
+// in another session (linked windows). This over-deletes that window's state,
+// but it self-heals on the next state-set hook, and demux never creates linked
+// windows, so the case is accepted.
 func applyWindowClosed(d *db.DB, windowID string) error {
 	demuxlog.Debug("window_closed", "window_id", windowID)
 	if windowID != "" {

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -182,6 +182,73 @@ var eventPaneClosedCmd = &cobra.Command{
 	},
 }
 
+var eventWindowClosedWindowID string
+
+var eventWindowClosedCmd = &cobra.Command{
+	Use:   "window_closed",
+	Short: "Clear state for a closed tmux window and its panes (called by the window-unlinked hook)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		d, err := openDB()
+		if err != nil {
+			return err
+		}
+		defer d.Close()
+		return applyWindowClosed(d, eventWindowClosedWindowID)
+	},
+}
+
+var eventSessionClosedSessionID string
+
+var eventSessionClosedCmd = &cobra.Command{
+	Use:   "session_closed",
+	Short: "Clear state for a closed tmux session and its windows/panes (called by the session-closed hook)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		d, err := openDB()
+		if err != nil {
+			return err
+		}
+		defer d.Close()
+		return applySessionClosed(d, eventSessionClosedSessionID)
+	},
+}
+
+// applyWindowClosed deletes the closed window's state row and its pane rows,
+// then runs the orphan sweep as a catch-all. Both steps are best-effort: a
+// failure is logged and the handler still returns nil so the tmux hook stays
+// quiet. The hook ID may be empty on some tmux versions; the sweep covers that.
+func applyWindowClosed(d *db.DB, windowID string) error {
+	demuxlog.Debug("window_closed", "window_id", windowID)
+	if windowID != "" {
+		if n, err := d.StateDeleteByWindow(windowID); err != nil {
+			demuxlog.Error("window_closed: delete by window failed", "window_id", windowID, "err", err)
+		} else {
+			demuxlog.Debug("window_closed: deleted", "window_id", windowID, "rows", n)
+		}
+	}
+	if _, _, err := sweepOrphans(d); err != nil {
+		demuxlog.Warn("window_closed: orphan sweep failed", "err", err)
+	}
+	return nil
+}
+
+// applySessionClosed deletes all state rows for the closed session (session,
+// window, and pane rows all carry session_id), then runs the orphan sweep as a
+// catch-all. Best-effort, same rationale as applyWindowClosed.
+func applySessionClosed(d *db.DB, sessionID string) error {
+	demuxlog.Debug("session_closed", "session_id", sessionID)
+	if sessionID != "" {
+		if n, err := d.StateDeleteBySession(sessionID); err != nil {
+			demuxlog.Error("session_closed: delete by session failed", "session_id", sessionID, "err", err)
+		} else {
+			demuxlog.Debug("session_closed: deleted", "session_id", sessionID, "rows", n)
+		}
+	}
+	if _, _, err := sweepOrphans(d); err != nil {
+		demuxlog.Warn("session_closed: orphan sweep failed", "err", err)
+	}
+	return nil
+}
+
 // runWindowFocus is the shared handler for the window_focus and session_changed
 // events. It clears resting done-states for the focused pane (like pane_focus)
 // and moves the sticky sidebar to the focused window/session.
@@ -413,6 +480,9 @@ func init() {
 	eventPaneClosedCmd.Flags().StringVar(&eventPaneClosedWindowID, "window", "", "Stable window ID (@N format) of the killed pane's window (optional)")
 	eventPaneClosedCmd.MarkFlagRequired("pane")
 
+	eventWindowClosedCmd.Flags().StringVar(&eventWindowClosedWindowID, "window", "", "Stable window ID (@N format) of the closed window")
+	eventSessionClosedCmd.Flags().StringVar(&eventSessionClosedSessionID, "session", "", "Stable session ID ($N format) of the closed session")
+
 	for _, c := range []*cobra.Command{eventWindowFocusCmd, eventSessionChangedCmd} {
 		c.Flags().String("pane-id", "", "Stable pane ID (%N format); auto-detected if omitted")
 		c.Flags().String("window-id", "", "Stable window ID (@N format); auto-detected if omitted")
@@ -420,6 +490,6 @@ func init() {
 	}
 
 	rejectUnknownSubcommand(eventCmd)
-	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd, eventClientAttachedCmd, eventWindowFocusCmd, eventSessionChangedCmd, eventNewWindowCmd)
+	eventCmd.AddCommand(eventPaneFocusCmd, eventHookErrorCmd, eventPaneExitingCmd, eventPaneClosedCmd, eventClientAttachedCmd, eventWindowFocusCmd, eventSessionChangedCmd, eventNewWindowCmd, eventWindowClosedCmd, eventSessionClosedCmd)
 	rootCmd.AddCommand(eventCmd)
 }

--- a/cmd/event.go
+++ b/cmd/event.go
@@ -212,50 +212,38 @@ var eventSessionClosedCmd = &cobra.Command{
 	},
 }
 
-// applyWindowClosed deletes the closed window's state row and its pane rows,
-// then runs the orphan sweep as a catch-all. Both steps are best-effort: a
-// failure is logged and the handler still returns nil so the tmux hook stays
+// applyClosedCleanup is shared by window_closed and session_closed. It calls
+// deleteFn(id) when id is non-empty (best-effort, errors logged), then runs
+// the orphan sweep as a catch-all. Always returns nil so the tmux hook stays
 // quiet. The hook ID may be empty on some tmux versions; the sweep covers that.
 //
-// Unlike pane_closed, this handler does no sticky-sidebar mutation - it is pure
-// DB work, like applyPaneFocus - so it intentionally does not take
-// withEventLock. The state writes serialize at the SQLite layer.
+// No sticky-sidebar mutation here (pure DB work), so no withEventLock needed;
+// state writes serialize at the SQLite layer.
 //
-// Known limitation: window-unlinked also fires for a window that is still alive
-// in another session (linked windows). This over-deletes that window's state,
-// but it self-heals on the next state-set hook, and demux never creates linked
-// windows, so the case is accepted.
-func applyWindowClosed(d *db.DB, windowID string) error {
-	demuxlog.Debug("window_closed", "window_id", windowID)
-	if windowID != "" {
-		if n, err := d.StateDeleteByWindow(windowID); err != nil {
-			demuxlog.Error("window_closed: delete by window failed", "window_id", windowID, "err", err)
+// Known limitation: window-unlinked also fires for a window still alive in
+// another session (linked windows). This over-deletes, but self-heals on the
+// next state-set hook. demux never creates linked windows, so this is accepted.
+func applyClosedCleanup(d *db.DB, event, idKey, id string, deleteFn func(string) (int64, error)) error {
+	demuxlog.Debug(event, idKey, id)
+	if id != "" {
+		if n, err := deleteFn(id); err != nil {
+			demuxlog.Error(event+": delete failed", idKey, id, "err", err)
 		} else {
-			demuxlog.Debug("window_closed: deleted", "window_id", windowID, "rows", n)
+			demuxlog.Debug(event+": deleted", idKey, id, "rows", n)
 		}
 	}
 	if _, _, err := sweepOrphans(d); err != nil {
-		demuxlog.Warn("window_closed: orphan sweep failed", "err", err)
+		demuxlog.Warn(event+": orphan sweep failed", "err", err)
 	}
 	return nil
 }
 
-// applySessionClosed deletes all state rows for the closed session (session,
-// window, and pane rows all carry session_id), then runs the orphan sweep as a
-// catch-all. Best-effort, same rationale as applyWindowClosed.
+func applyWindowClosed(d *db.DB, windowID string) error {
+	return applyClosedCleanup(d, "window_closed", "window_id", windowID, d.StateDeleteByWindow)
+}
+
 func applySessionClosed(d *db.DB, sessionID string) error {
-	demuxlog.Debug("session_closed", "session_id", sessionID)
-	if sessionID != "" {
-		if n, err := d.StateDeleteBySession(sessionID); err != nil {
-			demuxlog.Error("session_closed: delete by session failed", "session_id", sessionID, "err", err)
-		} else {
-			demuxlog.Debug("session_closed: deleted", "session_id", sessionID, "rows", n)
-		}
-	}
-	if _, _, err := sweepOrphans(d); err != nil {
-		demuxlog.Warn("session_closed: orphan sweep failed", "err", err)
-	}
-	return nil
+	return applyClosedCleanup(d, "session_closed", "session_id", sessionID, d.StateDeleteBySession)
 }
 
 // runWindowFocus is the shared handler for the window_focus and session_changed

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -266,3 +266,95 @@ func TestEventWindowEventsRegistered(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyWindowClosed_CascadeDeletesWindowAndPanes(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	orig := sweepOrphans
+	sweepOrphans = func(*db.DB) (int64, bool, error) { return 0, false, nil }
+	defer func() { sweepOrphans = orig }()
+
+	wt := windowTarget("@5", "$0")
+	p1 := paneTarget("%10", "@5", "$0")
+	other := paneTarget("%99", "@9", "$0")
+	d.StateSet(wt, "claude", db.StateWorking, "", db.SourceTool, false, nil)
+	d.StateSet(p1, "claude", db.StateWorking, "", db.SourceTool, false, nil)
+	d.StateSet(other, "claude", db.StateWorking, "", db.SourceTool, false, nil)
+
+	if err := applyWindowClosed(d, "@5"); err != nil {
+		t.Fatal(err)
+	}
+	if st, _ := d.StateByID(wt); st != nil {
+		t.Error("window state should be deleted")
+	}
+	if st, _ := d.StateByID(p1); st != nil {
+		t.Error("pane state in closed window should be deleted")
+	}
+	if st, _ := d.StateByID(other); st == nil {
+		t.Error("unrelated pane state should survive")
+	}
+}
+
+func TestApplyWindowClosed_EmptyIDStillSweeps(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	swept := false
+	orig := sweepOrphans
+	sweepOrphans = func(*db.DB) (int64, bool, error) { swept = true; return 0, false, nil }
+	defer func() { sweepOrphans = orig }()
+
+	if err := applyWindowClosed(d, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !swept {
+		t.Error("sweep should run even when window ID is empty")
+	}
+}
+
+func TestApplySessionClosed_CascadeDeletesSession(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	orig := sweepOrphans
+	sweepOrphans = func(*db.DB) (int64, bool, error) { return 0, false, nil }
+	defer func() { sweepOrphans = orig }()
+
+	inS0 := paneTarget("%10", "@5", "$0")
+	winS0 := windowTarget("@5", "$0")
+	inS1 := paneTarget("%20", "@8", "$1")
+	d.StateSet(inS0, "claude", db.StateWorking, "", db.SourceTool, false, nil)
+	d.StateSet(winS0, "claude", db.StateWorking, "", db.SourceTool, false, nil)
+	d.StateSet(inS1, "claude", db.StateWorking, "", db.SourceTool, false, nil)
+
+	if err := applySessionClosed(d, "$0"); err != nil {
+		t.Fatal(err)
+	}
+	if st, _ := d.StateByID(inS0); st != nil {
+		t.Error("pane in closed session should be deleted")
+	}
+	if st, _ := d.StateByID(winS0); st != nil {
+		t.Error("window in closed session should be deleted")
+	}
+	if st, _ := d.StateByID(inS1); st == nil {
+		t.Error("state in other session should survive")
+	}
+}
+
+func TestEventCloseCommandsRegistered(t *testing.T) {
+	want := map[string]bool{"window_closed": false, "session_closed": false}
+	for _, c := range eventCmd.Commands() {
+		if _, ok := want[c.Use]; ok {
+			want[c.Use] = true
+			if c.RunE == nil {
+				t.Errorf("%s command has no RunE", c.Use)
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("event %s subcommand not registered", name)
+		}
+	}
+}

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -342,6 +342,23 @@ func TestApplySessionClosed_CascadeDeletesSession(t *testing.T) {
 	}
 }
 
+func TestApplySessionClosed_EmptyIDStillSweeps(t *testing.T) {
+	d, _ := db.Open(":memory:")
+	defer d.Close()
+
+	swept := false
+	orig := sweepOrphans
+	sweepOrphans = func(*db.DB) (int64, bool, error) { swept = true; return 0, false, nil }
+	defer func() { sweepOrphans = orig }()
+
+	if err := applySessionClosed(d, ""); err != nil {
+		t.Fatal(err)
+	}
+	if !swept {
+		t.Error("sweep should run even when session ID is empty")
+	}
+}
+
 func TestEventCloseCommandsRegistered(t *testing.T) {
 	want := map[string]bool{"window_closed": false, "session_closed": false}
 	for _, c := range eventCmd.Commands() {

--- a/cmd/event_test.go
+++ b/cmd/event_test.go
@@ -17,6 +17,13 @@ func windowTarget(windowID, sessionID string) db.Target {
 	return db.Target{Type: db.TargetTypeWindow, ID: windowID, WindowID: windowID, SessionID: sessionID}
 }
 
+func stubSweep(t *testing.T, fn func(*db.DB) (int64, bool, error)) {
+	t.Helper()
+	orig := sweepOrphans
+	sweepOrphans = fn
+	t.Cleanup(func() { sweepOrphans = orig })
+}
+
 func TestPaneFocusClearsDoneStates(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
@@ -271,9 +278,7 @@ func TestApplyWindowClosed_CascadeDeletesWindowAndPanes(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	orig := sweepOrphans
-	sweepOrphans = func(*db.DB) (int64, bool, error) { return 0, false, nil }
-	defer func() { sweepOrphans = orig }()
+	stubSweep(t, func(*db.DB) (int64, bool, error) { return 0, false, nil })
 
 	wt := windowTarget("@5", "$0")
 	p1 := paneTarget("%10", "@5", "$0")
@@ -301,9 +306,7 @@ func TestApplyWindowClosed_EmptyIDStillSweeps(t *testing.T) {
 	defer d.Close()
 
 	swept := false
-	orig := sweepOrphans
-	sweepOrphans = func(*db.DB) (int64, bool, error) { swept = true; return 0, false, nil }
-	defer func() { sweepOrphans = orig }()
+	stubSweep(t, func(*db.DB) (int64, bool, error) { swept = true; return 0, false, nil })
 
 	if err := applyWindowClosed(d, ""); err != nil {
 		t.Fatal(err)
@@ -317,9 +320,7 @@ func TestApplySessionClosed_CascadeDeletesSession(t *testing.T) {
 	d, _ := db.Open(":memory:")
 	defer d.Close()
 
-	orig := sweepOrphans
-	sweepOrphans = func(*db.DB) (int64, bool, error) { return 0, false, nil }
-	defer func() { sweepOrphans = orig }()
+	stubSweep(t, func(*db.DB) (int64, bool, error) { return 0, false, nil })
 
 	inS0 := paneTarget("%10", "@5", "$0")
 	winS0 := windowTarget("@5", "$0")
@@ -347,9 +348,7 @@ func TestApplySessionClosed_EmptyIDStillSweeps(t *testing.T) {
 	defer d.Close()
 
 	swept := false
-	orig := sweepOrphans
-	sweepOrphans = func(*db.DB) (int64, bool, error) { swept = true; return 0, false, nil }
-	defer func() { sweepOrphans = orig }()
+	stubSweep(t, func(*db.DB) (int64, bool, error) { swept = true; return 0, false, nil })
 
 	if err := applySessionClosed(d, ""); err != nil {
 		t.Fatal(err)

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/rtalexk/demux/internal/db"
 	"github.com/rtalexk/demux/internal/tmux"
 	"github.com/spf13/cobra"
 )
@@ -18,10 +19,14 @@ var gcStatesCmd = &cobra.Command{
 	RunE:  runGCStates,
 }
 
-func runGCStates(_ *cobra.Command, _ []string) error {
+// sweepOrphanStates deletes state rows whose tmux target is no longer live.
+// It returns the number of rows deleted and skipped=true when no live tmux
+// targets are found (sweep skipped to avoid wiping the table during a tmux
+// outage). Shared by `demux gc states` and the window/session close handlers.
+func sweepOrphanStates(d *db.DB) (deleted int64, skipped bool, err error) {
 	panes, err := tmux.ListPanes()
 	if err != nil {
-		return fmt.Errorf("tmux not available: %w", err)
+		return 0, false, fmt.Errorf("tmux not available: %w", err)
 	}
 
 	livePaneIDs := make(map[string]bool, len(panes))
@@ -40,22 +45,37 @@ func runGCStates(_ *cobra.Command, _ []string) error {
 	}
 
 	if len(livePaneIDs) == 0 && len(liveWindowIDs) == 0 && len(liveSessionIDs) == 0 {
-		fmt.Println("No live tmux targets found; skipping GC to avoid data loss.")
-		return nil
+		return 0, true, nil
 	}
 
+	n, err := d.StateGCOrphaned(livePaneIDs, liveWindowIDs, liveSessionIDs)
+	if err != nil {
+		return 0, false, fmt.Errorf("gc states: %w", err)
+	}
+	return n, false, nil
+}
+
+// sweepOrphans is the orphan-state sweep, indirected so event-handler tests can
+// stub it (the real sweep shells out to tmux, which is unavailable in tests).
+var sweepOrphans = sweepOrphanStates
+
+func runGCStates(_ *cobra.Command, _ []string) error {
 	d, err := openDB()
 	if err != nil {
 		return err
 	}
 	defer d.Close()
 
-	n, err := d.StateGCOrphaned(livePaneIDs, liveWindowIDs, liveSessionIDs)
+	deleted, skipped, err := sweepOrphanStates(d)
 	if err != nil {
-		return fmt.Errorf("gc states: %w", err)
+		return err
 	}
-	if n > 0 {
-		fmt.Printf("Removed %d orphaned state record(s).\n", n)
+	if skipped {
+		fmt.Println("No live tmux targets found; skipping GC to avoid data loss.")
+		return nil
+	}
+	if deleted > 0 {
+		fmt.Printf("Removed %d orphaned state record(s).\n", deleted)
 	} else {
 		fmt.Println("No orphaned state records found.")
 	}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -66,7 +66,7 @@ func runGCStates(_ *cobra.Command, _ []string) error {
 	}
 	defer d.Close()
 
-	deleted, skipped, err := sweepOrphanStates(d)
+	deleted, skipped, err := sweepOrphans(d)
 	if err != nil {
 		return err
 	}

--- a/internal/db/states.go
+++ b/internal/db/states.go
@@ -397,6 +397,17 @@ func (d *DB) StateDeleteBySession(sessionID string) (int64, error) {
 	return res.RowsAffected()
 }
 
+// StateDeleteByWindow removes the window's own state row and all pane rows
+// belonging to it. Window-target rows and pane rows both carry window_id, so a
+// single delete cascades window + its panes. Returns the rows deleted.
+func (d *DB) StateDeleteByWindow(windowID string) (int64, error) {
+	res, err := d.sql.Exec(`DELETE FROM tool_states WHERE window_id = ?`, windowID)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 // StateByID returns the ToolState for the given target identity, or nil if no record exists (idle).
 func (d *DB) StateByID(t Target) (*ToolState, error) {
 	row := d.sql.QueryRow(`

--- a/internal/db/states_test.go
+++ b/internal/db/states_test.go
@@ -424,6 +424,42 @@ func TestStateDeleteBySession_DeletesAll(t *testing.T) {
 	}
 }
 
+func TestStateDeleteByWindow_CascadesPanesAndWindow(t *testing.T) {
+	d, _ := Open(":memory:")
+	defer d.Close()
+
+	// Window @5 with two panes, plus an unrelated window @6 with one pane.
+	win5 := Target{Type: TargetTypeWindow, ID: "@5", SessionID: "$0", WindowID: "@5"}
+	p1 := Target{Type: TargetTypePane, ID: "%10", SessionID: "$0", WindowID: "@5", PaneID: "%10"}
+	p2 := Target{Type: TargetTypePane, ID: "%11", SessionID: "$0", WindowID: "@5", PaneID: "%11"}
+	win6 := Target{Type: TargetTypeWindow, ID: "@6", SessionID: "$0", WindowID: "@6"}
+	p3 := Target{Type: TargetTypePane, ID: "%12", SessionID: "$0", WindowID: "@6", PaneID: "%12"}
+
+	d.StateSet(win5, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(p1, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(p2, "make", StateDone, "", SourceTool, false, nil)
+	d.StateSet(win6, "claude", StateWorking, "", SourceTool, false, nil)
+	d.StateSet(p3, "claude", StateWorking, "", SourceTool, false, nil)
+
+	n, err := d.StateDeleteByWindow("@5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Errorf("expected 3 rows deleted (window + 2 panes), got %d", n)
+	}
+	for _, gone := range []Target{win5, p1, p2} {
+		if st, _ := d.StateByID(gone); st != nil {
+			t.Errorf("expected %s deleted, still present", gone.ID)
+		}
+	}
+	for _, kept := range []Target{win6, p3} {
+		if st, _ := d.StateByID(kept); st == nil {
+			t.Errorf("expected %s to survive, was deleted", kept.ID)
+		}
+	}
+}
+
 func TestStateSet_StoresPaneID(t *testing.T) {
 	d, _ := Open(":memory:")
 	defer d.Close()

--- a/internal/tmuxhooks/hooks.go
+++ b/internal/tmuxhooks/hooks.go
@@ -49,6 +49,8 @@ func DesiredHooks() []Hook {
 		{Event: "after-kill-pane", Command: `run-shell -b 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'`},
 		{Event: "pane-exited", Command: `run-shell -b 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'`},
 		{Event: "after-new-window", Command: `run-shell -b 'demux event new_window 2>/dev/null; true'`},
+		{Event: "window-unlinked", Command: `run-shell -b 'demux event window_closed --window=#{hook_window} 2>/dev/null; true'`},
+		{Event: "session-closed", Command: `run-shell -b 'demux event session_closed --session=#{hook_session} 2>/dev/null; true'`},
 	}
 }
 

--- a/internal/tmuxhooks/hooks.go
+++ b/internal/tmuxhooks/hooks.go
@@ -49,6 +49,9 @@ func DesiredHooks() []Hook {
 		{Event: "after-kill-pane", Command: `run-shell -b 'demux event pane_closed --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'`},
 		{Event: "pane-exited", Command: `run-shell -b 'demux event pane_exiting --pane=#{hook_pane} --window=#{hook_window} 2>/dev/null; true'`},
 		{Event: "after-new-window", Command: `run-shell -b 'demux event new_window 2>/dev/null; true'`},
+		// window_closed and session_closed clear state for a closed window or
+		// session (and its descendants). Backgrounded (-b) like the other DB
+		// hooks so the run-shell never blocks the tmux server's command queue.
 		{Event: "window-unlinked", Command: `run-shell -b 'demux event window_closed --window=#{hook_window} 2>/dev/null; true'`},
 		{Event: "session-closed", Command: `run-shell -b 'demux event session_closed --session=#{hook_session} 2>/dev/null; true'`},
 	}

--- a/internal/tmuxhooks/hooks_test.go
+++ b/internal/tmuxhooks/hooks_test.go
@@ -11,8 +11,8 @@ func TestDesiredHooksExcludesClientAttached(t *testing.T) {
 	if len(hooks) == 0 {
 		t.Fatal("DesiredHooks returned empty set")
 	}
-	if len(hooks) != 7 {
-		t.Errorf("DesiredHooks: want 7 entries, got %d", len(hooks))
+	if len(hooks) != 9 {
+		t.Errorf("DesiredHooks: want 9 entries, got %d", len(hooks))
 	}
 	for _, h := range hooks {
 		if h.Event == "client-attached" {
@@ -28,6 +28,7 @@ func TestDesiredHooksCoversExpectedEvents(t *testing.T) {
 	want := []string{
 		"after-select-pane", "after-select-window", "client-session-changed",
 		"client-focus-in", "after-kill-pane", "pane-exited", "after-new-window",
+		"window-unlinked", "session-closed",
 	}
 	got := map[string]bool{}
 	for _, h := range DesiredHooks() {


### PR DESCRIPTION
## Context

When a tmux pane is killed, demux automatically clears its tool-state so the TUI doesn't show stale rows. However, killing a window or session left orphaned state rows until a manual `demux gc states` run. This gap means users could see stale "working" or "error" states for windows/sessions they closed hours ago.

This PR extends the auto-cleanup to windows and sessions, cascading to their descendant panes, with a GC-sweep fallback. Panes already covered by the existing `pane_closed` hook are now backstopped by the cascade, improving robustness against tmux edge cases.

## What does this PR do

**Database layer**
- Adds `StateDeleteByWindow(windowID)` to cascade-delete a window's own state row and all pane rows belonging to that window (identified by `window_id` column).
- Reuses existing `StateDeleteBySession` which cascades across all rows for a session (panes, windows, session).

**Event handlers**
- Extracts `sweepOrphanStates(d *db.DB) (deleted int64, skipped bool, err error)` from `runGCStates` into a reusable helper. The sweep is indirected via `var sweepOrphans` for test stubbing.
- Adds `applyWindowClosed` and `applySessionClosed` handlers (best-effort: log errors, always return nil so tmux hooks stay quiet). Each does a targeted cascade delete by hook ID, then sweeps orphans as a catch-all. Lock-free because state-only (serialized at SQLite).
- Registers `window_closed` and `session_closed` cobra subcommands with `--window` and `--session` flags.

**Tmux integration**
- Registers `window-unlinked` and `session-closed` hooks in `DesiredHooks()`, firing `demux event window_closed` and `demux event session_closed` respectively. Both backgrounded (`run-shell -b`) so never block the tmux command queue.
- Hook set changes trigger auto-reconcile on next client attach (HooksHash changes).

**Documentation**
- README: extended the "Hooks" section to mention automatic cleanup on pane/window/session close, with cascade semantics. Added quick-reference lines for the new event commands.
- Code comments: document why the handlers skip `withEventLock` (state-only, no sticky mutation), and note the linked-window limitation (low-impact, acceptable, self-healing).

### Out of scope

- Sticky sidebar interaction: sidebar sweeps already handle windows left behind by pane kills; window/session close inherits those same sweeps.
- Migration or schema change: state rows use pre-existing columns; no DB schema change.
- New config field: hooks are auto-managed; no configuration user choice needed.

## Manual QA

> Feature adds automatic tmux hooks that fire on window/session close. Core logic (cascade delete, sweep fallback) is covered by unit tests (TestStateDeleteByWindow, TestApplyWindowClosed, TestApplySessionClosed). Manual verification confirms the e2e integration.

### Prerequisites

<details>

<summary>1. demux binary is built and hooks are registered.</summary>

```bash
cd /Users/rtalex/com.github/demux/state-cleanup
go build -o /tmp/demux-qa .
/tmp/demux-qa hooks install --tool tmux
```

Expect output: "Registered demux hooks in the live tmux server" or "Updated ~/.tmux.conf".

Verify the hooks were installed:

```bash
tmux show-hooks -g | grep -E 'window-unlinked|session-closed'
```

Expect two lines (exact command strings).

</details>

### Scenario 1 — Window close clears descendant panes

1. In a tmux session, create a new window and a pane in it.
2. Set state on the window and its pane (simulating a running tool):
   ```bash
   /tmp/demux-qa state set --target-id @5 --state working --tool claude
   /tmp/demux-qa state set --target-id %10 --state working --tool claude
   /tmp/demux-qa state ls --format text
   ```
   Expect: both rows present in the output.
3. Kill the window:
   ```bash
   tmux kill-window -t @5
   ```
4. Verify state is gone (no row for @5 or %10):
   ```bash
   /tmp/demux-qa state ls --format text
   ```
   Expect: neither row appears (rows were deleted by the window-unlinked hook).

### Scenario 2 — Session close clears all windows and panes

1. Create a new session with a couple of windows and panes.
2. Set state on the session, a window, and panes:
   ```bash
   /tmp/demux-qa state set --target-id '$2' --state working --tool test
   /tmp/demux-qa state set --target-id '@7' --state working --tool test
   /tmp/demux-qa state set --target-id '%20' --state working --tool test
   /tmp/demux-qa state ls --format text
   ```
   Expect: three rows (session, window, pane).
3. Kill the session:
   ```bash
   tmux kill-session -t 2
   ```
4. Verify all three are gone:
   ```bash
   /tmp/demux-qa state ls --format text
   ```
   Expect: none of the three rows appear (session-closed hook deleted them).

### Scenario 3 — Existing pane close still works

1. Set state on a pane:
   ```bash
   /tmp/demux-qa state set --target-id '%1' --state working --tool test
   ```
2. Kill the pane:
   ```bash
   tmux kill-pane -t %1
   ```
3. Verify the pane state is gone:
   ```bash
   /tmp/demux-qa state ls --format text
   ```
   Expect: no row for %1 (existing `after-kill-pane` hook still works).

