### PR TITLE
feat(tui): per-session cpu/mem readout + caffeinate flag in sidebar

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -398,7 +398,7 @@ func Default() Config {
 			ColorTodo: "",
 			IconNote:  "✏",
 
-			IconCaffeine: "", // nf-fa-coffee
+			IconCaffeine: "\uf0f4", // nf-fa-coffee
 
 			IconTmuxSession: "⊞",
 			IconCfgSession:  "⚙︎",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,8 @@ type ThemeConfig struct {
 	ColorTodo string `toml:"color_todo"`
 	IconNote  string `toml:"icon_note"`
 
+	IconCaffeine string `toml:"icon_caffeine"`
+
 	IconTmuxSession string `toml:"icon_tmux_session"`
 	IconCfgSession  string `toml:"icon_cfg_session"`
 
@@ -253,6 +255,7 @@ type SidebarConfig struct {
 	FocusSearchOnOpen      bool                `toml:"focus_search_on_open"`
 	SearchSort             string              `toml:"search_sort"`
 	ShowLastSeen           bool                `toml:"show_last_seen"`
+	ShowSessionStats       bool                `toml:"show_session_stats"`
 	ActiveSessionIcon      string              `toml:"active_session_icon"`
 	Sort                   []string            `toml:"sort"`
 	SwitchFocus            string              `toml:"switch_focus"`
@@ -319,6 +322,7 @@ func Default() Config {
 			SwitchFocus:       "severity",
 			Width:             DefaultSidebarWidth,
 			ShowLastSeen:      true,
+			ShowSessionStats:  true,
 			ActiveSessionIcon: DefaultActiveSessionIcon,
 			SessionView:       SidebarViewRow,
 			CardSeparator:     CardSeparatorBlank,
@@ -393,6 +397,8 @@ func Default() Config {
 			IconTodo:  "☑︎",
 			ColorTodo: "",
 			IconNote:  "✏",
+
+			IconCaffeine: "", // nf-fa-coffee
 
 			IconTmuxSession: "⊞",
 			IconCfgSession:  "⚙︎",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -431,6 +431,13 @@ func TestDefaults_SidebarShowLastSeen(t *testing.T) {
 	}
 }
 
+func TestDefaults_SidebarShowSessionStats(t *testing.T) {
+	cfg := config.Default()
+	if !cfg.Sidebar.ShowSessionStats {
+		t.Error("expected Sidebar.ShowSessionStats to default to true")
+	}
+}
+
 func TestLoad_StatusBarShowFalse(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "demux.toml")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -124,11 +124,12 @@ type Model struct {
 	sessionIDMap map[string]string // $N → "session_name"
 	nameToIDMap  map[string]string // "session_name" → $N
 
-	sidebar  SidebarModel
-	procList ProcListModel
-	detail   DetailModel
-	yank     yankModel
-	help     HelpModel
+	sidebar      SidebarModel
+	procList     ProcListModel
+	detail       DetailModel
+	yank         yankModel
+	help         HelpModel
+	sessionStats SessionStatsModel
 
 	showYank    bool
 	showHelp    bool

--- a/internal/tui/model_stats_test.go
+++ b/internal/tui/model_stats_test.go
@@ -1,0 +1,40 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+)
+
+func TestHandleProcDataMsg_PopulatesSessionStats(t *testing.T) {
+	var m Model
+	m.cfg.Sidebar.ShowSessionStats = true
+	m.procGen = 0
+	m.panes = []tmux.Pane{{Session: "s", PanePID: 100}}
+
+	msg := procDataMsg{
+		gen:    0,
+		procs:  []proc.Process{{PID: 100, PPID: 1, CPU: 7, MemRSS: 50 * 1024 * 1024, Name: "zsh"}},
+		cwdMap: map[int32]string{},
+	}
+	m2, _ := m.handleProcDataMsg(msg)
+	st, ok := m2.sidebar.stats["s"]
+	if !ok {
+		t.Fatalf("sidebar stats not populated for session 's'")
+	}
+	if st.CPUNow != 7 {
+		t.Errorf("CPUNow = %v, want 7", st.CPUNow)
+	}
+}
+
+func TestHandleProcDataMsg_DisabledSkipsStats(t *testing.T) {
+	var m Model
+	m.cfg.Sidebar.ShowSessionStats = false
+	m.panes = []tmux.Pane{{Session: "s", PanePID: 100}}
+	msg := procDataMsg{gen: 0, procs: []proc.Process{{PID: 100, PPID: 1, CPU: 7, MemRSS: 1, Name: "zsh"}}, cwdMap: map[int32]string{}}
+	m2, _ := m.handleProcDataMsg(msg)
+	if _, ok := m2.sidebar.stats["s"]; ok {
+		t.Errorf("stats should be empty when ShowSessionStats is false")
+	}
+}

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -298,6 +298,10 @@ func (m Model) handleProcDataMsg(msg procDataMsg) (Model, tea.Cmd) {
 	if patterns := m.cfg.Sidebar.ProcessPatterns(); len(patterns) > 0 {
 		m.sidebar.SetProcLabels(procmatch.Match(m.panes, m.procs, patterns, m.cfg.IgnoredProcesses))
 	}
+	if m.cfg.Sidebar.ShowSessionStats {
+		m.sessionStats.Update(m.panes, m.procs)
+		m.sidebar.SetSessionStats(m.sessionStats.Snapshot())
+	}
 	if node := m.sidebar.Selected(); node != nil {
 		m.procList.SetSessionData(m.panes, node.Session, m.procs, m.cwdMap, m.gitInfo, m.cfg)
 	}

--- a/internal/tui/session_stats.go
+++ b/internal/tui/session_stats.go
@@ -75,3 +75,78 @@ func humanizeBytes(b uint64) string {
 	}
 	return fmt.Sprintf("%.1fGB", float64(b)/float64(gib))
 }
+
+// statsPeakWindow is the number of recent samples retained per session for the
+// rolling peak. At the ~2s proc-poll interval this is ~2 minutes of history.
+const statsPeakWindow = 60
+
+type statSample struct {
+	cpu float64
+	mem uint64
+}
+
+// SessionStatsModel computes per-session resource totals each refresh and
+// tracks a rolling-window peak. The zero value is ready to use; maps are
+// lazily initialized in Update.
+type SessionStatsModel struct {
+	rings map[string][]statSample
+	cur   map[string]SessionStat
+}
+
+// Update recomputes current totals for every live session and rolls the peak
+// window forward. Sessions absent from panes are pruned.
+func (m *SessionStatsModel) Update(panes []tmux.Pane, procs []proc.Process) {
+	if m.rings == nil {
+		m.rings = make(map[string][]statSample)
+	}
+	tree := proc.BuildTree(procs)
+	byPID := indexByPID(procs)
+	grouped := tmux.GroupBySessions(panes)
+
+	newRings := make(map[string][]statSample, len(grouped))
+	newCur := make(map[string]SessionStat, len(grouped))
+
+	for session, windows := range grouped {
+		var sessionPanes []tmux.Pane
+		for _, wPanes := range windows {
+			sessionPanes = append(sessionPanes, wPanes...)
+		}
+		cpu, mem, caf := computeSessionTotals(sessionPanes, byPID, tree)
+
+		ring := append(m.rings[session], statSample{cpu: cpu, mem: mem})
+		if len(ring) > statsPeakWindow {
+			ring = ring[len(ring)-statsPeakWindow:]
+		}
+		newRings[session] = ring
+
+		var cpuPeak float64
+		var memPeak uint64
+		for _, s := range ring {
+			if s.cpu > cpuPeak {
+				cpuPeak = s.cpu
+			}
+			if s.mem > memPeak {
+				memPeak = s.mem
+			}
+		}
+		newCur[session] = SessionStat{
+			CPUNow:      cpu,
+			MemNow:      mem,
+			CPUPeak:     cpuPeak,
+			MemPeak:     memPeak,
+			Caffeinated: caf,
+		}
+	}
+
+	m.rings = newRings // pruning: sessions not in `grouped` are dropped
+	m.cur = newCur
+}
+
+// Snapshot returns the latest per-session stats. The returned map is replaced
+// wholesale on each Update; callers must treat it as read-only.
+func (m SessionStatsModel) Snapshot() map[string]SessionStat {
+	if m.cur == nil {
+		return map[string]SessionStat{}
+	}
+	return m.cur
+}

--- a/internal/tui/session_stats.go
+++ b/internal/tui/session_stats.go
@@ -1,0 +1,77 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+)
+
+// SessionStat is the resource readout for one tmux session: live totals,
+// rolling peaks, and whether caffeinate is live in the session's pane trees.
+type SessionStat struct {
+	CPUNow      float64
+	MemNow      uint64
+	CPUPeak     float64
+	MemPeak     uint64
+	Caffeinated bool
+}
+
+// indexByPID builds a PID -> Process lookup over a snapshot.
+func indexByPID(procs []proc.Process) map[int32]proc.Process {
+	byPID := make(map[int32]proc.Process, len(procs))
+	for _, p := range procs {
+		byPID[p.PID] = p
+	}
+	return byPID
+}
+
+// subtreeHasCaffeinate reports whether rootPID or any descendant is a
+// caffeinate process. Matches on the lowercased FriendlyName.
+func subtreeHasCaffeinate(rootPID int32, byPID map[int32]proc.Process, tree map[int32][]proc.Process) bool {
+	if p, ok := byPID[rootPID]; ok {
+		if strings.ToLower(p.FriendlyName()) == "caffeinate" {
+			return true
+		}
+	}
+	for _, child := range tree[rootPID] {
+		if subtreeHasCaffeinate(child.PID, byPID, tree) {
+			return true
+		}
+	}
+	return false
+}
+
+// computeSessionTotals sums CPU% and MemRSS across every pane's process tree
+// for a single session, and reports whether caffeinate runs anywhere within.
+// panes must all belong to the same session. Panes whose shell PID cannot be
+// resolved (PanePID == 0 or absent from byPID) contribute nothing.
+func computeSessionTotals(panes []tmux.Pane, byPID map[int32]proc.Process, tree map[int32][]proc.Process) (cpu float64, mem uint64, caffeinated bool) {
+	for _, pane := range panes {
+		if pane.PanePID == 0 {
+			continue
+		}
+		shell, ok := byPID[pane.PanePID]
+		if !ok {
+			continue
+		}
+		c, m := aggStats(shell, tree)
+		cpu += c
+		mem += m
+		if !caffeinated && subtreeHasCaffeinate(pane.PanePID, byPID, tree) {
+			caffeinated = true
+		}
+	}
+	return cpu, mem, caffeinated
+}
+
+// humanizeBytes renders a byte count as "<n>MB" below 1GiB, else "<n.n>GB".
+func humanizeBytes(b uint64) string {
+	const mib = 1024 * 1024
+	const gib = 1024 * mib
+	if b < gib {
+		return fmt.Sprintf("%dMB", b/mib)
+	}
+	return fmt.Sprintf("%.1fGB", float64(b)/float64(gib))
+}

--- a/internal/tui/session_stats.go
+++ b/internal/tui/session_stats.go
@@ -76,6 +76,17 @@ func humanizeBytes(b uint64) string {
 	return fmt.Sprintf("%.1fGB", float64(b)/float64(gib))
 }
 
+// humanizeBytesShort is the compact form for the inline per-row readout:
+// "<n>M" below 1GiB, else "<n.n>G" (no trailing "B" to save sidebar width).
+func humanizeBytesShort(b uint64) string {
+	const mib = 1024 * 1024
+	const gib = 1024 * mib
+	if b < gib {
+		return fmt.Sprintf("%dM", b/mib)
+	}
+	return fmt.Sprintf("%.1fG", float64(b)/float64(gib))
+}
+
 // statsPeakWindow is the number of recent samples retained per session for the
 // rolling peak. At the ~2s proc-poll interval this is ~2 minutes of history.
 const statsPeakWindow = 60

--- a/internal/tui/session_stats_test.go
+++ b/internal/tui/session_stats_test.go
@@ -82,3 +82,52 @@ func TestHumanizeBytes(t *testing.T) {
 		}
 	}
 }
+
+func TestSessionStatsModel_RollingPeakDecays(t *testing.T) {
+	var m SessionStatsModel
+	mkProcs := func(cpu float64) []proc.Process {
+		return []proc.Process{{PID: 100, PPID: 1, CPU: cpu, MemRSS: 1, Name: "zsh"}}
+	}
+	panes := []tmux.Pane{{Session: "s", PanePID: 100}}
+
+	m.Update(panes, mkProcs(50)) // spike
+	for i := 0; i < statsPeakWindow; i++ {
+		m.Update(panes, mkProcs(10))
+	}
+	st := m.Snapshot()["s"]
+	if st.CPUNow != 10 {
+		t.Errorf("CPUNow = %v, want 10", st.CPUNow)
+	}
+	if st.CPUPeak != 10 {
+		t.Errorf("CPUPeak = %v, want 10 (50 should have decayed out of the %d-sample window)", st.CPUPeak, statsPeakWindow)
+	}
+}
+
+func TestSessionStatsModel_PeakHoldsWithinWindow(t *testing.T) {
+	var m SessionStatsModel
+	panes := []tmux.Pane{{Session: "s", PanePID: 100}}
+	m.Update(panes, []proc.Process{{PID: 100, PPID: 1, CPU: 50, MemRSS: 1, Name: "zsh"}})
+	m.Update(panes, []proc.Process{{PID: 100, PPID: 1, CPU: 10, MemRSS: 1, Name: "zsh"}})
+	st := m.Snapshot()["s"]
+	if st.CPUPeak != 50 {
+		t.Errorf("CPUPeak = %v, want 50 (still within window)", st.CPUPeak)
+	}
+	if st.CPUNow != 10 {
+		t.Errorf("CPUNow = %v, want 10", st.CPUNow)
+	}
+}
+
+func TestSessionStatsModel_PrunesVanishedSessions(t *testing.T) {
+	var m SessionStatsModel
+	m.Update([]tmux.Pane{{Session: "gone", PanePID: 100}},
+		[]proc.Process{{PID: 100, PPID: 1, CPU: 1, MemRSS: 1, Name: "zsh"}})
+	m.Update([]tmux.Pane{{Session: "live", PanePID: 200}},
+		[]proc.Process{{PID: 200, PPID: 1, CPU: 1, MemRSS: 1, Name: "zsh"}})
+	snap := m.Snapshot()
+	if _, ok := snap["gone"]; ok {
+		t.Errorf("session 'gone' should have been pruned")
+	}
+	if _, ok := snap["live"]; !ok {
+		t.Errorf("session 'live' should be present")
+	}
+}

--- a/internal/tui/session_stats_test.go
+++ b/internal/tui/session_stats_test.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/rtalexk/demux/internal/proc"
+	"github.com/rtalexk/demux/internal/tmux"
+)
+
+func TestComputeSessionTotals_SumsPaneTrees(t *testing.T) {
+	// pane A shell pid 100 -> child 101 (cpu 10, mem 200MB)
+	// pane B shell pid 200 -> child 201 (cpu 5,  mem 100MB)
+	procs := []proc.Process{
+		{PID: 100, PPID: 1, CPU: 1, MemRSS: 10 * 1024 * 1024, Name: "zsh"},
+		{PID: 101, PPID: 100, CPU: 10, MemRSS: 200 * 1024 * 1024, Name: "node"},
+		{PID: 200, PPID: 1, CPU: 1, MemRSS: 10 * 1024 * 1024, Name: "zsh"},
+		{PID: 201, PPID: 200, CPU: 5, MemRSS: 100 * 1024 * 1024, Name: "go"},
+	}
+	panes := []tmux.Pane{
+		{Session: "s", PanePID: 100},
+		{Session: "s", PanePID: 200},
+	}
+	tree := proc.BuildTree(procs)
+	byPID := indexByPID(procs)
+
+	cpu, mem, caf := computeSessionTotals(panes, byPID, tree)
+	if cpu != 17 { // 1+10+1+5
+		t.Errorf("cpu = %v, want 17", cpu)
+	}
+	if mem != 320*1024*1024 {
+		t.Errorf("mem = %v, want 320MB", mem)
+	}
+	if caf {
+		t.Errorf("caffeinated = true, want false")
+	}
+}
+
+func TestComputeSessionTotals_DetectsCaffeinate(t *testing.T) {
+	procs := []proc.Process{
+		{PID: 100, PPID: 1, CPU: 1, MemRSS: 1, Name: "zsh"},
+		{PID: 101, PPID: 100, CPU: 0, MemRSS: 1, Name: "caffeinate"},
+	}
+	panes := []tmux.Pane{{Session: "s", PanePID: 100}}
+	tree := proc.BuildTree(procs)
+	byPID := indexByPID(procs)
+
+	_, _, caf := computeSessionTotals(panes, byPID, tree)
+	if !caf {
+		t.Errorf("caffeinated = false, want true (caffeinate under pane)")
+	}
+}
+
+func TestComputeSessionTotals_IgnoresCaffeinateOutsidePaneTree(t *testing.T) {
+	// caffeinate (pid 900) is NOT a descendant of any pane shell.
+	procs := []proc.Process{
+		{PID: 100, PPID: 1, CPU: 1, MemRSS: 1, Name: "zsh"},
+		{PID: 900, PPID: 1, CPU: 0, MemRSS: 1, Name: "caffeinate"},
+	}
+	panes := []tmux.Pane{{Session: "s", PanePID: 100}}
+	tree := proc.BuildTree(procs)
+	byPID := indexByPID(procs)
+
+	_, _, caf := computeSessionTotals(panes, byPID, tree)
+	if caf {
+		t.Errorf("caffeinated = true, want false (caffeinate outside pane tree)")
+	}
+}
+
+func TestHumanizeBytes(t *testing.T) {
+	cases := []struct {
+		in   uint64
+		want string
+	}{
+		{320 * 1024 * 1024, "320MB"},
+		{1024 * 1024 * 1024, "1.0GB"},
+		{1536 * 1024 * 1024, "1.5GB"},
+		{0, "0MB"},
+	}
+	for _, c := range cases {
+		if got := humanizeBytes(c.in); got != c.want {
+			t.Errorf("humanizeBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -590,7 +590,7 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 	rowsLeft := contentRows
 	for i := offset; i < end; i++ {
 		isLastInList := (i == len(s.nodes)-1)
-		h := s.nodeHeight(isLastInList)
+		h := s.nodeHeight(i, isLastInList)
 		if h > rowsLeft {
 			break
 		}
@@ -604,7 +604,7 @@ func (s SidebarModel) buildSidebarLines(offset, contentRows int, hasAbove, hasBe
 			// includes the separator for non-last cards, so rowsLeft was already
 			// charged for it; skipping the append here over-subtracts rowsLeft by
 			// 1, but the loop is about to exit so no further damage.
-			nextH := s.nodeHeight((i + 1) == len(s.nodes)-1)
+			nextH := s.nodeHeight(i+1, (i+1) == len(s.nodes)-1)
 			if nextH <= rowsLeft {
 				lines = append(lines, sep)
 			}
@@ -622,7 +622,7 @@ func (s SidebarModel) Render(width, height int, focused bool, title, rightTitle 
 		visibleRows = 1
 	}
 
-	heightFn := func(_ int, isLast bool) int { return s.nodeHeight(isLast) }
+	heightFn := func(i int, isLast bool) int { return s.nodeHeight(i, isLast) }
 	offset, contentRows, hasAbove, hasBelow := sidebarViewport(s.cursor, s.offset, visibleRows, len(s.nodes), heightFn)
 
 	innerW := width - borderOverhead
@@ -684,17 +684,34 @@ func (s SidebarModel) cardSeparatorRow(innerW int) string {
 	}
 }
 
-// nodeHeight returns the viewport rows consumed by a session in the current
-// view. Card mode reserves 2 content rows; a trailing separator row adds 1
-// for every card except the last visible one when card_separator is enabled.
-func (s SidebarModel) nodeHeight(isLast bool) int {
+// statsExpandable reports whether the session has a stat entry and the
+// feature is enabled, i.e. its cursor row should show the resource readout.
+func (s SidebarModel) statsExpandable(session string) bool {
+	if !s.cfg.Sidebar.ShowSessionStats {
+		return false
+	}
+	_, ok := s.stats[session]
+	return ok
+}
+
+// nodeHeight returns the viewport rows consumed by node i in the current view.
+// Card mode reserves 2 content rows; a trailing separator row adds 1 for every
+// card except the last visible one when card_separator is enabled. The cursor
+// row gains 2 extra rows for the resource readout when stats are enabled and
+// available for that session.
+func (s SidebarModel) nodeHeight(i int, isLast bool) int {
+	h := 1
 	if s.cardView() {
 		if isLast || s.cfg.Sidebar.CardSeparator == config.CardSeparatorNone {
-			return 2
+			h = 2
+		} else {
+			h = 3
 		}
-		return 3
 	}
-	return 1
+	if i >= 0 && i < len(s.nodes) && i == s.cursor && s.statsExpandable(s.nodes[i].Session) {
+		h += 2
+	}
+	return h
 }
 
 // alignedRow builds a single sidebar line with the name on the left and
@@ -1033,11 +1050,35 @@ func (s SidebarModel) renderSession(node SidebarNode, selected, focused bool, wi
 	}
 
 	gap := s.activeIndicator(node, selected && focused)
+	var row string
 	if selected {
-		return renderSelectedRow(iconPrefix, nameStr, indicators, gap, availW, indW, focused)
+		row = renderSelectedRow(iconPrefix, nameStr, indicators, gap, availW, indW, focused)
+	} else {
+		text := alignedRow(nameStr, indicators, availW)
+		row = " " + gap + " " + styledIconPrefix(iconPrefix, false) + sessionStyle.Render(text)
 	}
-	text := alignedRow(nameStr, indicators, availW)
-	return " " + gap + " " + styledIconPrefix(iconPrefix, false) + sessionStyle.Render(text)
+	if selected && s.statsExpandable(node.Session) {
+		if lines := s.renderStatLines(node, width); lines != nil {
+			row += "\n" + strings.Join(lines, "\n")
+		}
+	}
+	return row
+}
+
+// renderStatLines returns the two muted readout lines for a session, or nil
+// when no stat is available. Indented to sit under the session name.
+func (s SidebarModel) renderStatLines(node SidebarNode, width int) []string {
+	st, ok := s.stats[node.Session]
+	if !ok {
+		return nil
+	}
+	cpuLine := fmt.Sprintf("cpu %.0f%% now · %.0f%% peak", st.CPUNow, st.CPUPeak)
+	memLine := fmt.Sprintf("mem %s now · %s peak", humanizeBytes(st.MemNow), humanizeBytes(st.MemPeak))
+	const indent = "     " // align under the session name (focus + gap + icon)
+	return []string{
+		hintStyle.Render(indent + cpuLine),
+		hintStyle.Render(indent + memLine),
+	}
 }
 
 // renderSessionCard renders a session as a two-row card.
@@ -1059,7 +1100,13 @@ func (s SidebarModel) renderSessionCard(node SidebarNode, selected, focused bool
 	}
 	header := s.renderCardHeader(node, selected, focused, innerW)
 	status := s.renderCardStatus(node, selected, focused, innerW)
-	return header + "\n" + status
+	out := header + "\n" + status
+	if selected && s.statsExpandable(node.Session) {
+		if lines := s.renderStatLines(node, width); lines != nil {
+			out += "\n" + strings.Join(lines, "\n")
+		}
+	}
+	return out
 }
 
 // cardLeadingGlyph returns the column-0 glyph for a card row. Selected cards
@@ -1299,7 +1346,7 @@ func (s *SidebarModel) clampViewport(visibleRows int) {
 	if effective < 1 {
 		effective = 1
 	}
-	heightFn := func(_ int, isLast bool) int { return s.nodeHeight(isLast) }
+	heightFn := func(i int, isLast bool) int { return s.nodeHeight(i, isLast) }
 	if s.cursor < s.offset {
 		s.offset = s.cursor
 	}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -953,6 +953,25 @@ func (s SidebarModel) caffeineIndicator(node SidebarNode, selected, focused bool
 	return caffeineStyle.Render(activeTheme.IconCaffeine)
 }
 
+// usageIndicator returns the compact current cpu/mem readout (e.g. "5% 1.0G")
+// shown inline on every row, or "" when stats are disabled or unavailable for
+// the session. It occupies the right-side slot where last-seen would otherwise
+// render.
+func (s SidebarModel) usageIndicator(node SidebarNode, selected, focused bool) string {
+	if !s.cfg.Sidebar.ShowSessionStats {
+		return ""
+	}
+	st, ok := s.stats[node.Session]
+	if !ok {
+		return ""
+	}
+	text := fmt.Sprintf("%.0f%% %s", st.CPUNow, humanizeBytesShort(st.MemNow))
+	if selected && focused {
+		return hintStyle.Background(activeTheme.ColorSelected).Render(text)
+	}
+	return hintStyle.Render(text)
+}
+
 // sessionIndicators assembles the right-side indicator string for a sidebar row.
 // Order: [proc] [git] [state] [coffee] [todo] [last-seen] [watch]
 func (s SidebarModel) sessionIndicators(node SidebarNode, selected, focused bool) string {
@@ -972,7 +991,11 @@ func (s SidebarModel) sessionIndicators(node SidebarNode, selected, focused bool
 	if ind := s.itemIndicator(node, selected, focused); ind != "" {
 		indParts = append(indParts, ind)
 	}
-	if ind := s.lastSeenIndicator(node, selected, focused); ind != "" {
+	// The inline cpu/mem readout takes the right-side slot; fall back to the
+	// last-seen age when no stat is available for this session.
+	if usage := s.usageIndicator(node, selected, focused); usage != "" {
+		indParts = append(indParts, usage)
+	} else if ind := s.lastSeenIndicator(node, selected, focused); ind != "" {
 		indParts = append(indParts, ind)
 	}
 	var other string
@@ -1223,16 +1246,22 @@ func (s SidebarModel) renderCardStatus(node SidebarNode, selected, focused bool,
 		leftLabel = labelStyle.Render(value.String())
 	}
 
-	// Right group: proc, git, todo, last-seen. Joined by a single space, styled
-	// when focused so the gap inherits the highlight.
+	// Right group: proc, git, caffeine, todo, then the inline cpu/mem readout
+	// (falling back to last-seen when no stat is available). Joined by a single
+	// space, styled when focused so the gap inherits the highlight.
 	indicatorFns := []func(SidebarNode, bool, bool) string{
-		s.procLabelIndicator, s.gitIndicator, s.caffeineIndicator, s.itemIndicator, s.lastSeenIndicator,
+		s.procLabelIndicator, s.gitIndicator, s.caffeineIndicator, s.itemIndicator,
 	}
 	var rightParts []string
 	for _, fn := range indicatorFns {
 		if ind := fn(node, focused, focused); ind != "" {
 			rightParts = append(rightParts, ind)
 		}
+	}
+	if usage := s.usageIndicator(node, focused, focused); usage != "" {
+		rightParts = append(rightParts, usage)
+	} else if ind := s.lastSeenIndicator(node, focused, focused); ind != "" {
+		rightParts = append(rightParts, ind)
 	}
 	sep := " "
 	if focused {

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -74,6 +74,7 @@ type SidebarModel struct {
 	itemSessions      map[string]struct{} // sessions with open (unchecked) TODOs
 	noteSessions      map[string]struct{} // sessions with at least one note
 	procLabels        map[string]procmatch.Label
+	stats             map[string]SessionStat
 	marquee           Marquee
 	lastMarqueeCursor int
 }
@@ -125,6 +126,12 @@ func (s *SidebarModel) SetNoteSessions(sessions []string) {
 // SetProcLabels updates the per-session sidebar process labels. Pass nil to clear.
 func (s *SidebarModel) SetProcLabels(labels map[string]procmatch.Label) {
 	s.procLabels = labels
+}
+
+// SetSessionStats updates the per-session resource stats used for the coffee
+// indicator and the focused-row readout. Pass nil to clear.
+func (s *SidebarModel) SetSessionStats(stats map[string]SessionStat) {
+	s.stats = stats
 }
 
 // SetFilter changes the active sidebar filter. Pressing the current filter's
@@ -915,8 +922,22 @@ func (s SidebarModel) itemIndicator(node SidebarNode, selected, focused bool) st
 	}
 }
 
+// caffeineIndicator returns the coffee glyph when caffeinate runs anywhere in
+// the session's pane trees, or "" otherwise. Styled to blend with the
+// selection background when the row is highlighted.
+func (s SidebarModel) caffeineIndicator(node SidebarNode, selected, focused bool) string {
+	st, ok := s.stats[node.Session]
+	if !ok || !st.Caffeinated || activeTheme.IconCaffeine == "" {
+		return ""
+	}
+	if selected && focused {
+		return caffeineStyle.Background(activeTheme.ColorSelected).Render(activeTheme.IconCaffeine)
+	}
+	return caffeineStyle.Render(activeTheme.IconCaffeine)
+}
+
 // sessionIndicators assembles the right-side indicator string for a sidebar row.
-// Order: [proc] [git] [state] [todo] [last-seen] [watch]
+// Order: [proc] [git] [state] [coffee] [todo] [last-seen] [watch]
 func (s SidebarModel) sessionIndicators(node SidebarNode, selected, focused bool) string {
 	var indParts []string
 	if ind := s.procLabelIndicator(node, selected, focused); ind != "" {
@@ -926,6 +947,9 @@ func (s SidebarModel) sessionIndicators(node SidebarNode, selected, focused bool
 		indParts = append(indParts, ind)
 	}
 	if ind := s.stateIndicator(node, selected, focused); ind != "" {
+		indParts = append(indParts, ind)
+	}
+	if ind := s.caffeineIndicator(node, selected, focused); ind != "" {
 		indParts = append(indParts, ind)
 	}
 	if ind := s.itemIndicator(node, selected, focused); ind != "" {
@@ -1155,7 +1179,7 @@ func (s SidebarModel) renderCardStatus(node SidebarNode, selected, focused bool,
 	// Right group: proc, git, todo, last-seen. Joined by a single space, styled
 	// when focused so the gap inherits the highlight.
 	indicatorFns := []func(SidebarNode, bool, bool) string{
-		s.procLabelIndicator, s.gitIndicator, s.itemIndicator, s.lastSeenIndicator,
+		s.procLabelIndicator, s.gitIndicator, s.caffeineIndicator, s.itemIndicator, s.lastSeenIndicator,
 	}
 	var rightParts []string
 	for _, fn := range indicatorFns {

--- a/internal/tui/sidebar_stats_test.go
+++ b/internal/tui/sidebar_stats_test.go
@@ -35,3 +35,60 @@ func TestSidebar_NoCaffeineIndicatorWhenAbsent(t *testing.T) {
 		t.Errorf("did not expect coffee glyph in row, got %q", out)
 	}
 }
+
+func TestSidebar_StatLinesUnderFocusedRow(t *testing.T) {
+	initStyles(Theme{IconCaffeine: coffeeGlyph}, config.ProcessesConfig{}, nil)
+	var s SidebarModel
+	s.cfg.Sidebar.ShowSessionStats = true
+	s.nodes = []SidebarNode{{Session: "work"}}
+	s.cursor = 0
+	s.SetSessionStats(map[string]SessionStat{
+		"work": {CPUNow: 9, MemNow: 1024 * 1024 * 1024, CPUPeak: 45, MemPeak: 1610612736},
+	})
+	out := s.renderNode(s.nodes[0], true, true, 40)
+	if !strings.Contains(out, "cpu") || !strings.Contains(out, "peak") {
+		t.Errorf("expected cpu/peak stat lines under focused row, got %q", out)
+	}
+	if !strings.Contains(out, "1.0GB") {
+		t.Errorf("expected humanized mem in stat lines, got %q", out)
+	}
+}
+
+func TestSidebar_NoStatLinesOnUnfocusedRow(t *testing.T) {
+	initStyles(Theme{IconCaffeine: coffeeGlyph}, config.ProcessesConfig{}, nil)
+	var s SidebarModel
+	s.cfg.Sidebar.ShowSessionStats = true
+	s.nodes = []SidebarNode{{Session: "work"}, {Session: "other"}}
+	s.cursor = 0
+	s.SetSessionStats(map[string]SessionStat{
+		"other": {CPUNow: 1, MemNow: 1024 * 1024},
+	})
+	out := s.renderNode(s.nodes[1], false, false, 40) // not the cursor row
+	if strings.Contains(out, "cpu") {
+		t.Errorf("did not expect stat lines on non-cursor row, got %q", out)
+	}
+}
+
+func TestNodeHeight_ExpandsCursorRowWhenStatsEnabled(t *testing.T) {
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	var s SidebarModel
+	s.cfg.Sidebar.ShowSessionStats = true
+	s.nodes = []SidebarNode{{Session: "work"}}
+	s.cursor = 0
+	s.SetSessionStats(map[string]SessionStat{"work": {CPUNow: 1, MemNow: 1}})
+	if got := s.nodeHeight(0, true); got != 3 { // list base 1 + 2 stat lines
+		t.Errorf("nodeHeight(cursor) = %d, want 3 (base + 2 stat lines)", got)
+	}
+}
+
+func TestNodeHeight_DisabledHasNoExtraRows(t *testing.T) {
+	initStyles(Theme{}, config.ProcessesConfig{}, nil)
+	var s SidebarModel
+	s.cfg.Sidebar.ShowSessionStats = false
+	s.nodes = []SidebarNode{{Session: "work"}}
+	s.cursor = 0
+	s.SetSessionStats(map[string]SessionStat{"work": {CPUNow: 1, MemNow: 1}})
+	if got := s.nodeHeight(0, true); got != 1 {
+		t.Errorf("nodeHeight = %d, want 1 when stats disabled", got)
+	}
+}

--- a/internal/tui/sidebar_stats_test.go
+++ b/internal/tui/sidebar_stats_test.go
@@ -92,3 +92,48 @@ func TestNodeHeight_DisabledHasNoExtraRows(t *testing.T) {
 		t.Errorf("nodeHeight = %d, want 1 when stats disabled", got)
 	}
 }
+
+func TestHumanizeBytesShort(t *testing.T) {
+	cases := map[uint64]string{
+		320 * 1024 * 1024:  "320M",
+		1024 * 1024 * 1024: "1.0G",
+		1610612736:         "1.5G",
+	}
+	for in, want := range cases {
+		if got := humanizeBytesShort(in); got != want {
+			t.Errorf("humanizeBytesShort(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSidebar_InlineUsageOnEveryRow(t *testing.T) {
+	initStyles(Theme{IconCaffeine: coffeeGlyph, IconTmuxSession: "S"}, config.ProcessesConfig{}, nil)
+	var s SidebarModel
+	s.cfg.Sidebar.ShowSessionStats = true
+	s.cfg.Sidebar.ShowLastSeen = true
+	s.nodes = []SidebarNode{{Session: "work"}}
+	s.SetSessionStats(map[string]SessionStat{
+		"work": {CPUNow: 5, MemNow: 1024 * 1024 * 1024},
+	})
+	// Non-focused row should still show inline current usage.
+	out := s.renderNode(s.nodes[0], false, false, 40)
+	if !strings.Contains(out, "5%") || !strings.Contains(out, "1.0G") {
+		t.Errorf("expected inline cpu/mem on a non-focused row, got %q", out)
+	}
+}
+
+func TestSidebar_UsageReplacesAgeWhenStatPresent(t *testing.T) {
+	initStyles(Theme{IconTmuxSession: "S"}, config.ProcessesConfig{}, nil)
+	var s SidebarModel
+	s.cfg.Sidebar.ShowSessionStats = true
+	s.cfg.Sidebar.ShowLastSeen = true
+	s.nodes = []SidebarNode{{Session: "work"}}
+	withStat := s.usageIndicator(s.nodes[0], false, false)
+	if withStat != "" {
+		t.Fatalf("expected empty usage with no stat, got %q", withStat)
+	}
+	s.SetSessionStats(map[string]SessionStat{"work": {CPUNow: 3, MemNow: 200 * 1024 * 1024}})
+	if got := s.usageIndicator(s.nodes[0], false, false); got == "" {
+		t.Errorf("expected non-empty usage indicator once a stat exists")
+	}
+}

--- a/internal/tui/sidebar_stats_test.go
+++ b/internal/tui/sidebar_stats_test.go
@@ -1,0 +1,37 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rtalexk/demux/internal/config"
+)
+
+// coffeeGlyph is the Nerd-Font nf-fa-coffee (U+F0F4) used in these tests.
+const coffeeGlyph = "\uf0f4"
+
+func TestSidebar_CaffeineIndicatorShown(t *testing.T) {
+	initStyles(Theme{IconCaffeine: coffeeGlyph}, config.ProcessesConfig{}, nil)
+	var s SidebarModel
+	s.nodes = []SidebarNode{{Session: "brewing"}}
+	s.SetSessionStats(map[string]SessionStat{
+		"brewing": {Caffeinated: true},
+	})
+	out := s.renderNode(s.nodes[0], false, false, 30)
+	if !strings.Contains(out, coffeeGlyph) {
+		t.Errorf("expected coffee glyph in row, got %q", out)
+	}
+}
+
+func TestSidebar_NoCaffeineIndicatorWhenAbsent(t *testing.T) {
+	initStyles(Theme{IconCaffeine: coffeeGlyph}, config.ProcessesConfig{}, nil)
+	var s SidebarModel
+	s.nodes = []SidebarNode{{Session: "plain"}}
+	s.SetSessionStats(map[string]SessionStat{
+		"plain": {Caffeinated: false},
+	})
+	out := s.renderNode(s.nodes[0], false, false, 30)
+	if strings.Contains(out, coffeeGlyph) {
+		t.Errorf("did not expect coffee glyph in row, got %q", out)
+	}
+}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1576,7 +1576,7 @@ func TestSidebar_IsIconLabel(t *testing.T) {
 		{"node", false},
 		{"", false},
 		{"🤖", true},
-		{"", true}, // Nerd Font PUA glyph
+		{"", true},   // Nerd Font PUA glyph
 		{" 🤖 ", true}, // padded with whitespace
 		{"Go!", false},
 		{"   ", false},
@@ -1608,7 +1608,7 @@ func TestNodeHeight(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := SidebarModel{cfg: config.Config{Sidebar: config.SidebarConfig{SessionView: tc.view, CardSeparator: tc.separator}}}
-			got := s.nodeHeight(tc.isLast)
+			got := s.nodeHeight(0, tc.isLast)
 			if got != tc.expected {
 				t.Errorf("nodeHeight(view=%q, sep=%v, isLast=%v): got %d, want %d", tc.view, tc.separator, tc.isLast, got, tc.expected)
 			}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -77,6 +77,9 @@ var (
 
 	// Todo indicator
 	todoStyle lipgloss.Style
+
+	// Caffeine indicator
+	caffeineStyle lipgloss.Style
 )
 
 // initStyles rebuilds every style using the given theme and merges proc-type
@@ -132,6 +135,7 @@ func initStyles(t Theme, procs config.ProcessesConfig, ignoredProcs []string) {
 
 	watchStyle = lipgloss.NewStyle().Foreground(t.ColorWatch)
 	todoStyle = lipgloss.NewStyle().Foreground(t.ColorTodo)
+	caffeineStyle = lipgloss.NewStyle().Foreground(t.ColorFgMuted)
 }
 
 // ageDrivenValue returns the effective display value for a state.

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -64,6 +64,8 @@ type Theme struct {
 	ColorTodo lipgloss.Color
 	IconNote  string
 
+	IconCaffeine string
+
 	IconTmuxSession string
 	IconCfgSession  string
 
@@ -133,6 +135,8 @@ func ThemeFromConfig(tc config.ThemeConfig) Theme {
 		IconTodo:  tc.IconTodo,
 		ColorTodo: lipgloss.Color(tc.ColorTodo),
 		IconNote:  tc.IconNote,
+
+		IconCaffeine: tc.IconCaffeine,
 
 		IconTmuxSession: tc.IconTmuxSession,
 		IconCfgSession:  tc.IconCfgSession,


### PR DESCRIPTION
## What

Adds per-session resource visibility to the sidebar, gated behind a single config flag `sidebar.show_session_stats` (default **on**):

1. **Current cpu/mem inline on every row** — a compact `<cpu>% <mem>` readout (e.g. `5% 1.0G`) in the right-hand slot (taking the last-seen-age slot when a stat is available). *now* = the live sum of every process across every pane in that tmux session.

2. **Rolling peak under the focused row** — the selected row expands with two lines: `cpu <now>% now · <peak>% peak` and `mem <now> now · <peak> peak`. *peak* = the rolling max over the last 60 proc-poll samples (~2 min).

3. **Coffee glyph** (Nerd-Font `nf-fa-coffee`, `U+F0F4`) beside any session running `caffeinate`. Scope is correct by construction — only pane process-trees are walked, so an agent-spawned `caffeinate` (e.g. an editor/agent keep-awake) flags the session but a standalone one started outside tmux does not.

## How

- New isolated `internal/tui/session_stats.go`: `computeSessionTotals` (reuses the existing `aggStats` + `proc.BuildTree` + `tmux.GroupBySessions` primitives) and `SessionStatsModel` (rolling-peak ring, pruned when a session disappears). The zero value is usable — no constructor wiring.
- Fed from `handleProcDataMsg` right next to the existing `SetProcLabels` call; pushed into the sidebar via `SetSessionStats`.
- Rendering reuses the existing per-node-height viewport machinery: the inline readout is a normal right-side indicator; `nodeHeight` becomes cursor-aware (`+2` rows for the focused peak lines); the coffee glyph is a themed indicator (`IconCaffeine`).
- Summed CPU can exceed 100% on multi-core — shown verbatim (matches Activity Monitor).

## Tests

`go test ./...` green. Unit coverage for aggregation, caffeinate detection (positive + negative scope), rolling-peak decay/hold/prune, the config default, the coffee indicator, the inline per-row readout, the focused-row peak lines, and the cursor-aware `nodeHeight`.

## Notes

- Independent of #56 (the gopsutil-v4 / macOS-26 crash fix) — rebased onto `main` with no `go.mod` churn.
- A follow-up PR adds mouse click-to-select to the sidebar; it builds on this one (reuses the cursor-aware `nodeHeight` + the line→node hit map), so it'll be opened stacked once this lands.
